### PR TITLE
Add retries for worker db calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 /temp_test/
 /dist/
 /search_tools.cfg
+/classes/


### PR DESCRIPTION
Adds retries for attempts to set event state in the storage system. Also
a refactor to DRY up the code a little and make the exception handling
somewhat less incomprehensible.

Manually tested stuff that's possible to test. Need to add unit tests
later.