### PR TITLE
Refactor statusevent w/ builder

### DIFF
--- a/lib/src/kbasesearchengine/events/StatusEvent.java
+++ b/lib/src/kbasesearchengine/events/StatusEvent.java
@@ -1,131 +1,85 @@
 package kbasesearchengine.events;
 
+import java.time.Instant;
+
+import com.google.common.base.Optional;
+
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.system.StorageObjectType;
+import kbasesearchengine.tools.Utils;
 
 public class StatusEvent {
-    private final String _id;
-    private final String storageCode;
-    private final Integer accessGroupId;
-    private final String accessGroupObjectId;
-    private final Integer version;
-    private final Integer targetAccessGroupId;
-    private final Long timestamp;
-    private final StorageObjectType storageObjectType;
-    private final StatusEventType eventType;
-    private final Boolean isGlobalAccessed;
-    private final String newName;
 
-
-    //TODO BUILDER
     //TODO JAVADOC
     //TODO TEST
+    //TODO add some validation that the available fields match the requirement for the event type
     
-    public StatusEvent(
-            final String _id,
-            final Integer accessGroupId,
-            final String accessGroupObjectId,
-            final Integer version,
-            final String newName,
-            final Integer targetAccessGroupId,
-            final Long timestamp,
-            final StorageObjectType storageObjectType,
+    private final Instant time;
+    private final StatusEventType eventType;
+    private final String storageCode;
+    private final Optional<StorageObjectType> storageObjectType;
+    private final String id; // TODO NOW remove
+    private final Optional<Integer> accessGroupID;
+    private final Optional<String> objectID;
+    private final Optional<Integer> version;
+    private final Optional<Boolean> isPublic;
+    private final Optional<String> newName;
+    
+    private StatusEvent(
+            final String id,
             final StatusEventType eventType,
-            final Boolean isGlobalAccessed) {
-        super();
-        this._id = _id;
-        this.storageCode = storageObjectType.getStorageCode();
-        this.accessGroupId = accessGroupId;
-        this.accessGroupObjectId = accessGroupObjectId;
-        this.version = version;
-        this.targetAccessGroupId = targetAccessGroupId;
-        this.timestamp = timestamp;
-        this.storageObjectType = storageObjectType;
-        this.eventType = eventType;
-        this.isGlobalAccessed = isGlobalAccessed;
-        this.newName = newName;
-    }
-    
-    public StatusEvent(
-            final String _id,
             final String storageCode,
-            final Integer accessGroupId,
-            final String accessGroupObjectId,
-            final Integer version,
-            final String newName,
-            final Integer targetAccessGroupId,
-            final Long timestamp,
-            final StatusEventType eventType,
-            final Boolean isGlobalAccessed) {
-        super();
-        this._id = _id;
-        this.storageCode = storageCode;
-        this.accessGroupId = accessGroupId;
-        this.accessGroupObjectId = accessGroupObjectId;
-        this.version = version;
-        this.targetAccessGroupId = targetAccessGroupId;
-        this.timestamp = timestamp;
-        this.storageObjectType = null;
+            final Optional<Integer> accessGroupID,
+            final Optional<String> objectID,
+            final Optional<Integer> version,
+            final Optional<StorageObjectType> storageObjectType,
+            final Instant time,
+            final Optional<Boolean> isPublic,
+            final Optional<String> newName) {
+        this.id = id;
         this.eventType = eventType;
-        this.isGlobalAccessed = isGlobalAccessed;
+        this.storageCode = storageCode;
+        this.accessGroupID = accessGroupID;
+        this.objectID = objectID;
+        this.version = version;
+        this.storageObjectType = storageObjectType;
+        this.time = time;
+        this.isPublic = isPublic;
         this.newName = newName;
-    }
-    
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("ObjectStatusEvent [_id=");
-        builder.append(_id);
-        builder.append(", storageCode=");
-        builder.append(storageCode);
-        builder.append(", accessGroupId=");
-        builder.append(accessGroupId);
-        builder.append(", accessGroupObjectId=");
-        builder.append(accessGroupObjectId);
-        builder.append(", version=");
-        builder.append(version);
-        builder.append(", targetAccessGroupId=");
-        builder.append(targetAccessGroupId);
-        builder.append(", timestamp=");
-        builder.append(timestamp);
-        builder.append(", storageObjectType=");
-        builder.append(storageObjectType);
-        builder.append(", eventType=");
-        builder.append(eventType);
-        builder.append(", isGlobalAccessed=");
-        builder.append(isGlobalAccessed);
-        builder.append(", newName=");
-        builder.append(newName);
-        builder.append("]");
-        return builder.toString();
     }
 
     public GUID toGUID(){
-        return new GUID(getStorageCode(), accessGroupId, accessGroupObjectId, version, null, null);
+        // TODO NOW should this throw an error if some or all of the ids are null?
+        return new GUID(
+                getStorageCode(),
+                accessGroupID.orNull(),
+                objectID.orNull(),
+                version.orNull(),
+                null,
+                null);
     }
 
     public String getId() {
-        return _id;
+        return id;
     }
 
     public String getStorageCode() {
-        return storageObjectType == null ? storageCode : storageObjectType.getStorageCode();
+        return storageCode;
     }
 
-
-    public Integer getAccessGroupId() {
-        return accessGroupId;
+    public Optional<Integer> getAccessGroupId() {
+        return accessGroupID;
     }
 
-    public String getAccessGroupObjectId() {
-        return accessGroupObjectId;
+    public Optional<String> getAccessGroupObjectId() {
+        return objectID;
     }
 
-    public Integer getVersion() {
+    public Optional<Integer> getVersion() {
         return version;
     }
 
-    public StorageObjectType getStorageObjectType() {
+    public Optional<StorageObjectType> getStorageObjectType() {
         return storageObjectType;
     }
 
@@ -133,20 +87,140 @@ public class StatusEvent {
         return eventType;
     }
 
-    public Integer getTargetAccessGroupId() {
-        return targetAccessGroupId;
+    public Instant getTimestamp() {
+        return time;
     }
 
-    public Long getTimestamp() {
-        return timestamp;
+    public Optional<Boolean> isGlobalAccessed(){
+        return isPublic;
     }
 
-    public Boolean isGlobalAccessed(){
-        return isGlobalAccessed;
-    }
-
-    public String getNewName() {
+    public Optional<String> getNewName() {
         return newName;
     }
-
+    
+    @Override
+    public String toString() {
+        StringBuilder builder2 = new StringBuilder();
+        builder2.append("StatusEvent [time=");
+        builder2.append(time);
+        builder2.append(", eventType=");
+        builder2.append(eventType);
+        builder2.append(", storageCode=");
+        builder2.append(storageCode);
+        builder2.append(", storageObjectType=");
+        builder2.append(storageObjectType);
+        builder2.append(", id=");
+        builder2.append(id);
+        builder2.append(", accessGroupID=");
+        builder2.append(accessGroupID);
+        builder2.append(", objectID=");
+        builder2.append(objectID);
+        builder2.append(", version=");
+        builder2.append(version);
+        builder2.append(", isPublic=");
+        builder2.append(isPublic);
+        builder2.append(", newName=");
+        builder2.append(newName);
+        builder2.append("]");
+        return builder2.toString();
+    }
+    
+    public static Builder getBuilder(
+            final String storageCode,
+            final Instant time,
+            final StatusEventType eventType) {
+        return new Builder(storageCode, time, eventType);
+    }
+    
+    public static Builder getBuilder(
+            final StorageObjectType storageType,
+            final Instant time,
+            final StatusEventType eventType) {
+        return new Builder(storageType, time, eventType);
+    }
+    
+    public static class Builder {
+        
+        private final Instant time;
+        private final StatusEventType eventType;
+        private final String storageCode;
+        private final Optional<StorageObjectType> storageObjectType;
+        private String id = null; // TODO NOW remove
+        private Optional<Integer> accessGroupID = Optional.absent();
+        private Optional<String> objectID = Optional.absent();
+        private Optional<Integer> version = Optional.absent();
+        private Optional<Boolean> isPublic = Optional.absent();
+        private Optional<String> newName = Optional.absent();
+        
+        private Builder(
+                final String storageCode,
+                final Instant time,
+                final StatusEventType eventType) {
+            Utils.notNullOrEmpty(storageCode, "storageCode cannot be null or the empty string");
+            Utils.nonNull(time, "time");
+            Utils.nonNull(eventType, "eventType");
+            this.time = time;
+            this.storageCode = storageCode;
+            this.eventType = eventType;
+            this.storageObjectType = Optional.absent();
+        }
+        
+        private Builder(
+                final StorageObjectType storageType,
+                final Instant time,
+                final StatusEventType eventType) {
+            Utils.nonNull(time, "time");
+            Utils.nonNull(eventType, "eventType");
+            Utils.nonNull(storageType, "storageType");
+            this.time = time;
+            this.storageCode = storageType.getStorageCode();
+            this.eventType = eventType;
+            this.storageObjectType = Optional.of(storageType);
+        }
+        
+        //TODO NOW remove. Use StatusEventWithID
+        public Builder withID(final String id) {
+            this.id = id;
+            return this;
+        }
+        
+        public Builder withNullableAccessGroupID(final Integer accessGroupID) {
+            this.accessGroupID = Optional.fromNullable(accessGroupID);
+            return this;
+        }
+        
+        public Builder withNullableObjectID(final String objectID) {
+            if (Utils.isNullOrEmpty(objectID)) {
+                this.objectID = Optional.absent();
+            } else {
+                this.objectID = Optional.of(objectID);
+            }
+            return this;
+        }
+        
+        public Builder withNullableVersion(final Integer version) {
+            this.version = Optional.fromNullable(version);
+            return this;
+        }
+        
+        public Builder withNullableisPublic(final Boolean isPublic) {
+            this.isPublic = Optional.fromNullable(isPublic);
+            return this;
+        }
+        
+        public Builder withNullableNewName(final String newName) {
+            if (Utils.isNullOrEmpty(newName)) {
+                this.newName = Optional.absent();
+            } else {
+                this.newName = Optional.of(newName);
+            }
+            return this;
+        }
+        
+        public StatusEvent build() {
+            return new StatusEvent(id, eventType, storageCode, accessGroupID, objectID,
+                    version, storageObjectType, time, isPublic, newName);
+        }
+    }
 }

--- a/lib/src/kbasesearchengine/events/handler/ResolvedReference.java
+++ b/lib/src/kbasesearchengine/events/handler/ResolvedReference.java
@@ -1,7 +1,10 @@
 package kbasesearchengine.events.handler;
 
+import java.time.Instant;
+
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.system.StorageObjectType;
+import kbasesearchengine.tools.Utils;
 
 public class ResolvedReference {
     
@@ -11,17 +14,21 @@ public class ResolvedReference {
     private final GUID reference;
     private final GUID resolvedReference;
     private final StorageObjectType type;
-    private final long timestamp;
+    private final Instant timestamp;
     
     public ResolvedReference(
             final GUID reference,
             final GUID resolvedReference,
             final StorageObjectType type,
-            final long timestamp) {
+            final Instant time) {
+        Utils.nonNull(reference, "reference");
+        Utils.nonNull(resolvedReference, "resolvedReference");
+        Utils.nonNull(type, "type");
+        Utils.nonNull(time, "time");
         this.reference = reference;
         this.resolvedReference = resolvedReference;
         this.type = type;
-        this.timestamp = timestamp;
+        this.timestamp = time;
     }
 
     public GUID getReference() {
@@ -36,7 +43,7 @@ public class ResolvedReference {
         return type;
     }
 
-    public long getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -172,7 +173,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     public void indexObjects(
             final String objectType,
             final SourceData data,
-            final long timestamp, 
+            final Instant timestamp, 
             final String parentJsonValue,
             final GUID pguid,
             final Map<GUID, ParsedObject> idToObj,
@@ -226,7 +227,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final String objectType,
             final ParsedObject obj, 
             final SourceData data,
-            final long timestamp,
+            final Instant timestamp,
             final String parentJson,
             final boolean isPublic,
             final int lastVersion) {
@@ -247,7 +248,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         doc.put(OBJ_PROV_MODULE_VERSION, data.getVersion());
         doc.put(OBJ_PROV_COMMIT_HASH, data.getCommitHash());
         
-        doc.put("timestamp", timestamp);
+        doc.put("timestamp", timestamp.toEpochMilli());
         doc.put("prefix", toGUIDPrefix(id));
         doc.put("str_cde", id.getStorageCode());
         doc.put("accgrp", id.getAccessGroupId());
@@ -264,7 +265,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
 
     @Override
     public void indexObject(GUID id, String objectType, ParsedObject obj, SourceData data,
-            long timestamp, String parentJsonValue, boolean isPublic,
+            Instant timestamp, String parentJsonValue, boolean isPublic,
             List<IndexingRules> indexingRules) throws IOException {
         String indexName = checkIndex(objectType, indexingRules);
         GUID parentGUID = new GUID(id.getStorageCode(), id.getAccessGroupId(), 

--- a/lib/src/kbasesearchengine/search/IndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/IndexingStorage.java
@@ -1,6 +1,7 @@
 package kbasesearchengine.search;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,10 +27,10 @@ public interface IndexingStorage {
      * @throws IOException
      */
     public void indexObject(GUID guid, String objectType, ParsedObject obj, SourceData source,
-            long timestamp, String parentJsonValue, boolean isPublic,
+            Instant timestamp, String parentJsonValue, boolean isPublic,
             List<IndexingRules> indexingRules) throws IOException;
 
-    public void indexObjects(String objectType, SourceData obj, long timestamp,
+    public void indexObjects(String objectType, SourceData obj, Instant timestamp,
             String parentJsonValue, GUID pguid, Map<GUID, ParsedObject> idToObj,
             boolean isPublic, List<IndexingRules> indexingRules) 
                     throws IOException;

--- a/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
+++ b/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
@@ -209,17 +209,15 @@ public class WorkspaceEventGenerator {
         final String type = typeString[0];
         final int typever = Integer.parseInt(typeString[1].split("\\.")[0]);
         try {
-            storage.store(new StatusEvent(
-                    null, // no mongo id
-                    wsid,
-                    objid + "",
-                    vernum,
-                    null,
-                    null,
-                    ver.getDate(WS_KEY_SAVEDATE).getTime(),
+            storage.store(StatusEvent.getBuilder(
                     new StorageObjectType("WS", type, typever),
-                    StatusEventType.NEW_VERSION,
-                    pub));
+                    ver.getDate(WS_KEY_SAVEDATE).toInstant(),
+                    StatusEventType.NEW_VERSION)
+                    .withNullableAccessGroupID(wsid)
+                    .withNullableObjectID(objid + "")
+                    .withNullableVersion(vernum)
+                    .withNullableisPublic(pub)
+                    .build());
         } catch (IOException e) {
             throw new EventGeneratorException("Error saving event to RESKE db: " + e.getMessage(),
                     e);

--- a/test/src/kbasesearchengine/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/events/exceptions/RetrierTest.java
@@ -166,9 +166,12 @@ public class RetrierTest {
     public void consumer2RetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Collections.emptyList(), collog);
-        final StatusEvent ev = new StatusEvent(
-                null, 23, "bar", 6, null, null, 2L, new StorageObjectType("foo", "whee"),
-                StatusEventType.DELETED, false);
+        final StatusEvent ev = StatusEvent.getBuilder(
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                .withNullableAccessGroupID(23)
+                .withNullableObjectID("bar")
+                .withNullableVersion(6)
+                .build();
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2), "foo", ev);
         final Instant end = Instant.now();
@@ -237,9 +240,12 @@ public class RetrierTest {
     public void consumer2FatalRetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Arrays.asList(70, 30), collog);
-        final StatusEvent ev = new StatusEvent(
-                null, 23, "bar", 6, null, null, 2L, new StorageObjectType("foo", "whee"),
-                StatusEventType.DELETED, false);
+        final StatusEvent ev = StatusEvent.getBuilder(
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                .withNullableAccessGroupID(23)
+                .withNullableObjectID("bar")
+                .withNullableVersion(6)
+                .build();
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2, true), "foo", ev);
         final Instant end = Instant.now();
@@ -351,9 +357,12 @@ public class RetrierTest {
     public void function2RetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Collections.emptyList(), collog);
-        final StatusEvent ev = new StatusEvent(
-                null, 23, "bar", 6, null, null, 2L, new StorageObjectType("foo", "whee"),
-                StatusEventType.DELETED, false);
+        final StatusEvent ev = StatusEvent.getBuilder(
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                .withNullableAccessGroupID(23)
+                .withNullableObjectID("bar")
+                .withNullableVersion(6)
+                .build();
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 26L, 2), "foo", ev);
         final Instant end = Instant.now();
@@ -424,9 +433,12 @@ public class RetrierTest {
     public void function2FatalRetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Arrays.asList(70, 30), collog);
-        final StatusEvent ev = new StatusEvent(
-                null, 23, "bar", 6, null, null, 2L, new StorageObjectType("foo", "whee"),
-                StatusEventType.DELETED, false);
+        final StatusEvent ev = StatusEvent.getBuilder(
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                .withNullableAccessGroupID(23)
+                .withNullableObjectID("bar")
+                .withNullableVersion(6)
+                .build();
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 64L, 2, true), "foo", ev);
         final Instant end = Instant.now();

--- a/test/src/kbasesearchengine/main/test/PerformanceTester.java
+++ b/test/src/kbasesearchengine/main/test/PerformanceTester.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -208,17 +209,16 @@ public class PerformanceTester {
                 String[] parts = ref.split("/");
                 int wsId = Integer.parseInt(parts[0]);
                 int version = Integer.parseInt(parts[2]);
-                StatusEvent ev = new StatusEvent(
-                        "-1",
-                        wsId,
-                        parts[1],
-                        version, 
-                        null,
-                        null,
-                        System.currentTimeMillis(),
+                final StatusEvent ev = StatusEvent.getBuilder(
                         new StorageObjectType("WS", "KBaseGenomes.Genome"),
-                        StatusEventType.NEW_VERSION,
-                        true);
+                        Instant.now(),
+                        StatusEventType.NEW_VERSION)
+                        .withID("-1")
+                        .withNullableAccessGroupID(wsId)
+                        .withNullableObjectID(parts[1])
+                        .withNullableVersion(version)
+                        .withNullableisPublic(true)
+                        .build();
                 long t2 = System.currentTimeMillis();
                 try {
                     mop.processOneEvent(ev);

--- a/test/src/kbasesearchengine/search/test/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/search/test/ElasticIndexingStorageTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -153,7 +154,7 @@ public class ElasticIndexingStorageTest {
     }
     
     private static void indexObject(GUID id, String objectType, String json, String objectName,
-            long timestamp, String parentJsonValue, boolean isPublic,
+            Instant timestamp, String parentJsonValue, boolean isPublic,
             List<IndexingRules> indexingRules)
             throws IOException, ObjectParseException, IndexingException, InterruptedException {
         ParsedObject obj = KeywordParser.extractKeywords(objectType, json, parentJsonValue, 
@@ -190,7 +191,7 @@ public class ElasticIndexingStorageTest {
             }
             GUID id = ObjectParser.prepareGUID(parsingRules, ref, path, idConsumer);
             indexObject(id, parsingRules.getGlobalObjectType(), subJson, 
-                    objName, System.currentTimeMillis(), parentJson,
+                    objName, Instant.now(), parentJson,
                     false, parsingRules.getIndexingRules());
         }
 
@@ -282,25 +283,25 @@ public class ElasticIndexingStorageTest {
         ir.setFullText(true);
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id11 = new GUID("WS:2/1/1");
-        indexObject(id11, objType, "{\"prop1\":\"abc 123\"}", "obj.1", 0, null,
+        indexObject(id11, objType, "{\"prop1\":\"abc 123\"}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         checkIdInSet(indexStorage.searchIds(objType, ft("abc"), null, 
                 AccessFilter.create().withAccessGroups(2)), 1, id11);
         GUID id2 = new GUID("WS:2/2/1");
-        indexObject(id2, objType, "{\"prop1\":\"abd\"}", "obj.2", 0, null,
+        indexObject(id2, objType, "{\"prop1\":\"abd\"}", "obj.2", Instant.now(), null,
                 false, indexingRules);
         GUID id3 = new GUID("WS:3/1/1");
-        indexObject(id3, objType, "{\"prop1\":\"abc\"}", "obj.3", 0, null,
+        indexObject(id3, objType, "{\"prop1\":\"abc\"}", "obj.3", Instant.now(), null,
                 false, indexingRules);
         checkIdInSet(indexStorage.searchIds(objType, ft("abc"), null, 
                 AccessFilter.create().withAccessGroups(2)), 1, id11);
         GUID id12 = new GUID("WS:2/1/2");
-        indexObject(id12, objType, "{\"prop1\":\"abc 124\"}", "obj.1", 0, null,
+        indexObject(id12, objType, "{\"prop1\":\"abc 124\"}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         checkIdInSet(indexStorage.searchIds(objType, ft("abc"), null, 
                 AccessFilter.create().withAccessGroups(2)), 1, id12);
         GUID id13 = new GUID("WS:2/1/3");
-        indexObject(id13, objType, "{\"prop1\":\"abc 125\"}", "obj.1", 0, null,
+        indexObject(id13, objType, "{\"prop1\":\"abc 125\"}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         //indexStorage.refreshIndex(indexStorage.getIndex(objType));
         checkIdInSet(indexStorage.searchIds(objType, ft("abc"), null, 
@@ -340,13 +341,13 @@ public class ElasticIndexingStorageTest {
         ir.setKeywordType("integer");
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:10/1/1");
-        indexObject(id1, objType, "{\"prop2\": 123}", "obj.1", 0, null,
+        indexObject(id1, objType, "{\"prop2\": 123}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         GUID id2 = new GUID("WS:10/1/2");
-        indexObject(id2, objType, "{\"prop2\": 124}", "obj.1", 0, null,
+        indexObject(id2, objType, "{\"prop2\": 124}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         GUID id3 = new GUID("WS:10/1/3");
-        indexObject(id3, objType, "{\"prop2\": 125}", "obj.1", 0, null,
+        indexObject(id3, objType, "{\"prop2\": 125}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         AccessFilter af10 = AccessFilter.create().withAccessGroups(10);
         Assert.assertEquals(0, lookupIdsByKey(objType, "prop2", 123, af10).size());
@@ -392,9 +393,9 @@ public class ElasticIndexingStorageTest {
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:20/1/1");
         GUID id2 = new GUID("WS:20/2/1");
-        indexObject(id1, objType, "{\"prop3\": \"private gggg\"}", "obj.1", 0, null,
+        indexObject(id1, objType, "{\"prop3\": \"private gggg\"}", "obj.1", Instant.now(), null,
                 false, indexingRules);
-        indexObject(id2, objType, "{\"prop3\": \"public gggg\"}", "obj.2", 0, null,
+        indexObject(id2, objType, "{\"prop3\": \"public gggg\"}", "obj.2", Instant.now(), null,
                 true, indexingRules);
         Assert.assertEquals(0, lookupIdsByKey(objType, "prop3", "private", 
                 AccessFilter.create().withPublic(true)).size());
@@ -444,7 +445,7 @@ public class ElasticIndexingStorageTest {
         ir.setKeywordType("integer");
         List<IndexingRules> indexingRules = Arrays.asList(ir);
         GUID id1 = new GUID("WS:30/1/1");
-        indexObject(id1, objType, "{\"prop4\": 123}", "obj.1", 0, null,
+        indexObject(id1, objType, "{\"prop4\": 123}", "obj.1", Instant.now(), null,
                 false, indexingRules);
         AccessFilter af30 = AccessFilter.create().withAccessGroups(30);
         checkIdInSet(lookupIdsByKey(objType, "prop4", 123, af30), 1, id1);
@@ -481,10 +482,10 @@ public class ElasticIndexingStorageTest {
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:100/2/1");
         GUID id2 = new GUID("WS:100/2/2");
-        indexObject(id1, objType, "{\"myprop\": \"some stuff\"}", "myobj", 0, null,
+        indexObject(id1, objType, "{\"myprop\": \"some stuff\"}", "myobj", Instant.now(), null,
                 false, indexingRules);
-        indexObject(id2, objType, "{\"myprop\": \"some other stuff\"}", "myobj", 0, null,
-                false, indexingRules);
+        indexObject(id2, objType, "{\"myprop\": \"some other stuff\"}", "myobj", Instant.now(),
+                null, false, indexingRules);
         
         final AccessFilter filter = AccessFilter.create().withAccessGroups(100);
         final AccessFilter filterAllVers = AccessFilter.create().withAccessGroups(100)
@@ -528,10 +529,10 @@ public class ElasticIndexingStorageTest {
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:200/2/1");
         GUID id2 = new GUID("WS:200/2/2");
-        indexObject(id1, objType, "{\"myprop\": \"some stuff\"}", "myobj", 0, null,
+        indexObject(id1, objType, "{\"myprop\": \"some stuff\"}", "myobj", Instant.now(), null,
                 false, indexingRules);
-        indexObject(id2, objType, "{\"myprop\": \"some other stuff\"}", "myobj", 0, null,
-                false, indexingRules);
+        indexObject(id2, objType, "{\"myprop\": \"some other stuff\"}", "myobj", Instant.now(),
+                null, false, indexingRules);
         
         final AccessFilter filter = AccessFilter.create()
                 .withAllHistory(true).withPublic(false);


### PR DESCRIPTION
Adds a builder for status event in preparation for removing the id field
and adding a processing status field.

Also switch long, which is ambiguous, to Instant, and use Optionals for
nullable values.