### PR TITLE
Add update time to event record

### DIFF
--- a/lib/src/kbasesearchengine/events/StoredStatusEvent.java
+++ b/lib/src/kbasesearchengine/events/StoredStatusEvent.java
@@ -1,5 +1,7 @@
 package kbasesearchengine.events;
 
+import java.time.Instant;
+
 import com.google.common.base.Optional;
 
 import kbasesearchengine.tools.Utils;
@@ -14,12 +16,17 @@ public class StoredStatusEvent {
     private final StatusEvent event;
     private final StatusEventID id;
     private final StatusEventProcessingState state;
+    private final Optional<Instant> updateTime;
     private final Optional<String> updater;
+    
+    // right on the edge of needing to convert to a builder...
     
     /** Create a stored event.
      * @param event the event.
      * @param id the event ID.
      * @param state the processing state of the event.
+     * @param updateTime the time of the last update to the processing state. Optional and
+     * nullable.
      * @param updater the id of the operator that last updated the processing state. Optional and
      * nullable.
      */
@@ -27,6 +34,7 @@ public class StoredStatusEvent {
             final StatusEvent event,
             final StatusEventID id,
             final StatusEventProcessingState state,
+            final Instant updateTime,
             final String updater) {
         Utils.nonNull(event, "event");
         Utils.nonNull(id, "id");
@@ -34,6 +42,7 @@ public class StoredStatusEvent {
         this.event = event;
         this.id = id;
         this.state = state;
+        this.updateTime = Optional.fromNullable(updateTime);
         if (Utils.isNullOrEmpty(updater)) {
             this.updater = Optional.absent();
         } else {
@@ -62,6 +71,13 @@ public class StoredStatusEvent {
         return state;
     }
     
+    /** Get the time at which the event was updated.
+     * @return the update time, or absent if missing.
+     */
+    public Optional<Instant> getUpdateTime() {
+        return updateTime;
+    }
+
     /** Return the ID of the operator that last updated the processing state.
      * @return the operator ID, or absent if missing.
      */

--- a/lib/src/kbasesearchengine/events/storage/StatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/StatusEventStorage.java
@@ -1,5 +1,6 @@
 package kbasesearchengine.events.storage;
 
+import java.time.Instant;
 import java.util.List;
 
 import com.google.common.base.Optional;
@@ -48,6 +49,7 @@ public interface StatusEventStorage {
      * Returns the event that matches the processing state with the earliest timestamp.
      * @param oldState the state of the event to find.
      * @param newState the state to which the event will be updated.
+     * @param updateTime the time to set as the event update time. Usually {@link Instant#now()}.
      * @param updater an optional (e.g. nullable) id or name to associate with the state change.
      * Only the most recent state change is recorded.
      * @return the updated event or absent if no events are in the requested state.
@@ -56,6 +58,7 @@ public interface StatusEventStorage {
     Optional<StoredStatusEvent> getAndSetProcessingState(
             StatusEventProcessingState oldState,
             StatusEventProcessingState newState,
+            Instant updateTime,
             String updater)
             throws FatalRetriableIndexingException;
     

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -194,8 +194,8 @@ public class IndexerWorker {
     
     private boolean performOneTick() throws InterruptedException, IndexingException {
         final Optional<StoredStatusEvent> optEvent = retrier.retryFunc(
-                s -> s.getAndSetProcessingState(
-                        StatusEventProcessingState.READY, StatusEventProcessingState.PROC, id),
+                s -> s.getAndSetProcessingState(StatusEventProcessingState.READY,
+                        StatusEventProcessingState.PROC, Instant.now(), id),
                 storage, null);
         boolean processedEvent = false;
         if (optEvent.isPresent()) {

--- a/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
+++ b/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
@@ -29,13 +29,14 @@ public class StoredStatusEventTest {
         final StatusEvent se = StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
         
-        final StoredStatusEvent sei = new StoredStatusEvent(
-                se, new StatusEventID("foo"), StatusEventProcessingState.UNPROC, updater);
+        final StoredStatusEvent sei = new StoredStatusEvent(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC, null, updater);
         assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
         assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
         assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", sei.getUpdateTime(), is(Optional.absent()));
     }
     
     @Test
@@ -43,13 +44,15 @@ public class StoredStatusEventTest {
         final StatusEvent se = StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
         
-        final StoredStatusEvent sei = new StoredStatusEvent(
-                se, new StatusEventID("foo"), StatusEventProcessingState.UNPROC, "foo");
+        final StoredStatusEvent sei = new StoredStatusEvent(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC, Instant.ofEpochMilli(20000), "foo");
         assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
         assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
         assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.of("foo")));
+        assertThat("incorrect update time", sei.getUpdateTime(),
+                is(Optional.of(Instant.ofEpochMilli(20000))));
     }
     
     @Test
@@ -71,7 +74,8 @@ public class StoredStatusEventTest {
             final StatusEventProcessingState state,
             final Exception expected) {
         try {
-            new StoredStatusEvent(event, id, state, null);
+            // no exceptions can be triggered by update time or updater
+            new StoredStatusEvent(event, id, state, null, null);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);

--- a/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
@@ -184,6 +184,7 @@ public class RetrierTest {
                 .build(),
                 new StatusEventID("wugga"),
                 StatusEventProcessingState.UNPROC,
+                null,
                 null);
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2), "foo", ev);
@@ -261,6 +262,7 @@ public class RetrierTest {
                 .build(),
                 new StatusEventID("wugga"),
                 StatusEventProcessingState.UNPROC,
+                null,
                 null);
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2, true), "foo", ev);
@@ -381,6 +383,7 @@ public class RetrierTest {
                 .build(),
                 new StatusEventID("wugga"),
                 StatusEventProcessingState.UNPROC,
+                null,
                 null);
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 26L, 2), "foo", ev);
@@ -460,6 +463,7 @@ public class RetrierTest {
                 .build(),
                 new StatusEventID("wugga"),
                 StatusEventProcessingState.UNPROC,
+                null,
                 null);
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 64L, 2, true), "foo", ev);

--- a/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
@@ -275,6 +275,7 @@ public class IndexerWorkerTest {
                 .build(),
                 new StatusEventID("-1"),
                 StatusEventProcessingState.UNPROC,
+                null,
                 null);
         mop.processOneEvent(ev);
         PostProcessing pp = new PostProcessing();
@@ -316,6 +317,7 @@ public class IndexerWorkerTest {
                     .build(),
                     evid.getId(),
                     StatusEventProcessingState.UNPROC,
+                    null,
                     null);
             mop.processOneEvent(ev2);
         }
@@ -348,7 +350,7 @@ public class IndexerWorkerTest {
                 .withNullableisPublic(false)
                 .build();
         indexFewVersions(new StoredStatusEvent(ev, new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC, null));
+                StatusEventProcessingState.UNPROC, null, null));
         checkSearch(1, "Narrative", "tree", wsid, false);
         checkSearch(1, "Narrative", "species", wsid, false);
         /*indexFewVersions(new ObjectStatusEvent("-1", "WS", 10455, "1", 78, null, 
@@ -375,7 +377,7 @@ public class IndexerWorkerTest {
                 .withNullableisPublic(false)
                 .build();
         indexFewVersions(new StoredStatusEvent(ev, new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC, null));
+                StatusEventProcessingState.UNPROC, null, null));
         checkSearch(1, "PairedEndLibrary", "Illumina", wsid, true);
         checkSearch(1, "PairedEndLibrary", "sample1se.fastq.gz", wsid, false);
         final StatusEvent ev2 = StatusEvent.getBuilder(
@@ -388,7 +390,7 @@ public class IndexerWorkerTest {
                 .withNullableisPublic(false)
                 .build();
         indexFewVersions(new StoredStatusEvent(ev2, new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC, null));
+                StatusEventProcessingState.UNPROC, null, null));
         checkSearch(1, "SingleEndLibrary", "PacBio", wsid, true);
         checkSearch(1, "SingleEndLibrary", "reads.2", wsid, false);
     }

--- a/test/src/kbasesearchengine/test/main/PerformanceTester.java
+++ b/test/src/kbasesearchengine/test/main/PerformanceTester.java
@@ -229,6 +229,7 @@ public class PerformanceTester {
                         .build(),
                         new StatusEventID("-1"),
                         StatusEventProcessingState.UNPROC,
+                        null,
                         null);
                 long t2 = System.currentTimeMillis();
                 try {


### PR DESCRIPTION
Allows the coordinator to detect workers that have hung or failed and
log warnings (or something else)