### PR TITLE
Refactor MOP to use dependency injection, fix workspace timestamp

### DIFF
--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -206,10 +206,8 @@ public class WorkspaceEventHandler implements EventHandler {
                 new GUID(STORAGE_CODE, Math.toIntExact(obj.getE7()), obj.getE1() + "",
                         Math.toIntExact(obj.getE5()), null, null),
                 new StorageObjectType(STORAGE_CODE, obj.getE3().split("-")[0],
-                      Integer.parseInt(
-                              obj.getE3().split("-")[1].split("\\.")[0])),
-                DATE_PARSER.parseDateTime(
-                      obj.getE4()).getMillis());
+                      Integer.parseInt(obj.getE3().split("-")[1].split("\\.")[0])),
+                DATE_PARSER.parseDateTime(obj.getE4()).getMillis());
     }
 
     @Override
@@ -491,7 +489,7 @@ public class WorkspaceEventHandler implements EventHandler {
                 Math.toIntExact(obj.getE5()), // vers are always ints
                 null, // no rename
                 null, // not a datapalette share
-                origEvent.getTimestamp(), //TODO NOW switch to object timestamp
+                DATE_PARSER.parseDateTime(obj.getE4()).getMillis(),
                 new StorageObjectType(STORAGE_CODE, obj.getE3().split("-")[0],
                         Integer.parseInt(obj.getE3().split("-")[1].split("\\.")[0])),
                 ObjectStatusEventType.NEW_VERSION,

--- a/test/src/kbasesearchengine/main/test/PerformanceTester.java
+++ b/test/src/kbasesearchengine/main/test/PerformanceTester.java
@@ -146,9 +146,16 @@ public class PerformanceTester {
         final Map<String, TypeMappingParser> parsers = ImmutableMap.of(
                 "yaml", new YAMLTypeMappingParser());
         final TypeStorage ss = new TypeFileStorage(typesDir, mappingsDir, parsers, logger);
-        mop = new MainObjectProcessor(wsUrl, kbaseIndexerToken,
-                esHostPort, esUser, esPassword, esIndexPrefix, 
-                ss, tempDir, logger);
+        
+        final ElasticIndexingStorage esStorage = new ElasticIndexingStorage(esHostPort,
+                MainObjectProcessor.getTempSubDir(tempDir, "esbulk"));
+        if (esUser != null) {
+            esStorage.setEsUser(esUser);
+            esStorage.setEsPassword(esPassword);
+        }
+        esStorage.setIndexNamePrefix(esIndexPrefix);
+        
+        mop = new MainObjectProcessor(esStorage, ss, tempDir, logger);
     }
     
     private static void deleteAllTestElasticIndices(HttpHost esHostPort, String esUser,


### PR DESCRIPTION
* Use the object timestamp instead of the event timestamp when indexing objects
* Switch to dependency injection for MOP creation. Should make splitting the indexer out of MOP much easier. Also makes testing and component swapping easier.