### PR TITLE
TASK-1161 Store sub events in database

### DIFF
--- a/lib/src/kbasesearchengine/events/StatusEvent.java
+++ b/lib/src/kbasesearchengine/events/StatusEvent.java
@@ -18,7 +18,6 @@ public class StatusEvent {
     private final StatusEventType eventType;
     private final String storageCode;
     private final Optional<StorageObjectType> storageObjectType;
-    private final String id; // TODO NOW remove
     private final Optional<Integer> accessGroupID;
     private final Optional<String> objectID;
     private final Optional<Integer> version;
@@ -26,7 +25,6 @@ public class StatusEvent {
     private final Optional<String> newName;
     
     private StatusEvent(
-            final String id,
             final StatusEventType eventType,
             final String storageCode,
             final Optional<Integer> accessGroupID,
@@ -36,7 +34,6 @@ public class StatusEvent {
             final Instant time,
             final Optional<Boolean> isPublic,
             final Optional<String> newName) {
-        this.id = id;
         this.eventType = eventType;
         this.storageCode = storageCode;
         this.accessGroupID = accessGroupID;
@@ -57,10 +54,6 @@ public class StatusEvent {
                 version.orNull(),
                 null,
                 null);
-    }
-
-    public String getId() {
-        return id;
     }
 
     public String getStorageCode() {
@@ -110,8 +103,6 @@ public class StatusEvent {
         builder2.append(storageCode);
         builder2.append(", storageObjectType=");
         builder2.append(storageObjectType);
-        builder2.append(", id=");
-        builder2.append(id);
         builder2.append(", accessGroupID=");
         builder2.append(accessGroupID);
         builder2.append(", objectID=");
@@ -146,7 +137,6 @@ public class StatusEvent {
         private final StatusEventType eventType;
         private final String storageCode;
         private final Optional<StorageObjectType> storageObjectType;
-        private String id = null; // TODO NOW remove
         private Optional<Integer> accessGroupID = Optional.absent();
         private Optional<String> objectID = Optional.absent();
         private Optional<Integer> version = Optional.absent();
@@ -177,12 +167,6 @@ public class StatusEvent {
             this.storageCode = storageType.getStorageCode();
             this.eventType = eventType;
             this.storageObjectType = Optional.of(storageType);
-        }
-        
-        //TODO NOW remove. Use StatusEventWithID
-        public Builder withID(final String id) {
-            this.id = id;
-            return this;
         }
         
         public Builder withNullableAccessGroupID(final Integer accessGroupID) {
@@ -219,7 +203,7 @@ public class StatusEvent {
         }
         
         public StatusEvent build() {
-            return new StatusEvent(id, eventType, storageCode, accessGroupID, objectID,
+            return new StatusEvent(eventType, storageCode, accessGroupID, objectID,
                     version, storageObjectType, time, isPublic, newName);
         }
     }

--- a/lib/src/kbasesearchengine/events/StatusEventID.java
+++ b/lib/src/kbasesearchengine/events/StatusEventID.java
@@ -1,0 +1,51 @@
+package kbasesearchengine.events;
+
+import kbasesearchengine.tools.Utils;
+
+public class StatusEventID {
+    
+    //TODO JAVADOC
+    //TODO TEST
+    
+    private final String id;
+
+    public StatusEventID(final String id) {
+        Utils.notNullOrEmpty(id, "id cannot be null or the empty string");
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        StatusEventID other = (StatusEventID) obj;
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/lib/src/kbasesearchengine/events/StatusEventWithID.java
+++ b/lib/src/kbasesearchengine/events/StatusEventWithID.java
@@ -1,0 +1,28 @@
+package kbasesearchengine.events;
+
+import kbasesearchengine.tools.Utils;
+
+public class StatusEventWithID {
+    
+    //TODO JAVADOC
+    //TODO TEST
+    
+    private final StatusEvent event;
+    private final StatusEventID id;
+    
+    public StatusEventWithID(final StatusEvent event, final StatusEventID id) {
+        Utils.nonNull(event, "event");
+        Utils.nonNull(id, "id");
+        this.event = event;
+        this.id = id;
+    }
+
+    public StatusEvent getEvent() {
+        return event;
+    }
+
+    public StatusEventID getId() {
+        return id;
+    }
+
+}

--- a/lib/src/kbasesearchengine/events/exceptions/Retrier.java
+++ b/lib/src/kbasesearchengine/events/exceptions/Retrier.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Optional;
 
-import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.tools.Utils;
 
 /** Generic code for retrying functions. Expects the code to throw
@@ -94,7 +94,7 @@ public class Retrier {
     public <T> void retryCons(
             final RetryConsumer<T> consumer,
             final T input,
-            final StatusEvent event)
+            final StatusEventWithID event)
             throws InterruptedException, IndexingException {
         Utils.nonNull(consumer, "consumer");
         int retries = 1;
@@ -125,7 +125,7 @@ public class Retrier {
     public <T, R> R retryFunc(
             final RetryFunction<T, R> function,
             final T input,
-            final StatusEvent event)
+            final StatusEventWithID event)
             throws InterruptedException, IndexingException {
         Utils.nonNull(function, "function");
         int retries = 1;
@@ -145,7 +145,7 @@ public class Retrier {
     }
     
     private boolean handleException(
-            final StatusEvent event,
+            final StatusEventWithID event,
             final RetriableIndexingException e,
             final int retries,
             final int fatalRetries)

--- a/lib/src/kbasesearchengine/events/exceptions/RetryLogger.java
+++ b/lib/src/kbasesearchengine/events/exceptions/RetryLogger.java
@@ -2,7 +2,7 @@ package kbasesearchengine.events.exceptions;
 
 import com.google.common.base.Optional;
 
-import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 
 /** A logging interface for the retrier.
  * @see Retrier
@@ -16,6 +16,6 @@ public interface RetryLogger {
      * @param event an event associated with the retry. May be absent.
      * @param e the exception that occurred on the current retry.
      */
-    void log(int retryCount, Optional<StatusEvent> event, RetriableIndexingException e);
+    void log(int retryCount, Optional<StatusEventWithID> event, RetriableIndexingException e);
 
 }

--- a/lib/src/kbasesearchengine/events/handler/EventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/EventHandler.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.events.exceptions.IndexingException;
 import kbasesearchengine.events.exceptions.IndexingExceptionUncheckedWrapper;
 import kbasesearchengine.events.exceptions.RetriableIndexingException;
@@ -29,8 +30,6 @@ public interface EventHandler {
 
     /** Expands an event into multiple sub events. Returns the input event in a single item
      * Iterable if the event requires no expansion.
-     * Note that the _id field of the sub events will be null since they have no storage system
-     * records.
      * Also note that the {@link Iterable#iterator()} and  {@link Iterator#next()} functions may
      * throw {@link IndexingExceptionUncheckedWrapper} and
      * {@link RetriableIndexingExceptionUncheckedWrapper} exceptions, which should be unwrapped
@@ -41,7 +40,7 @@ public interface EventHandler {
      * @throws IndexingException if an error occurred expanding the event.
      * @throws RetriableIndexingException if a retriable error occurred loading the data.
      */
-    Iterable<StatusEvent> expand(StatusEvent event)
+    Iterable<StatusEvent> expand(StatusEventWithID event)
             throws IndexingException, RetriableIndexingException;
     
     /** The equivalent of {@link #load(List, Path) load(Arrays.asList(guid), tempfile)}
@@ -88,5 +87,5 @@ public interface EventHandler {
      * @param parentEvent the event to check.
      * @return true if the event will be expanded, false otherwise.
      */
-    boolean isExpandable(StatusEvent parentEvent);
+    boolean isExpandable(StatusEventWithID parentEvent);
 }

--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.IndexingException;
@@ -252,9 +253,9 @@ public class WorkspaceEventHandler implements EventHandler {
     }
 
     @Override
-    public boolean isExpandable(final StatusEvent parentEvent) {
+    public boolean isExpandable(final StatusEventWithID parentEvent) {
         checkStorageCode(parentEvent);
-        return EXPANDABLES.contains(parentEvent.getEventType());
+        return EXPANDABLES.contains(parentEvent.getEvent().getEventType());
         
     };
     
@@ -266,9 +267,10 @@ public class WorkspaceEventHandler implements EventHandler {
             StatusEventType.UNPUBLISH_ACCESS_GROUP));
     
     @Override
-    public Iterable<StatusEvent> expand(final StatusEvent event)
+    public Iterable<StatusEvent> expand(final StatusEventWithID eventWID)
             throws IndexingException, RetriableIndexingException {
-        checkStorageCode(event);
+        checkStorageCode(eventWID);
+        final StatusEvent event = eventWID.getEvent();
         if (StatusEventType.NEW_ALL_VERSIONS.equals(event.getEventType())) {
             return handleNewAllVersions(event);
         } else if (StatusEventType.COPY_ACCESS_GROUP.equals(event.getEventType())) {
@@ -284,8 +286,12 @@ public class WorkspaceEventHandler implements EventHandler {
         }
     }
 
-    private void checkStorageCode(final StatusEvent event) {
-        if (!STORAGE_CODE.equals(event.getStorageCode())) {
+    private void checkStorageCode(final StatusEventWithID event) {
+        checkStorageCode(event.getEvent().getStorageCode());
+    }
+
+    private void checkStorageCode(final String storageCode) {
+        if (!STORAGE_CODE.equals(storageCode)) {
             throw new IllegalArgumentException("This handler only accepts "
                     + STORAGE_CODE + "events");
         }

--- a/lib/src/kbasesearchengine/events/storage/OldStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/OldStatusEventStorage.java
@@ -1,14 +1,13 @@
 package kbasesearchengine.events.storage;
 
-import java.io.IOException;
-
 import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 
 public interface OldStatusEventStorage {
 	
-	public void store(StatusEvent obj) throws IOException;
+	public StatusEventWithID store(StatusEvent obj);
 	
-	public void markAsProcessed(StatusEvent row, boolean isIndexed) throws IOException;
+	public void markAsProcessed(StatusEventWithID row, boolean isIndexed);
 	
 	public StatusEventCursor cursor(String storageCode, boolean processed, int pageSize, String timeAlive);
 	

--- a/lib/src/kbasesearchengine/events/storage/StatusEventCursor.java
+++ b/lib/src/kbasesearchengine/events/storage/StatusEventCursor.java
@@ -3,7 +3,7 @@ package kbasesearchengine.events.storage;
 import java.util.ArrayList;
 import java.util.List;
 
-import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 
 public class StatusEventCursor {
 	
@@ -11,7 +11,7 @@ public class StatusEventCursor {
 	private int pageSize;
 	private String timeAlive;
 	private int pageIndex;
-	List<StatusEvent> data = new ArrayList<StatusEvent>();
+	List<StatusEventWithID> data = new ArrayList<StatusEventWithID>();
 	
 	public StatusEventCursor(String cursorId, int pageSize, String timeAlive) {
 		super();
@@ -21,10 +21,10 @@ public class StatusEventCursor {
 		pageIndex = 0;
 	}
 
-	public void nextPage(List<StatusEvent> items){
+	public void nextPage(List<StatusEventWithID> objs){
 		pageIndex++;
 		data.clear();
-		data.addAll(items);
+		data.addAll(objs);
 	}
 	
 	public int getPageSize() {
@@ -43,7 +43,7 @@ public class StatusEventCursor {
 		return pageIndex;
 	}
 
-	public List<StatusEvent> getData() {
+	public List<StatusEventWithID> getData() {
 		return data;
 	}
 }

--- a/lib/src/kbasesearchengine/queue/StatusEventIterator.java
+++ b/lib/src/kbasesearchengine/queue/StatusEventIterator.java
@@ -1,8 +1,6 @@
 package kbasesearchengine.queue;
 
-import java.io.IOException;
-
-import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 
@@ -10,8 +8,5 @@ public interface StatusEventIterator {
 
     public boolean hasNext();
 
-    public StatusEvent next() throws FatalIndexingException, FatalRetriableIndexingException;
-
-    public void markAsVisited(boolean isIndexed) throws IOException;
-
+    public StatusEventWithID next() throws FatalIndexingException, FatalRetriableIndexingException;
 }

--- a/lib/src/kbasesearchengine/queue/StatusEventQueue.java
+++ b/lib/src/kbasesearchengine/queue/StatusEventQueue.java
@@ -1,9 +1,8 @@
 package kbasesearchengine.queue;
 
-import java.io.IOException;
 import java.util.NoSuchElementException;
 
-import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.storage.StatusEventCursor;
@@ -17,7 +16,7 @@ public class StatusEventQueue {
 	class _Iterator implements StatusEventIterator{
 		String storageCode;
 		StatusEventCursor cursor = null;
-		StatusEvent[] buffer = new StatusEvent[BUFFER_SIZE];
+		StatusEventWithID[] buffer = new StatusEventWithID[BUFFER_SIZE];
 		int nextPos = 0;
 		int nItems = 0;
 		int nMarkedAsVisited = 0;
@@ -28,7 +27,6 @@ public class StatusEventQueue {
 			this.storageCode = storageCode;
 			loadBuffer();
 		}
-				
 
 		@Override
 		public boolean hasNext() {
@@ -46,7 +44,7 @@ public class StatusEventQueue {
 			}
 						
 			int i = 0;
-			for(StatusEvent row : cursor.getData()){
+			for(StatusEventWithID row : cursor.getData()){
 				buffer[i++] = row;
 			}
 			nextPos = 0;
@@ -57,24 +55,12 @@ public class StatusEventQueue {
 			return !(nextPos < nItems);
 		}
 
-		@Override
-		public void markAsVisited(boolean isIndexed) throws IOException {
-			int curPos = nextPos - 1;
-			if (curPos >= 0 && curPos < nItems) {
-				objStatusStorage.markAsProcessed(buffer[curPos], isIndexed);
-				
-			} else {
-				throw new IndexOutOfBoundsException();
-			}		
-			nMarkedAsVisited++;
-		}
-
         @Override
-        public StatusEvent next() {
+        public StatusEventWithID next() {
             if (isBufferEmpty()) {
                 throw new NoSuchElementException();
             }
-            final StatusEvent ev = buffer[nextPos++];
+            final StatusEventWithID ev = buffer[nextPos++];
             return ev;
         }
 	}

--- a/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
+++ b/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
@@ -3,7 +3,6 @@ package kbasesearchengine.tools;
 import static kbasesearchengine.tools.Utils.noNulls;
 import static kbasesearchengine.tools.Utils.nonNull;
 
-import java.io.IOException;
 import java.io.PrintStream;
 import java.time.Instant;
 import java.util.Collection;
@@ -208,20 +207,15 @@ public class WorkspaceEventGenerator {
         final String[] typeString = ver.getString(WS_KEY_TYPE).split("-");
         final String type = typeString[0];
         final int typever = Integer.parseInt(typeString[1].split("\\.")[0]);
-        try {
-            storage.store(StatusEvent.getBuilder(
-                    new StorageObjectType("WS", type, typever),
-                    ver.getDate(WS_KEY_SAVEDATE).toInstant(),
-                    StatusEventType.NEW_VERSION)
-                    .withNullableAccessGroupID(wsid)
-                    .withNullableObjectID(objid + "")
-                    .withNullableVersion(vernum)
-                    .withNullableisPublic(pub)
-                    .build());
-        } catch (IOException e) {
-            throw new EventGeneratorException("Error saving event to RESKE db: " + e.getMessage(),
-                    e);
-        }
+        storage.store(StatusEvent.getBuilder(
+                new StorageObjectType("WS", type, typever),
+                ver.getDate(WS_KEY_SAVEDATE).toInstant(),
+                StatusEventType.NEW_VERSION)
+                .withNullableAccessGroupID(wsid)
+                .withNullableObjectID(objid + "")
+                .withNullableVersion(vernum)
+                .withNullableisPublic(pub)
+                .build());
         log(String.format("Generated event %s/%s/%s %s-%s", wsid, objid, vernum, type, typever));
     }
 

--- a/test/src/kbasesearchengine/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/events/exceptions/RetrierTest.java
@@ -15,7 +15,9 @@ import org.junit.Test;
 import com.google.common.base.Optional;
 
 import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventID;
 import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.events.exceptions.RetriableIndexingException;
 import kbasesearchengine.events.exceptions.Retrier;
 import kbasesearchengine.events.exceptions.RetryLogger;
@@ -27,13 +29,13 @@ public class RetrierTest {
     private class LogEvent {
         private final Instant time;
         private final int retryCount;
-        private final Optional<StatusEvent> event;
+        private final Optional<StatusEventWithID> event;
         private final RetriableIndexingException exception;
         
         private LogEvent(
                 final Instant time,
                 final int retryCount,
-                final Optional<StatusEvent> optional,
+                final Optional<StatusEventWithID> optional,
                 final RetriableIndexingException exception) {
             this.time = time;
             this.retryCount = retryCount;
@@ -47,7 +49,7 @@ public class RetrierTest {
         private final List<LogEvent> events = new LinkedList<>();
         
         @Override
-        public void log(int retryCount, Optional<StatusEvent> optional,
+        public void log(int retryCount, Optional<StatusEventWithID> optional,
                 RetriableIndexingException e) {
             events.add(new LogEvent(Instant.now(), retryCount, optional, e));
         }
@@ -166,12 +168,13 @@ public class RetrierTest {
     public void consumer2RetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Collections.emptyList(), collog);
-        final StatusEvent ev = StatusEvent.getBuilder(
+        final StatusEventWithID ev = new StatusEventWithID(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
-                .build();
+                .build(),
+                new StatusEventID("wugga"));
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2), "foo", ev);
         final Instant end = Instant.now();
@@ -240,12 +243,13 @@ public class RetrierTest {
     public void consumer2FatalRetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Arrays.asList(70, 30), collog);
-        final StatusEvent ev = StatusEvent.getBuilder(
+        final StatusEventWithID ev = new StatusEventWithID(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
-                .build();
+                .build(),
+                new StatusEventID("wugga"));
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2, true), "foo", ev);
         final Instant end = Instant.now();
@@ -357,12 +361,13 @@ public class RetrierTest {
     public void function2RetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Collections.emptyList(), collog);
-        final StatusEvent ev = StatusEvent.getBuilder(
+        final StatusEventWithID ev = new StatusEventWithID(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
-                .build();
+                .build(),
+                new StatusEventID("wugga"));
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 26L, 2), "foo", ev);
         final Instant end = Instant.now();
@@ -433,12 +438,13 @@ public class RetrierTest {
     public void function2FatalRetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Arrays.asList(70, 30), collog);
-        final StatusEvent ev = StatusEvent.getBuilder(
+        final StatusEventWithID ev = new StatusEventWithID(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
-                .build();
+                .build(),
+                new StatusEventID("wugga"));
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 64L, 2, true), "foo", ev);
         final Instant end = Instant.now();

--- a/test/src/kbasesearchengine/main/test/PerformanceTester.java
+++ b/test/src/kbasesearchengine/main/test/PerformanceTester.java
@@ -26,7 +26,9 @@ import com.google.common.collect.ImmutableMap;
 
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventID;
 import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.StatusEventWithID;
 import kbasesearchengine.main.LineLogger;
 import kbasesearchengine.main.IndexerCoordinator;
 import kbasesearchengine.search.AccessFilter;
@@ -209,16 +211,16 @@ public class PerformanceTester {
                 String[] parts = ref.split("/");
                 int wsId = Integer.parseInt(parts[0]);
                 int version = Integer.parseInt(parts[2]);
-                final StatusEvent ev = StatusEvent.getBuilder(
+                final StatusEventWithID ev = new StatusEventWithID(StatusEvent.getBuilder(
                         new StorageObjectType("WS", "KBaseGenomes.Genome"),
                         Instant.now(),
                         StatusEventType.NEW_VERSION)
-                        .withID("-1")
                         .withNullableAccessGroupID(wsId)
                         .withNullableObjectID(parts[1])
                         .withNullableVersion(version)
                         .withNullableisPublic(true)
-                        .build();
+                        .build(),
+                        new StatusEventID("-1"));
                 long t2 = System.currentTimeMillis();
                 try {
                     mop.processOneEvent(ev);


### PR DESCRIPTION
Now stores sub events in database and generates an ID for the sub event.
Does not yet check to avoid storing duplicate events or reprocessing
successful sub events.

Removed the id field from StatusEvent (now in StatusEventWithID).

Remove a not particularly helpful level of indirection by marking event
processing state in the storage system with a direct storage call,
rather than via an iterator then a queue then the storage system