### PR TITLE
Add safety check to event state changes

### DIFF
--- a/lib/src/kbasesearchengine/events/storage/StatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/StatusEventStorage.java
@@ -63,15 +63,18 @@ public interface StatusEventStorage {
             throws FatalRetriableIndexingException;
     
     /** Mark an event with a processing state.
-     * @param event the event to modify.
-     * @param state the processing state to set on the event.
+     * @param id the id of the event to modify.
+     * @param oldState the expected state of the event. If non-null, an event is only modified
+     * if both the id and the oldState match.
+     * @param newState the processing state to set on the event.
      * @return true if the event was updated, false if the event was not found in the storage
      * system.
      * @throws FatalRetriableIndexingException if an error occurs while setting the state.
      */
     boolean setProcessingState(
-            StoredStatusEvent event,
-            StatusEventProcessingState state)
+            StatusEventID id,
+            StatusEventProcessingState oldState,
+            StatusEventProcessingState newState)
             throws FatalRetriableIndexingException;
 
 }

--- a/lib/src/kbasesearchengine/main/IndexerCoordinator.java
+++ b/lib/src/kbasesearchengine/main/IndexerCoordinator.java
@@ -114,7 +114,8 @@ public class IndexerCoordinator {
         final List<StoredStatusEvent> parentEvents = retrier.retryFunc(
                 s -> s.get(StatusEventProcessingState.UNPROC, 1000), storage, null);
         for (final StoredStatusEvent parentEvent: parentEvents) {
-            retrier.retryCons(e -> storage.setProcessingState(e, StatusEventProcessingState.READY),
+            retrier.retryCons(e -> storage.setProcessingState(e.getId(),
+                    StatusEventProcessingState.UNPROC, StatusEventProcessingState.READY),
                     parentEvent, parentEvent);
         }
     }


### PR DESCRIPTION
Add option to specify current state of event when changing state based
on ID. This prevents the indexer switching an in process event back to
the ready state.