### PR TITLE
TASK-1160 Refactor child event handling

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -150,6 +150,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
             <include name="kbasesearchengine/test/parse/**Test.java"/>
             <include name="kbasesearchengine/test/authorization/AccessGroupCacheTest.java"/>
             <include name="kbasesearchengine/test/events/AccessGroupEventQueueTest.java"/>
+            <include name="kbasesearchengine/test/events/ChildStatusEventTest.java"/>
             <include name="kbasesearchengine/test/events/EventQueueTest.java"/>
             <include name="kbasesearchengine/test/events/ObjectEventQueueTest.java"/>
             <include name="kbasesearchengine/test/events/StatusEventIDTest.java"/>

--- a/lib/src/kbasesearchengine/events/ChildStatusEvent.java
+++ b/lib/src/kbasesearchengine/events/ChildStatusEvent.java
@@ -1,0 +1,78 @@
+package kbasesearchengine.events;
+
+import kbasesearchengine.tools.Utils;
+
+/** An event resulting from the expansion of a single event into two or more sub events.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class ChildStatusEvent implements StatusEventWithId {
+    
+    private final StatusEvent event;
+    private final StatusEventID parentId;
+    
+    /** Create a child event.
+     * @param event the child status event.
+     * @param parentId the ID of the parent status event.
+     */
+    public ChildStatusEvent(final StatusEvent event, final StatusEventID parentId) {
+        Utils.nonNull(event, "event");
+        Utils.nonNull(parentId, "parentId");
+        this.event = event;
+        this.parentId = parentId;
+    }
+
+    @Override
+    public StatusEventID getId() {
+        return parentId;
+    }
+
+    @Override
+    public boolean isParentId() {
+        return true;
+    }
+    
+    @Override
+    public StatusEvent getEvent() {
+        return event;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((event == null) ? 0 : event.hashCode());
+        result = prime * result
+                + ((parentId == null) ? 0 : parentId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ChildStatusEvent other = (ChildStatusEvent) obj;
+        if (event == null) {
+            if (other.event != null) {
+                return false;
+            }
+        } else if (!event.equals(other.event)) {
+            return false;
+        }
+        if (parentId == null) {
+            if (other.parentId != null) {
+                return false;
+            }
+        } else if (!parentId.equals(other.parentId)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/lib/src/kbasesearchengine/events/StatusEventWithId.java
+++ b/lib/src/kbasesearchengine/events/StatusEventWithId.java
@@ -1,0 +1,24 @@
+package kbasesearchengine.events;
+
+/** A status event associated with a unique ID, which may be of the event itself or the event's
+ * parent in the case of expandable events.
+ * @author gaprice@lbl.gov
+ *
+ */
+public interface StatusEventWithId {
+
+    /** Returns the event associated with the ID.
+     * @return the event.
+     */
+    StatusEvent getEvent();
+    
+    /** Get the id of the status event or the id of the status event's parent event.
+     * @return the id.
+     */
+    StatusEventID getId();
+    
+    /** Get whether the ID is for a parent event or the event itself.
+     * @return true if the ID is for the parent event, false otherwise.
+     */
+    boolean isParentId();
+}

--- a/lib/src/kbasesearchengine/events/StoredStatusEvent.java
+++ b/lib/src/kbasesearchengine/events/StoredStatusEvent.java
@@ -11,7 +11,7 @@ import kbasesearchengine.tools.Utils;
  * @author gaprice@lbl.gov
  *
  */
-public class StoredStatusEvent {
+public class StoredStatusEvent implements StatusEventWithId {
     
     private final StatusEvent event;
     private final StatusEventID id;
@@ -50,18 +50,19 @@ public class StoredStatusEvent {
         }
     }
 
-    /** Get the status event.
-     * @return the id.
-     */
+    @Override
     public StatusEvent getEvent() {
         return event;
     }
 
-    /** Get the id.
-     * @return the id.
-     */
+    @Override
     public StatusEventID getId() {
         return id;
+    }
+    
+    @Override
+    public boolean isParentId() {
+        return false;
     }
 
     /** Return the state of the stored event the last time it was accessed.

--- a/lib/src/kbasesearchengine/events/exceptions/Retrier.java
+++ b/lib/src/kbasesearchengine/events/exceptions/Retrier.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Optional;
 
-import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.StatusEventWithId;
 import kbasesearchengine.tools.Utils;
 
 /** Generic code for retrying functions. Expects the code to throw
@@ -94,7 +94,7 @@ public class Retrier {
     public <T> void retryCons(
             final RetryConsumer<T> consumer,
             final T input,
-            final StoredStatusEvent event)
+            final StatusEventWithId event)
             throws InterruptedException, IndexingException {
         Utils.nonNull(consumer, "consumer");
         int retries = 1;
@@ -125,7 +125,7 @@ public class Retrier {
     public <T, R> R retryFunc(
             final RetryFunction<T, R> function,
             final T input,
-            final StoredStatusEvent event)
+            final StatusEventWithId event)
             throws InterruptedException, IndexingException {
         Utils.nonNull(function, "function");
         int retries = 1;
@@ -145,7 +145,7 @@ public class Retrier {
     }
     
     private boolean handleException(
-            final StoredStatusEvent event,
+            final StatusEventWithId event,
             final RetriableIndexingException e,
             final int retries,
             final int fatalRetries)

--- a/lib/src/kbasesearchengine/events/exceptions/RetryLogger.java
+++ b/lib/src/kbasesearchengine/events/exceptions/RetryLogger.java
@@ -2,7 +2,7 @@ package kbasesearchengine.events.exceptions;
 
 import com.google.common.base.Optional;
 
-import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.StatusEventWithId;
 
 /** A logging interface for the retrier.
  * @see Retrier
@@ -16,6 +16,6 @@ public interface RetryLogger {
      * @param event an event associated with the retry. May be absent.
      * @param e the exception that occurred on the current retry.
      */
-    void log(int retryCount, Optional<StoredStatusEvent> event, RetriableIndexingException e);
+    void log(int retryCount, Optional<StatusEventWithId> event, RetriableIndexingException e);
 
 }

--- a/lib/src/kbasesearchengine/events/handler/EventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/EventHandler.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import kbasesearchengine.common.GUID;
-import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.ChildStatusEvent;
 import kbasesearchengine.events.StoredStatusEvent;
 import kbasesearchengine.events.exceptions.IndexingException;
 import kbasesearchengine.events.exceptions.IndexingExceptionUncheckedWrapper;
@@ -28,19 +28,18 @@ public interface EventHandler {
      */
     String getStorageCode();
 
-    /** Expands an event into multiple sub events. Returns the input event in a single item
-     * Iterable if the event requires no expansion.
+    /** Expands an event into multiple sub events.
      * Also note that the {@link Iterable#iterator()} and  {@link Iterator#next()} functions may
      * throw {@link IndexingExceptionUncheckedWrapper} and
      * {@link RetriableIndexingExceptionUncheckedWrapper} exceptions, which should be unwrapped
      * and rethrown as soon as possible.
      * @param event the event to be expanded.
-     * @return an Iterable of the of the events resulting from the expansion or the original
-     * event if no expansion is necessary.
+     * @return an Iterable of the of the events resulting from the expansion.
      * @throws IndexingException if an error occurred expanding the event.
      * @throws RetriableIndexingException if a retriable error occurred loading the data.
+     * @throws IllegalArgumentException if the event is not expandable.
      */
-    Iterable<StatusEvent> expand(StoredStatusEvent event)
+    Iterable<ChildStatusEvent> expand(StoredStatusEvent event)
             throws IndexingException, RetriableIndexingException;
     
     /** The equivalent of {@link #load(List, Path) load(Arrays.asList(guid), tempfile)}
@@ -83,9 +82,9 @@ public interface EventHandler {
     Set<ResolvedReference> resolveReferences(List<GUID> refpath, Set<GUID> refsToResolve)
             throws IndexingException, RetriableIndexingException;
 
-    /** Returns whether an event will be expanded into multiple individual events.
+    /** Returns whether an event is expandable into multiple individual events.
      * @param parentEvent the event to check.
-     * @return true if the event will be expanded, false otherwise.
+     * @return true if the event is expandable, false otherwise.
      */
     boolean isExpandable(StoredStatusEvent parentEvent);
 }

--- a/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
@@ -41,6 +41,8 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     
     //TODO DB add schema ver code
     
+    private static final int MAX_RETURNED_EVENTS = 10000;
+    
     private static final String FLD_STATUS = "status";
     private static final String FLD_STORAGE_CODE = "strcde";
     private static final String FLD_ACCESS_GROUP_ID = "accgrp";
@@ -241,8 +243,8 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     public List<StoredStatusEvent> get(final StatusEventProcessingState state, int limit)
             throws FatalRetriableIndexingException {
         Utils.nonNull(state, "state");
-        if (limit < 1 || limit > 10000) { //TODO NNOW make constant
-            limit = 10000;
+        if (limit < 1 || limit > MAX_RETURNED_EVENTS) {
+            limit = MAX_RETURNED_EVENTS;
         }
         final List<StoredStatusEvent> ret = new LinkedList<>();
         try {

--- a/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
@@ -40,7 +40,6 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     /* Note that general mongoexceptions are more or less impossible to test. */
     
     //TODO DB add schema ver code
-    //TODO EVENT need optional parent event for sub events, so can check if event already exists
     
     private static final String FLD_STATUS = "status";
     private static final String FLD_STORAGE_CODE = "strcde";
@@ -242,7 +241,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     public List<StoredStatusEvent> get(final StatusEventProcessingState state, int limit)
             throws FatalRetriableIndexingException {
         Utils.nonNull(state, "state");
-        if (limit < 1 || limit > 10000) {
+        if (limit < 1 || limit > 10000) { //TODO NNOW make constant
             limit = 10000;
         }
         final List<StoredStatusEvent> ret = new LinkedList<>();

--- a/lib/src/kbasesearchengine/main/IndexerCoordinator.java
+++ b/lib/src/kbasesearchengine/main/IndexerCoordinator.java
@@ -19,6 +19,7 @@ import com.google.common.cache.CacheBuilder;
 import kbasesearchengine.events.EventQueue;
 import kbasesearchengine.events.StatusEventID;
 import kbasesearchengine.events.StatusEventProcessingState;
+import kbasesearchengine.events.StatusEventWithId;
 import kbasesearchengine.events.StoredStatusEvent;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.IndexingException;
@@ -187,10 +188,11 @@ public class IndexerCoordinator {
 
     private void logError(
             final int retrycount,
-            final Optional<StoredStatusEvent> event,
+            final Optional<StatusEventWithId> event,
             final RetriableIndexingException e) {
         final String msg;
         if (event.isPresent()) {
+            // no child events here, all ids are for the event itself
             msg = String.format("Retriable error in indexer for event %s %s, retry %s",
                     event.get().getEvent().getEventType(), event.get().getId().getId(),
                     retrycount);
@@ -298,7 +300,7 @@ public class IndexerCoordinator {
 
     /** Returns the number of cycles the indexer has run without pausing (e.g. without the
      * indexer cycle being scheduled). This information is mostly useful for test purposes.
-     * @return 
+     * @return the number of cycles the indexer has run without pausing.
      */
     public int getContinuousCycles() {
         return continuousCycles;

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -23,8 +23,10 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.google.common.base.Optional;
 
 import kbasesearchengine.common.GUID;
+import kbasesearchengine.events.ChildStatusEvent;
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventProcessingState;
+import kbasesearchengine.events.StatusEventWithId;
 import kbasesearchengine.events.StoredStatusEvent;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
@@ -172,20 +174,21 @@ public class IndexerWorker {
     }
 
     private void logError(final String msg, final Throwable e) {
-        final String firstStackLine = e.getStackTrace().length == 0 ? "<not-available>" : 
-                e.getStackTrace()[0].toString();
-        logger.logError(msg + e + ", " + firstStackLine);
-        logger.logError(e); //TODO LOG split into lines with id
+        // TODO LOG make log method that takes msg + e and have the logger figure out how to log it correctly
+        logger.logError(msg + ": " + e);
+        logger.logError(e);
     }
 
     private void logError(
             final int retrycount,
-            final Optional<StoredStatusEvent> event,
+            final Optional<StatusEventWithId> event,
             final RetriableIndexingException e) {
         final String msg;
         if (event.isPresent()) {
-            msg = String.format("Retriable error in indexer for event %s %s, retry %s: ",
-                    event.get().getEvent().getEventType(), event.get().getId().getId(),
+            msg = String.format("Retriable error in indexer for event %s %s%s, retry %s: ",
+                    event.get().getEvent().getEventType(),
+                    event.get().isParentId() ? "with parent ID " : "",
+                    event.get().getId().getId(),
                     retrycount);
         } else {
             msg = String.format("Retriable error in indexer, retry %s: ", retrycount);
@@ -206,7 +209,7 @@ public class IndexerWorker {
                 logger.logInfo(String.format("[Indexer] Expanding event %s %s",
                         parentEvent.getEvent().getEventType(), parentEvent.getId().getId()));
                 try {
-                    final Iterator<StatusEvent> er = retrier.retryFunc(
+                    final Iterator<ChildStatusEvent> er = retrier.retryFunc(
                             e -> getSubEventIterator(e), parentEvent, parentEvent);
                     storage.setProcessingState(parentEvent.getId(),
                             StatusEventProcessingState.PROC, processEvents(parentEvent, er)); //TODO INDEXER NOW retry
@@ -240,7 +243,7 @@ public class IndexerWorker {
         return processedEvent;
     }
     
-    private Iterator<StatusEvent> getSubEventIterator(final StoredStatusEvent ev)
+    private Iterator<ChildStatusEvent> getSubEventIterator(final StoredStatusEvent ev)
             throws IndexingException, RetriableIndexingException {
         try {
             return getEventHandler(ev).expand(ev).iterator();
@@ -266,24 +269,16 @@ public class IndexerWorker {
     // returns whether processing was successful or not.
     private StatusEventProcessingState processEvents(
             final StoredStatusEvent parentEvent,
-            final Iterator<StatusEvent> expanditer)
+            final Iterator<ChildStatusEvent> expanditer)
             throws InterruptedException, FatalIndexingException {
         StatusEventProcessingState allsuccess = StatusEventProcessingState.INDX;
         while (expanditer.hasNext()) {
-            //TODO EVENT insert sub event into db - need to ensure not inserted twice on reprocess - use parent id
             final StatusEventProcessingState res;
             try {
-                final StatusEvent subev = retrier.retryFunc(
+                final ChildStatusEvent subev = retrier.retryFunc(
                         i -> getNextSubEvent(i), expanditer, parentEvent);
-                //TODO NOW store parent ID
-                final StoredStatusEvent ev = retrier.retryFunc(
-                        s -> s.store(subev, StatusEventProcessingState.PROC), //TODO QUEUE WORKER store ID
-                        storage, parentEvent);
-                res = processEvent(ev);
-                retrier.retryFunc(s -> s.setProcessingState(
-                        ev.getId(), StatusEventProcessingState.PROC, res), storage, ev);
+                res = processEvent(subev);
             } catch (IndexingException e) {
-                // TODO EVENT mark sub event as failed
                 handleException("Error getting event from data storage", parentEvent, e);
                 return StatusEventProcessingState.FAIL;
             }
@@ -294,7 +289,7 @@ public class IndexerWorker {
         return allsuccess;
     }
 
-    private StatusEventProcessingState processEvent(final StoredStatusEvent ev)
+    private StatusEventProcessingState processEvent(final StatusEventWithId ev)
             throws InterruptedException, FatalIndexingException {
         final Optional<StorageObjectType> type = ev.getEvent().getStorageObjectType();
         if (type.isPresent() && !isStorageTypeSupported(ev)) {
@@ -306,7 +301,7 @@ public class IndexerWorker {
                 toLogString(type) + ev.getEvent().toGUID() + "...");
         final long time = System.currentTimeMillis();
         try {
-            retrier.retryCons(e -> processOneEvent(e), ev, ev);
+            retrier.retryCons(e -> processOneEvent(e), ev.getEvent(), ev);
         } catch (IndexingException e) {
             handleException("Error processing event", ev, e);
             return StatusEventProcessingState.FAIL;
@@ -315,7 +310,7 @@ public class IndexerWorker {
         return StatusEventProcessingState.INDX;
     }
     
-    private StatusEvent getNextSubEvent(Iterator<StatusEvent> iter)
+    private ChildStatusEvent getNextSubEvent(Iterator<ChildStatusEvent> iter)
             throws IndexingException, RetriableIndexingException {
         try {
             return iter.next();
@@ -328,14 +323,16 @@ public class IndexerWorker {
     
     private void handleException(
             final String error,
-            final StoredStatusEvent event,
+            final StatusEventWithId event,
             final IndexingException exception)
             throws FatalIndexingException {
         if (exception instanceof FatalIndexingException) {
             throw (FatalIndexingException) exception;
         } else {
-            final String msg = error + String.format(" for event %s %s: ",
-                    event.getEvent().getEventType(), event.getId().getId());
+            final String msg = error + String.format(" for event %s %s%s: ",
+                    event.getEvent().getEventType(),
+                    event.isParentId() ? "with parent ID " : "",
+                    event.getId().getId());
             logError(msg, exception);
         }
     }
@@ -375,10 +372,9 @@ public class IndexerWorker {
         return eventHandlers.get(storageCode);
     }
 
-    public void processOneEvent(final StoredStatusEvent evid)
+    public void processOneEvent(final StatusEvent ev)
             throws IndexingException, InterruptedException, RetriableIndexingException {
         try {
-            final StatusEvent ev = evid.getEvent();
             switch (ev.getEventType()) {
             case NEW_VERSION:
                 GUID pguid = ev.toGUID();
@@ -437,7 +433,7 @@ public class IndexerWorker {
     }
 
     // returns false if a non-fatal error prevents retrieving the info
-    public boolean isStorageTypeSupported(final StoredStatusEvent ev)
+    public boolean isStorageTypeSupported(final StatusEventWithId ev)
             throws InterruptedException, FatalIndexingException {
         try {
             return retrier.retryFunc(

--- a/test/src/kbasesearchengine/test/events/ChildStatusEventTest.java
+++ b/test/src/kbasesearchengine/test/events/ChildStatusEventTest.java
@@ -1,0 +1,58 @@
+package kbasesearchengine.test.events;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import kbasesearchengine.events.ChildStatusEvent;
+import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventID;
+import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.test.common.TestCommon;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class ChildStatusEventTest {
+    
+    @Test
+    public void equals() {
+        EqualsVerifier.forClass(ChildStatusEvent.class).usingGetClass().verify();
+    }
+
+    @Test
+    public void construct() {
+        final ChildStatusEvent e = new ChildStatusEvent(StatusEvent.getBuilder(
+                "ws", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP).build(),
+                new StatusEventID("whee"));
+        
+        assertThat("incorrect event", e.getEvent(), is(StatusEvent.getBuilder(
+                "ws", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP).build()));
+        assertThat("incorrect id", e.getId(), is(new StatusEventID("whee")));
+        assertThat("incorrect is parent", e.isParentId(), is(true));
+    }
+    
+    @Test
+    public void constructFail() {
+        final StatusEvent e = StatusEvent.getBuilder(
+                "ws", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP).build();
+        failConstruct(null, new StatusEventID("foo"), new NullPointerException("event"));
+        failConstruct(e, null, new NullPointerException("parentId"));
+    }
+    
+    private void failConstruct(
+            final StatusEvent event,
+            final StatusEventID id,
+            final Exception expected) {
+        try {
+            new ChildStatusEvent(event, id);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+        
+    }
+    
+}

--- a/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
+++ b/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
@@ -37,6 +37,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
         assertThat("incorrect update time", sei.getUpdateTime(), is(Optional.absent()));
+        assertThat("incorrect is parent", sei.isParentId(), is(false));
     }
     
     @Test
@@ -53,6 +54,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.of("foo")));
         assertThat("incorrect update time", sei.getUpdateTime(),
                 is(Optional.of(Instant.ofEpochMilli(20000))));
+        assertThat("incorrect is parent", sei.isParentId(), is(false));
     }
     
     @Test

--- a/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
@@ -19,6 +19,7 @@ import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventID;
 import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.StatusEventWithId;
 import kbasesearchengine.events.StoredStatusEvent;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
@@ -37,13 +38,13 @@ public class RetrierTest {
     private class LogEvent {
         private final Instant time;
         private final int retryCount;
-        private final Optional<StoredStatusEvent> event;
+        private final Optional<StatusEventWithId> event;
         private final RetriableIndexingException exception;
         
         private LogEvent(
                 final Instant time,
                 final int retryCount,
-                final Optional<StoredStatusEvent> optional,
+                final Optional<StatusEventWithId> optional,
                 final RetriableIndexingException exception) {
             this.time = time;
             this.retryCount = retryCount;
@@ -57,7 +58,7 @@ public class RetrierTest {
         private final List<LogEvent> events = new LinkedList<>();
         
         @Override
-        public void log(int retryCount, Optional<StoredStatusEvent> optional,
+        public void log(int retryCount, Optional<StatusEventWithId> optional,
                 RetriableIndexingException e) {
             events.add(new LogEvent(Instant.now(), retryCount, optional, e));
         }

--- a/test/src/kbasesearchengine/test/main/IndexerCoordinatorTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerCoordinatorTest.java
@@ -129,7 +129,7 @@ public class IndexerCoordinatorTest {
                 Instant.now(), sse.getUpdater().orNull());
     }
     
-    @Test(timeout = 1000) // in case the coordinator loops forever
+    @Test(timeout = 2000) // in case the coordinator loops forever
     public void blockingEvent() throws Exception {
         /* this test is a bit complex, since it runs through multiple indexer cycles
          * First call is two loops - first loop moves event1 to processing, second loop
@@ -207,7 +207,7 @@ public class IndexerCoordinatorTest {
         verify(logger, never()).logError(any(Throwable.class));
     }
     
-    @Test(timeout = 1000) // in case the coordinator loops forever
+    @Test(timeout = 2000) // in case the coordinator loops forever
     public void eventLoadRequestSize() throws Exception {
         /* test that the coordinator requests the correct number of events from storage,
          * and that the coordinator stops cycling when no events were returned or the
@@ -293,7 +293,7 @@ public class IndexerCoordinatorTest {
         verify(logger, never()).logError(any(Throwable.class));
     }
     
-    @Test(timeout = 1000) // in case the coordinator loops forever
+    @Test(timeout = 2000) // in case the coordinator loops forever
     public void emptyNoInput() throws Exception {
         final StatusEventStorage storage = mock(StatusEventStorage.class);
         final LineLogger logger = mock(LineLogger.class);
@@ -321,7 +321,7 @@ public class IndexerCoordinatorTest {
         verify(logger, never()).logError(any(Throwable.class));
     }
     
-    @Test(timeout = 1000) // in case the coordinator loops forever
+    @Test(timeout = 2000) // in case the coordinator loops forever
     public void constructWithMultipleEvents() throws Exception {
         final StoredStatusEvent event1 = new StoredStatusEvent(StatusEvent.getBuilder(
                 "WS", Instant.ofEpochMilli(10000), StatusEventType.PUBLISH_ALL_VERSIONS)
@@ -380,7 +380,7 @@ public class IndexerCoordinatorTest {
         verify(logger, never()).logError(any(Throwable.class));
     }
     
-    @Test(timeout = 1000) // in case the coordinator loops forever
+    @Test(timeout = 2000) // in case the coordinator loops forever
     public void constructWithSingleEvent() throws Exception {
         final StoredStatusEvent event1 = new StoredStatusEvent(StatusEvent.getBuilder(
                 "WS", Instant.ofEpochMilli(10000), StatusEventType.PUBLISH_ACCESS_GROUP)
@@ -425,7 +425,7 @@ public class IndexerCoordinatorTest {
         verify(logger, never()).logError(any(Throwable.class));
     }
     
-    @Test(timeout = 1000) // in case the coordinator loops forever
+    @Test(timeout = 2000) // in case the coordinator loops forever
     public void desynchedQueue() throws Exception {
         /* test the case where the in memory queue does not match the DB. */
         final StoredStatusEvent event1 = new StoredStatusEvent(StatusEvent.getBuilder(

--- a/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
@@ -277,7 +277,7 @@ public class IndexerWorkerTest {
                 StatusEventProcessingState.UNPROC,
                 null,
                 null);
-        mop.processOneEvent(ev);
+        mop.processOneEvent(ev.getEvent());
         PostProcessing pp = new PostProcessing();
         pp.objectInfo = true;
         pp.objectData = true;
@@ -319,7 +319,7 @@ public class IndexerWorkerTest {
                     StatusEventProcessingState.UNPROC,
                     null,
                     null);
-            mop.processOneEvent(ev2);
+            mop.processOneEvent(ev2.getEvent());
         }
     }
     

--- a/test/src/kbasesearchengine/test/main/PerformanceTester.java
+++ b/test/src/kbasesearchengine/test/main/PerformanceTester.java
@@ -233,7 +233,7 @@ public class PerformanceTester {
                         null);
                 long t2 = System.currentTimeMillis();
                 try {
-                    mop.processOneEvent(ev);
+                    mop.processOneEvent(ev.getEvent());
                     processTime += System.currentTimeMillis() - t2;
                 } catch (Exception ex) {
                     ex.printStackTrace();


### PR DESCRIPTION
The changes here, although numerous, are actually pretty simple and just
entail wrapping child StatusEvents in ChildStatusEvent which associates
the parent ID with the child event.

There is currently no reasonable test suite for the
WorkspaceEventHandler or the IndexerWorker and building one would take a
really long time so manually tested for now. The only real logical
changes (other than removing code) are some minor logging changes.

Child events are no longer stored in the database, but these changes
make it pretty easy to do so if we want to later.

Also make max returned events in mongostatusstorage a constant 