### PR TITLE
Add object level queue

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -149,6 +149,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
           <fileset dir="${test.src}">
             <include name="kbasesearchengine/test/parse/**Test.java"/>
             <include name="kbasesearchengine/test/authorization/AccessGroupCacheTest.java"/>
+            <include name="kbasesearchengine/test/events/ObjectEventQueueTest.java"/>
             <include name="kbasesearchengine/test/events/StatusEventIDTest.java"/>
             <include name="kbasesearchengine/test/events/StatusEventTest.java"/>
             <include name="kbasesearchengine/test/events/StoredStatusEventTest.java"/>

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -136,10 +136,12 @@ public class ObjectEventQueue {
     public void load(final StoredStatusEvent event) {
         Utils.nonNull(event, "event");
         if (!event.getState().equals(StatusEventProcessingState.UNPROC)) {
-            throw new IllegalArgumentException("Can only load events in the unprocessed state");
+            throw new IllegalArgumentException("Illegal state for loading event: " +
+                    event.getState());
         }
         if (!OBJ_AND_VER_LVL_EVENTS.contains(event.getEvent().getEventType())) {
-            throw new IllegalArgumentException("Cannot load access group level events");
+            throw new IllegalArgumentException("Illegal type for loading event: " +
+                    event.getEvent().getEventType());
         }
         queue.add(event);
     }

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -111,8 +111,8 @@ public class ObjectEventQueue {
     public ObjectEventQueue(final StoredStatusEvent initialEvent) {
         Utils.nonNull(initialEvent, "initialEvent");
         if (!isObjectLevelEvent(initialEvent)) {
-            throw new IllegalArgumentException(
-                    "This constructor only accepts object level events");
+            throw new IllegalArgumentException("Illegal initial event type: " +
+                    initialEvent.getEvent().getEventType());
         }
         final StatusEventProcessingState state = initialEvent.getState();
         if (state.equals(StatusEventProcessingState.PROC)) {

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -1,6 +1,7 @@
 package kbasesearchengine.events;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,6 +19,8 @@ import kbasesearchengine.tools.Utils;
  * Note that the calling code is responsible for ensuring that IDs for events added to this queue
  * are unique.
  * If events with duplicate IDs are added to the queue unexpected behavior may result.
+ * 
+ * This class is not thread safe.
  * @author gaprice@lbl.gov
  *
  */
@@ -152,7 +155,7 @@ public class ObjectEventQueue {
         } else {
             ret = new HashSet<>(Arrays.asList(ready));
         }
-        return ret;
+        return Collections.unmodifiableSet(ret);
     }
     
     /** Get the set of events that the queue has determined are ready for processing, and set
@@ -171,16 +174,18 @@ public class ObjectEventQueue {
             processing = ready;
             ready = null;
         }
-        return ret;
+        return Collections.unmodifiableSet(ret);
     }
     
     public Set<StoredStatusEvent> getProcessing() {
+        final Set<StoredStatusEvent> ret;
         if (processing == null) {
             // will be empty list if ready != null;
-            return new HashSet<>(versionProcessing.values());
+            ret = new HashSet<>(versionProcessing.values());
         } else {
-            return new HashSet<>(Arrays.asList(processing));
+            ret = new HashSet<>(Arrays.asList(processing));
         }
+        return Collections.unmodifiableSet(ret);
     }
     
     /** Remove a processed event from the queue and update the queue state, potentially adding
@@ -241,7 +246,7 @@ public class ObjectEventQueue {
             return ret;
         }
         /* Either no events are ready/processing or only version level events are ready/processing.
-         * pull all the version level events off the front of the queue and put them in
+         * Pull all the version level events off the front of the queue and put them in
          * the ready state.
          */
         /* should really check we're not running events for the same version at the same time,
@@ -265,7 +270,7 @@ public class ObjectEventQueue {
             ret.add(next);
             queue.remove();
         }
-        return ret;
+        return Collections.unmodifiableSet(ret);
     }
     
     //TODO QUEUE set and remove drain and block 

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -1,0 +1,278 @@
+package kbasesearchengine.events;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import kbasesearchengine.tools.Utils;
+
+/** An event queue on the level of an object. Object level events block the queue entirely,
+ * while in contrast multiple version level events (e.g. {@link StatusEventType#NEW_VERSION})
+ * can run at the same time.
+ * 
+ * Note that the calling code is responsible for ensuring that IDs for events added to this queue
+ * are unique.
+ * If events with duplicate IDs are added to the queue unexpected behavior may result.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class ObjectEventQueue {
+    
+    /* Implementation notes:
+     * the queue can have an unlimited number of NEW_VERSION events ready for processing or
+     * processing at once, but only if no other type of event is ready for processing or
+     * processing.
+     * 
+     * In other words, if the ready variable is not null, processing must be null and 
+     * versionReady and versionProcessing must be empty. Same for processing except ready must
+     * be null.
+     * If versionReady or versionProcessing are not empty, both ready and processing must be null.
+     * 
+     * The intent is to ensure that no record in the search index is modified concurrently.
+     */
+    
+    private static final Set<StatusEventType> OBJ_LVL_EVENTS = new HashSet<>(Arrays.asList(
+            StatusEventType.DELETE_ALL_VERSIONS, StatusEventType.NEW_ALL_VERSIONS,
+            StatusEventType.PUBLISH_ALL_VERSIONS, StatusEventType.RENAME_ALL_VERSIONS,
+            StatusEventType.UNDELETE_ALL_VERSIONS, StatusEventType.UNPUBLISH_ALL_VERSIONS));
+    
+    private static final Set<StatusEventType> OBJ_AND_VER_LVL_EVENTS = new HashSet<>(Arrays.asList(
+            StatusEventType.NEW_VERSION));
+    static {
+        OBJ_AND_VER_LVL_EVENTS.addAll(OBJ_LVL_EVENTS);
+    }
+    
+    private final PriorityQueue<StoredStatusEvent> queue = new PriorityQueue<StoredStatusEvent>(
+            new Comparator<StoredStatusEvent>() {
+                
+                @Override
+                public int compare(final StoredStatusEvent e1, final StoredStatusEvent e2) {
+                    return e1.getEvent().getTimestamp().compareTo(e2.getEvent().getTimestamp());
+                }
+            });
+    
+    private StoredStatusEvent ready = null;
+    private final Set<StoredStatusEvent> versionReady = new HashSet<>();
+    private StoredStatusEvent processing = null;
+    // maps id to event
+    private final Map<StatusEventID, StoredStatusEvent> versionProcessing = new HashMap<>();
+    
+    // could require an access group id and object id and reject any events that don't match
+    
+    /** Create a new, empty, queue. */
+    public ObjectEventQueue() {}
+    
+    /** Create a new queue with an initial state consisting of {@link StatusEventType#NEW_VERSION}
+     * events in the {@link StatusEventProcessingState#READY} and
+     * {@link StatusEventProcessingState#PROC} states.
+     * @param initialReady a list of events that are ready for processing.
+     * @param initialProcessing a list of event that are being processed.
+     */
+    public ObjectEventQueue(
+            final List<StoredStatusEvent> initialReady,
+            final List<StoredStatusEvent> initialProcessing) {
+        Utils.nonNull(initialReady, "initialReady");
+        Utils.nonNull(initialProcessing, "initialProcessing");
+        checkState(initialReady, StatusEventProcessingState.READY, StatusEventType.NEW_VERSION);
+        checkState(initialProcessing, StatusEventProcessingState.PROC,
+                StatusEventType.NEW_VERSION);
+        versionReady.addAll(initialReady);
+        initialProcessing.stream().forEach(e -> versionProcessing.put(e.getId(), e));
+    }
+    
+    private void checkState(
+            final List<StoredStatusEvent> events,
+            final StatusEventProcessingState state,
+            final StatusEventType type) {
+        for (final StoredStatusEvent e: events) {
+            if (!e.getState().equals(state)) {
+                throw new IllegalArgumentException("Illegal initial event state: " + e.getState());
+            }
+            if (!e.getEvent().getEventType().equals(type)) {
+                throw new IllegalArgumentException("Illegal initial event type: " +
+                        e.getEvent().getEventType());
+            }
+        }
+    }
+
+    /** Create a new queue with an initial state consisting of an object-level, not version-level,
+     * event. The event must be in either the {@link StatusEventProcessingState#READY} or
+     * {@link StatusEventProcessingState#PROC} state.
+     * @param initialEvent the initial event.
+     */
+    public ObjectEventQueue(final StoredStatusEvent initialEvent) {
+        Utils.nonNull(initialEvent, "initialEvent");
+        if (!isObjectLevelEvent(initialEvent)) {
+            throw new IllegalArgumentException(
+                    "This constructor only accepts object level events");
+        }
+        final StatusEventProcessingState state = initialEvent.getState();
+        if (state.equals(StatusEventProcessingState.PROC)) {
+            this.processing = initialEvent; 
+        } else if (state.equals(StatusEventProcessingState.READY)){
+            this.ready = initialEvent;
+        } else {
+            throw new IllegalArgumentException("Illegal initial event state: " + state);
+        }
+    }
+    
+    private boolean isObjectLevelEvent(final StoredStatusEvent initialEvent) {
+        return OBJ_LVL_EVENTS.contains(initialEvent.getEvent().getEventType());
+    }
+
+    /** Add a new {@link StatusEventProcessingState#UNPROC} event to the queue.
+     * Before any loaded events are added to the ready or processing states,
+     * {@link #moveToReady()} must be called.
+     * @param event the event to add.
+     */
+    public void load(final StoredStatusEvent event) {
+        Utils.nonNull(event, "event");
+        if (!event.getState().equals(StatusEventProcessingState.UNPROC)) {
+            throw new IllegalArgumentException("Can only load events in the unprocessed state");
+        }
+        if (!OBJ_AND_VER_LVL_EVENTS.contains(event.getEvent().getEventType())) {
+            throw new IllegalArgumentException("Cannot load access group level events");
+        }
+        queue.add(event);
+    }
+    
+    /** Get the set of events that the queue has determined are ready for processing.
+     * @return the events ready for processing.
+     */
+    public Set<StoredStatusEvent> getReadyForProcessing() {
+        final Set<StoredStatusEvent> ret;
+        if (ready == null) {
+            // if processing != null this'll return an empty list
+            ret = new HashSet<>(versionReady);
+        } else {
+            ret = new HashSet<>(Arrays.asList(ready));
+        }
+        return ret;
+    }
+    
+    /** Get the set of events that the queue has determined are ready for processing, and set
+     * those events as in process in the queue.
+     * @return the events that were ready for processing and are now in the processing state.
+     */
+    public Set<StoredStatusEvent> moveReadyToProcessing() {
+        final Set<StoredStatusEvent> ret;
+        if (ready == null) {
+            // if processing != null this'll return an empty list
+            ret = new HashSet<>(versionReady);
+            versionReady.stream().forEach(e -> versionProcessing.put(e.getId(), e));
+            versionReady.clear();
+        } else {
+            ret = new HashSet<>(Arrays.asList(ready));
+            processing = ready;
+            ready = null;
+        }
+        return ret;
+    }
+    
+    public Set<StoredStatusEvent> getProcessing() {
+        if (processing == null) {
+            // will be empty list if ready != null;
+            return new HashSet<>(versionProcessing.values());
+        } else {
+            return new HashSet<>(Arrays.asList(processing));
+        }
+    }
+    
+    /** Remove a processed event from the queue and update the queue state, potentially adding
+     * more events to the ready state.
+     * This function implicitly calls {@link #moveToReady()}.
+     * @param event the event to remove.
+     */
+    public void setProcessingComplete(final StoredStatusEvent event) {
+        Utils.nonNull(event, "event");
+        if (processing != null) {
+            if (event.getId().equals(processing.getId())) {
+                processing = null;
+                moveToReady();
+            } else {
+                throw new NoSuchEventException(event);
+            }
+        } else {
+            if (versionProcessing.containsKey(event.getId())) {
+                versionProcessing.remove(event.getId());
+                moveToReady();
+            } else {
+                throw new NoSuchEventException(event);
+            }
+        }
+    }
+    
+    /** Returns true if at least one event is in the processing state.
+     * @return true if the queue has event sin the processing state.
+     */
+    public boolean isProcessing() {
+        return !versionProcessing.isEmpty() || processing != null;
+    }
+    
+    /** Returns the number of events in the queue.
+     * @return the queue size.
+     */
+    public int size() {
+        return queue.size() + versionReady.size() + versionProcessing.size() +
+                (ready == null ? 0 : 1) + (processing == null ? 0 : 1);
+    }
+    
+    /** Move events into the ready state if possible. Usually called after loading
+     * ({@link #load(StoredStatusEvent)}) one or more events.
+     * @return the events that have been moved into the ready state.
+     */
+    public Set<StoredStatusEvent> moveToReady() {
+        final Set<StoredStatusEvent> ret = new HashSet<>();
+        // if a object level event is ready for processing or processing, do nothing.
+        // the queue is blocked.
+        if (ready != null || processing != null) {
+            return ret;
+        }
+        /* Either no events are ready/processing or only version level events are ready/processing.
+         * pull all the version level events off the front of the queue and put them in
+         * the ready state.
+         */
+        /* should really check we're not running events for the same version at the same time,
+         * but that should never happen since you only create a new version once.
+         * might add admin tools to delete and reindex something but again, that should not
+         * cause multiple events for the same version.
+         */
+        StoredStatusEvent next = queue.peek();
+        while (next != null &&
+                next.getEvent().getEventType().equals(StatusEventType.NEW_VERSION)) {
+            versionReady.add(next);
+            ret.add(next);
+            queue.remove();
+            next = queue.peek();
+        }
+        // if there's still an event left in the queue and no version level events are ready
+        // for processing or processing, put the object level event in the ready state.
+        // this blocks the queue for all other events.
+        if (next != null && versionProcessing.isEmpty() && versionReady.isEmpty()) {
+            ready = next;
+            ret.add(next);
+            queue.remove();
+        }
+        return ret;
+    }
+    
+    //TODO QUEUE set and remove drain and block 
+    
+    /** Thrown when an attempt at accessing an event that does not exist in the queue is made.
+     * @author gaprice@lbl.gov
+     *
+     */
+    @SuppressWarnings("serial")
+    public class NoSuchEventException extends RuntimeException {
+        
+        public NoSuchEventException(final StoredStatusEvent event) {
+            super(String.format("No event with ID %s is in a processing state", event));
+        }
+    }
+
+}

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -222,6 +222,13 @@ public class ObjectEventQueue {
                 (ready == null ? 0 : 1) + (processing == null ? 0 : 1);
     }
     
+    /** Check if the queue is empty.
+     * @return true if the queue is empty.
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+    
     /** Move events into the ready state if possible. Usually called after loading
      * ({@link #load(StoredStatusEvent)}) one or more events.
      * @return the events that have been moved into the ready state.

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -282,7 +282,7 @@ public class ObjectEventQueue {
      *
      */
     @SuppressWarnings("serial")
-    public class NoSuchEventException extends RuntimeException {
+    public static class NoSuchEventException extends RuntimeException {
         
         public NoSuchEventException(final StoredStatusEvent event) {
             super(String.format("No event with ID %s is in a processing state", event));

--- a/lib/src/kbasesearchengine/events/StatusEventType.java
+++ b/lib/src/kbasesearchengine/events/StatusEventType.java
@@ -2,9 +2,10 @@ package kbasesearchengine.events;
 
 public enum StatusEventType {
 	NEW_VERSION,
-	DELETED,
-	SHARED,
-	UNSHARED,
+	// these are currently unused
+//	DELETED,
+//	SHARED,
+//	UNSHARED,
 	PUBLISH_ALL_VERSIONS,
 	PUBLISH_ACCESS_GROUP, //TODO NOW need to add access group to access docs public list where access group in groups list
 	UNPUBLISH_ALL_VERSIONS,

--- a/lib/src/kbasesearchengine/main/IndexerCoordinator.java
+++ b/lib/src/kbasesearchengine/main/IndexerCoordinator.java
@@ -42,6 +42,7 @@ public class IndexerCoordinator {
     }
     
     public void startIndexer() {
+        //TODO TEST add a way to inject an executor for testing purposes
         executor = Executors.newSingleThreadScheduledExecutor();
         // may want to make this configurable
         executor.scheduleAtFixedRate(new IndexerRunner(), 0, 1000, TimeUnit.MILLISECONDS);

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -395,23 +395,24 @@ public class IndexerWorker {
                             ev.isPublic().get(), null, new LinkedList<>());
                 }
                 break;
-            case DELETED:
-                unshare(ev.toGUID(), ev.getAccessGroupId().get());
-                break;
+            // currently unused
+//            case DELETED:
+//                unshare(ev.toGUID(), ev.getAccessGroupId().get());
+//                break;
             case DELETE_ALL_VERSIONS:
-                unshareAllVersions(ev.toGUID());
+                deleteAllVersions(ev.toGUID());
                 break;
             case UNDELETE_ALL_VERSIONS:
-                shareAllVersions(ev.toGUID());
+                undeleteAllVersions(ev.toGUID());
                 break;
-            case SHARED:
                 //TODO DP reenable if we support DPs
+//            case SHARED:
 //                share(ev.toGUID(), ev.getTargetAccessGroupId());
-                break;
-            case UNSHARED:
+//                break;
                 //TODO DP reenable if we support DPs
+//            case UNSHARED:
 //                unshare(ev.toGUID(), ev.getTargetAccessGroupId());
-                break;
+//                break;
             case RENAME_ALL_VERSIONS:
                 renameAllVersions(ev.toGUID(), ev.getNewName().get());
                 break;
@@ -577,20 +578,20 @@ public class IndexerWorker {
         return parentJson;
     }
     
-    public void share(GUID guid, int accessGroupId) throws IOException {
-        indexingStorage.shareObjects(new LinkedHashSet<>(Arrays.asList(guid)), accessGroupId, 
-                false);
-    }
+//    public void share(GUID guid, int accessGroupId) throws IOException {
+//        indexingStorage.shareObjects(new LinkedHashSet<>(Arrays.asList(guid)), accessGroupId, 
+//                false);
+//    }
     
-    public void shareAllVersions(final GUID guid) throws IOException {
+    public void undeleteAllVersions(final GUID guid) throws IOException {
         indexingStorage.undeleteAllVersions(guid);
     }
 
-    public void unshare(GUID guid, int accessGroupId) throws IOException {
-        indexingStorage.unshareObjects(new LinkedHashSet<>(Arrays.asList(guid)), accessGroupId);
-    }
+//    public void unshare(GUID guid, int accessGroupId) throws IOException {
+//        indexingStorage.unshareObjects(new LinkedHashSet<>(Arrays.asList(guid)), accessGroupId);
+//    }
 
-    public void unshareAllVersions(final GUID guid) throws IOException {
+    public void deleteAllVersions(final GUID guid) throws IOException {
         indexingStorage.deleteAllVersions(guid);
     }
 

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -122,6 +122,7 @@ public class IndexerWorker {
     }
     
     public void startIndexer() {
+        //TODO TEST add a way to inject an executor for testing purposes
         executor = Executors.newSingleThreadScheduledExecutor();
         // may want to make this configurable
         executor.scheduleAtFixedRate(new IndexerRunner(), 0, 1000, TimeUnit.MILLISECONDS);

--- a/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
@@ -391,5 +391,124 @@ public class ObjectEventQueueTest {
         assertEmpty(q);
     }
     
-    //TODO TEST returned sets are immutable
+    @Test
+    public void immutableGetReady() {
+        // test both getReady paths
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+        
+        final ObjectEventQueue q = new ObjectEventQueue(sse);
+        assertGetReadyReturnIsImmutable(sse2, q);
+        
+        final ObjectEventQueue q2 = new ObjectEventQueue(Arrays.asList(sse2), new LinkedList<>());
+        assertGetReadyReturnIsImmutable(sse, q2);
+    }
+
+    private void assertGetReadyReturnIsImmutable(
+            final StoredStatusEvent sse,
+            final ObjectEventQueue q) {
+        try {
+            q.getReadyForProcessing().add(sse);
+            fail("expected exception");
+        } catch (UnsupportedOperationException e) {
+            //test passed
+        }
+    }
+    
+    @Test
+    public void immutableGetProcessing() {
+        // test both getProcessing paths
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null);
+        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null);
+        
+        final ObjectEventQueue q = new ObjectEventQueue(sse);
+        assertGetProcessingReturnIsImmutable(sse2, q);
+        
+        final ObjectEventQueue q2 = new ObjectEventQueue(new LinkedList<>(), Arrays.asList(sse2));
+        assertGetProcessingReturnIsImmutable(sse, q2);
+    }
+
+    private void assertGetProcessingReturnIsImmutable(final StoredStatusEvent sse,
+            final ObjectEventQueue q) {
+        try {
+            q.getProcessing().add(sse);
+            fail("expected exception");
+        } catch (UnsupportedOperationException e) {
+            //test passed
+        }
+    }
+    
+    @Test
+    public void immutableMoveReady() {
+        // test both moveReady paths
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+        
+        final ObjectEventQueue q = new ObjectEventQueue();
+        q.load(sse);
+        assertMoveReadyReturnIsImmutable(sse2, q);
+        
+        final ObjectEventQueue q2 = new ObjectEventQueue();
+        q2.load(sse2);
+        assertMoveReadyReturnIsImmutable(sse, q2);
+    }
+
+    private void assertMoveReadyReturnIsImmutable(
+            final StoredStatusEvent sse,
+            final ObjectEventQueue q) {
+        try {
+            q.moveToReady().add(sse);
+            fail("expected exception");
+        } catch (UnsupportedOperationException e) {
+            // test passed
+        }
+    }
+    
+    @Test
+    public void immutableMoveProcessing() {
+        // test both moveProcessing paths
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+        
+        final ObjectEventQueue q = new ObjectEventQueue(sse);
+        assertMoveProcessingReturnIsImmutable(sse2, q);
+        
+        final ObjectEventQueue q2 = new ObjectEventQueue(Arrays.asList(sse2), new LinkedList<>());
+        assertMoveProcessingReturnIsImmutable(sse, q2);
+    }
+
+    private void assertMoveProcessingReturnIsImmutable(
+            final StoredStatusEvent sse,
+            final ObjectEventQueue q) {
+        try {
+            q.moveReadyToProcessing().add(sse);
+            fail("expected exception");
+        } catch (UnsupportedOperationException e) {
+            // test passed
+        }
+    }
 }

--- a/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
@@ -1,0 +1,200 @@
+package kbasesearchengine.test.events;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static kbasesearchengine.test.common.TestCommon.set;
+
+import org.junit.Test;
+
+import kbasesearchengine.events.ObjectEventQueue;
+import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventID;
+import kbasesearchengine.events.StatusEventProcessingState;
+import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.StoredStatusEvent;
+
+public class ObjectEventQueueTest {
+
+    /* this assert does not mutate the queue state */
+    private void assertQueueState(
+            final ObjectEventQueue queue,
+            final Set<StoredStatusEvent> ready,
+            final Set<StoredStatusEvent> processing,
+            final int size) {
+        assertThat("incorrect ready", queue.getReadyForProcessing(), is(ready));
+        assertThat("incorrect get processing", queue.getProcessing(), is(processing));
+        assertThat("incorrect is processing", queue.isProcessing(), is(!processing.isEmpty()));
+        assertThat("incorrect size", queue.size(), is(size));
+    }
+    
+    /* this assert does not mutate the queue state */
+    private void assertEmpty(final ObjectEventQueue queue) {
+        assertQueueState(queue, set(), set(), 0);
+        assertMoveToReadyCorrect(queue, set());
+        assertMoveToProcessingCorrect(queue, set());
+    }
+    
+    /* note this assert may change the queue state. */
+    private void assertMoveToProcessingCorrect(
+            final ObjectEventQueue queue,
+            final Set<StoredStatusEvent> moveToProcessing) {
+        assertThat("incorrect move", queue.moveReadyToProcessing(), is(moveToProcessing));
+    }
+    
+    /* note this assert may change the queue state. */
+    private void assertMoveToReadyCorrect(
+            final ObjectEventQueue queue,
+            final Set<StoredStatusEvent> moveToReady) {
+        assertThat("incorrect move", queue.moveToReady(), is(moveToReady));
+    }
+    
+    @Test
+    public void constructEmpty() {
+        assertEmpty(new ObjectEventQueue());
+    }
+    
+    @Test
+    public void loadOneObjectLevelEventAndProcess() {
+        final ObjectEventQueue q = new ObjectEventQueue();
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+        
+        assertEmpty(q);
+        
+        q.load(sse);
+        assertQueueState(q, set(), set(), 1);
+        assertMoveToReadyCorrect(q, set(sse)); //mutates queue
+        assertQueueState(q, set(sse), set(), 1);
+        assertMoveToProcessingCorrect(q, set(sse)); //mutates queue
+        assertQueueState(q, set(), set(sse), 1);
+        
+        q.setProcessingComplete(sse);
+        assertEmpty(q);
+    }
+    
+    @Test
+    public void loadMultipleVersionLevelEventsAndProcess() {
+        final ObjectEventQueue q = new ObjectEventQueue();
+        
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
+        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+        
+        assertEmpty(q);
+        
+        q.load(sse2);
+        q.load(sse);
+        assertQueueState(q, set(), set(), 2);
+        assertMoveToReadyCorrect(q, set(sse, sse2)); //mutates queue
+        assertQueueState(q, set(sse, sse2), set(), 2);
+        assertMoveToProcessingCorrect(q, set(sse, sse2)); //mutates queue
+        assertQueueState(q, set(), set(sse, sse2), 2);
+        
+        q.load(sse1);
+        assertQueueState(q, set(), set(sse, sse2), 3);
+        
+        q.setProcessingComplete(sse2); // calls move to ready
+        assertQueueState(q, set(sse1), set(sse), 2);
+        assertMoveToReadyCorrect(q, set()); // does not mutate queue
+        assertQueueState(q, set(sse1), set(sse), 2);
+        assertMoveToProcessingCorrect(q, set(sse1)); //mutates queue
+        assertQueueState(q, set(), set(sse, sse1), 2);
+
+        q.setProcessingComplete(sse1);
+        assertQueueState(q, set(), set(sse), 1);
+
+        q.setProcessingComplete(sse);
+        assertEmpty(q);
+    }
+    
+    @Test
+    public void blockVersionEventsWithObjectLevelEvent() {
+        final ObjectEventQueue q = new ObjectEventQueue();
+        
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
+        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+        final StoredStatusEvent sse3 = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar3", Instant.ofEpochMilli(40000), StatusEventType.NEW_VERSION)
+                .build(),
+                new StatusEventID("foo4"), StatusEventProcessingState.UNPROC, null, null);
+        
+        
+        final StoredStatusEvent blocking = new StoredStatusEvent(StatusEvent.getBuilder(
+                "blocker", Instant.ofEpochMilli(25000), StatusEventType.DELETE_ALL_VERSIONS)
+                .build(),
+                new StatusEventID("blk"), StatusEventProcessingState.UNPROC, null, null);
+        
+        assertEmpty(q);
+        
+        q.load(sse3);
+        q.load(sse2);
+        q.load(sse1);
+        q.load(sse);
+        q.load(blocking);
+        assertQueueState(q, set(), set(), 5);
+        assertMoveToReadyCorrect(q, set(sse, sse1));
+        assertQueueState(q, set(sse, sse1), set(), 5);
+        // check the queue is now blocked
+        assertMoveToReadyCorrect(q, set());
+        assertQueueState(q, set(sse, sse1), set(), 5);
+        assertMoveToProcessingCorrect(q, set(sse, sse1));
+        assertQueueState(q, set(), set(sse, sse1), 5);
+        // check queue is still blocked
+        assertMoveToReadyCorrect(q, set());
+        assertMoveToProcessingCorrect(q, set());
+        
+        q.setProcessingComplete(sse1);
+        assertQueueState(q, set(), set(sse), 4);
+        // check queue is still blocked
+        assertMoveToReadyCorrect(q, set());
+        assertMoveToProcessingCorrect(q, set());
+        
+        q.setProcessingComplete(sse); // calls move to ready
+        assertQueueState(q, set(blocking), set(), 3);
+        // check queue is blocked
+        assertMoveToReadyCorrect(q, set());
+        assertQueueState(q, set(blocking), set(), 3);
+        assertMoveToProcessingCorrect(q, set(blocking));
+        assertQueueState(q, set(), set(blocking), 3);
+        //check queue is still blocked
+        assertMoveToReadyCorrect(q, set());
+        assertMoveToProcessingCorrect(q, set());
+        assertQueueState(q, set(), set(blocking), 3);
+        
+        q.setProcessingComplete(blocking); // calls move to ready
+        assertQueueState(q, set(sse2, sse3), set(), 2);
+        assertMoveToReadyCorrect(q, set());
+        assertMoveToProcessingCorrect(q, set(sse2, sse3));
+        assertQueueState(q, set(), set(sse2, sse3), 2);
+        
+        q.setProcessingComplete(sse2);
+        q.setProcessingComplete(sse3);
+        assertEmpty(q);
+    }
+}

--- a/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Set;
 
 import static kbasesearchengine.test.common.TestCommon.set;
@@ -275,6 +276,44 @@ public class ObjectEventQueueTest {
         q.setProcessingComplete(sse2);
         q.setProcessingComplete(sse3);
         assertEmpty(q);
+    }
+    
+    @Test
+    public void initializeWithReadyObjectLevelEvent() {
+        for (final StatusEventType type: Arrays.asList(StatusEventType.DELETE_ALL_VERSIONS,
+                StatusEventType.NEW_ALL_VERSIONS, StatusEventType.PUBLISH_ALL_VERSIONS,
+                StatusEventType.RENAME_ALL_VERSIONS, StatusEventType.UNDELETE_ALL_VERSIONS)) {
+            assertSingleReadyEvent(type);
+            
+        }
+    }
+
+    private void assertSingleReadyEvent(final StatusEventType type) {
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), type)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+        final ObjectEventQueue q = new ObjectEventQueue(sse);
+        assertQueueState(q, set(sse), set(), 1);
+    }
+    
+    @Test
+    public void initializeWithProcessingObjectLevelEvent() {
+        for (final StatusEventType type: Arrays.asList(StatusEventType.DELETE_ALL_VERSIONS,
+                StatusEventType.NEW_ALL_VERSIONS, StatusEventType.PUBLISH_ALL_VERSIONS,
+                StatusEventType.RENAME_ALL_VERSIONS, StatusEventType.UNDELETE_ALL_VERSIONS)) {
+            assertSingleProcessingEvent(type);
+            
+        }
+    }
+    
+    private void assertSingleProcessingEvent(final StatusEventType type) {
+        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+                "bar", Instant.ofEpochMilli(10000), type)
+                .build(),
+                new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null);
+        final ObjectEventQueue q = new ObjectEventQueue(sse);
+        assertQueueState(q, set(), set(sse), 1);
     }
     
     //TODO TEST returned sets are immutable

--- a/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
@@ -177,7 +177,7 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Collections.emptyList(), collog);
         final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
-                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
@@ -255,7 +255,7 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Arrays.asList(70, 30), collog);
         final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
-                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
@@ -376,7 +376,7 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Collections.emptyList(), collog);
         final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
-                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
@@ -456,7 +456,7 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 50, Arrays.asList(70, 30), collog);
         final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
-                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.DELETED)
+                new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)


### PR DESCRIPTION
An access group level queue will wrap, initialize, and control multiple object level queues.

This is really big, but it's almost all greenfield code and so is easier to read.

Either @arfathpasha or @tianhao-gu could review this, but tian doesn't have write access to I can't add him to the reviewer list.