### PR TITLE
SCT-157 Refactor indexing rules

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -166,6 +166,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
             <include name="kbasesearchengine/test/search/ElasticIndexingStorageTest.java"/>
             <include name="kbasesearchengine/test/system/StorageObjectTypeTest.java"/>
             <include name="kbasesearchengine/test/system/TypeMappingTest.java"/>
+            <include name="kbasesearchengine/test/system/TransformTest.java"/>
             <include name="kbasesearchengine/test/main/IndexerCoordinatorTest.java"/>
           </fileset>
         </batchtest>

--- a/build.xml
+++ b/build.xml
@@ -164,6 +164,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
             <include name="kbasesearchengine/test/integration/IndexerIntegrationTest.java"/>
             <include name="kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java"/>
             <include name="kbasesearchengine/test/search/ElasticIndexingStorageTest.java"/>
+            <include name="kbasesearchengine/test/system/IndexingRulesTest.java"/>
             <include name="kbasesearchengine/test/system/StorageObjectTypeTest.java"/>
             <include name="kbasesearchengine/test/system/TypeMappingTest.java"/>
             <include name="kbasesearchengine/test/system/TransformTest.java"/>

--- a/lib/src/kbasesearchengine/main/SearchMethods.java
+++ b/lib/src/kbasesearchengine/main/SearchMethods.java
@@ -346,7 +346,7 @@ public class SearchMethods {
                 KeyDescription kd = new KeyDescription().withKeyName(keyName)
                         .withKeyUiTitle(uiKeyName).withKeyValueType(keyValueType)
                         .withKeyValueType(keyValueType).withHidden(hidden)
-                        .withLinkKey(ir.getUiLinkKey());
+                        .withLinkKey(ir.getUiLinkKey().orNull());
                 keys.add(kd);
             }
             TypeDescriptor td = new TypeDescriptor().withTypeName(typeName)

--- a/lib/src/kbasesearchengine/main/SearchMethods.java
+++ b/lib/src/kbasesearchengine/main/SearchMethods.java
@@ -31,7 +31,6 @@ import kbasesearchengine.SortingRule;
 import kbasesearchengine.TypeDescriptor;
 import kbasesearchengine.authorization.AccessGroupProvider;
 import kbasesearchengine.common.GUID;
-import kbasesearchengine.parse.KeywordParser;
 import kbasesearchengine.search.FoundHits;
 import kbasesearchengine.search.IndexingStorage;
 import kbasesearchengine.system.IndexingRules;
@@ -337,14 +336,11 @@ public class SearchMethods {
                 if (ir.isNotIndexed()) {
                     continue;
                 }
-                String keyName = KeywordParser.getKeyName(ir);
+                String keyName = ir.getKeyName();
                 String uiKeyName = ir.getUiName();
-                if (uiKeyName == null) {
-                    uiKeyName = guessUIName(keyName);
-                }
                 String keyValueType = ir.getKeywordType();
                 if (keyValueType == null) {
-                    keyValueType = "string";
+                    keyValueType = "string"; //TODO CODE this seems wrong for fulltext, which is the only case where keyWordtype is null
                 }
                 long hidden = ir.isUiHidden() ? 1L : 0L;
                 KeyDescription kd = new KeyDescription().withKeyName(keyName)

--- a/lib/src/kbasesearchengine/main/SearchMethods.java
+++ b/lib/src/kbasesearchengine/main/SearchMethods.java
@@ -338,7 +338,7 @@ public class SearchMethods {
                 }
                 String keyName = ir.getKeyName();
                 String uiKeyName = ir.getUiName();
-                String keyValueType = ir.getKeywordType();
+                String keyValueType = ir.getKeywordType().orNull();
                 if (keyValueType == null) {
                     keyValueType = "string"; //TODO CODE this seems wrong for fulltext, which is the only case where keyWordtype is null
                 }

--- a/lib/src/kbasesearchengine/parse/KeywordParser.java
+++ b/lib/src/kbasesearchengine/parse/KeywordParser.java
@@ -330,12 +330,6 @@ public class KeywordParser {
                 throw new IllegalStateException("Path should be defined for non-derived " +
                         "indexing rules");
             }
-            if (rules.getTransform().isPresent() &&
-                    rules.getTransform().get().getSubobjectIdKey().isPresent()) {
-                //TODO NNOW CODE not sure why this needs to be true but add constraint & docs to indexing rule
-                throw new IllegalStateException("Subobject ID key can only be set for derived " +
-                        "keywords: " + rules.getKeyName());
-            }
             if (rules.isFromParent() != fromParent) {
                 continue;
             }

--- a/lib/src/kbasesearchengine/parse/ObjectParser.java
+++ b/lib/src/kbasesearchengine/parse/ObjectParser.java
@@ -76,7 +76,8 @@ public class ObjectParser {
             if (!rules.isFromParent()) {
                 continue;
             }
-            indexingPaths.add(rules.getPath());
+            //TODO CODE this seems wrong. Why adding null paths?
+            indexingPaths.add(rules.getPath().orNull());
         }
         if (indexingPaths.size() == 0) {
             return null;
@@ -96,8 +97,8 @@ public class ObjectParser {
             if (rules.isFromParent()) {
                 continue;
             }
-            if (rules.getPath() != null) {
-                indexingPaths.add(rules.getPath());
+            if (rules.getPath().isPresent()) {
+                indexingPaths.add(rules.getPath().get());
             }
         }
         ObjectJsonPath pathToSubObjects = parsingRules.getPathToSubObjects() == null ?

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1422,11 +1422,6 @@ public class ElasticIndexingStorage implements IndexingStorage {
         return ret;
     }
     
-    private String getKeyName(IndexingRules rules) {
-        return rules.getKeyName() != null ? rules.getKeyName():
-            rules.getPath().getPathItems()[0];
-    }
-    
     private String getKeyProperty(String keyName) {
         return "key." + keyName;
     }
@@ -1662,7 +1657,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
                 if (rules.getKeywordType() == null && !rules.isFullText()) {
                     continue;
                 }
-                String propName = getKeyProperty(getKeyName(rules));
+                String propName = getKeyProperty(rules.getKeyName());
                 String propType = getEsType(rules.isFullText(), rules.getKeywordType());
                 props.put(propName, new LinkedHashMap<String, Object>() {{
                     put("type", propType);

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -40,6 +40,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import kbasesearchengine.common.GUID;
@@ -1530,14 +1531,14 @@ public class ElasticIndexingStorage implements IndexingStorage {
         }
     }
 
-    private String getEsType(boolean fullText, String keywordType) {
+    private String getEsType(boolean fullText, Optional<String> keywordType) {
         if (fullText) {
             return "text";
         }
-        if (keywordType == null || keywordType.equals("string")) {
-            return "keyword";
+        if (keywordType.get().equals("string")) {
+            return "keyword"; //TODO CODE why? why? why? 
         }
-        return keywordType;
+        return keywordType.get();
     }
     
     private String getDataTableName() {
@@ -1654,9 +1655,6 @@ public class ElasticIndexingStorage implements IndexingStorage {
             }});
         } else {
             for (IndexingRules rules : indexingRules) {
-                if (rules.getKeywordType() == null && !rules.isFullText()) {
-                    continue;
-                }
                 String propName = getKeyProperty(rules.getKeyName());
                 String propType = getEsType(rules.isFullText(), rules.getKeywordType());
                 props.put(propName, new LinkedHashMap<String, Object>() {{

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -119,7 +119,6 @@ public class IndexingRules {
      */
     private final Optional<String> uiLinkKey;
     
-    //TODO NNOW return optionals instead of nulls
     private IndexingRules(
             final ObjectJsonPath path,
             final boolean fullText,
@@ -273,6 +272,12 @@ public class IndexingRules {
         
         public Builder withTransform(final Transform transform) {
             Utils.nonNull(transform, "transform");
+            // not clear why this is required, but this constraint was in original code
+            if (transform.getSubobjectIdKey().isPresent() && path != null) {
+                throw new IllegalArgumentException(
+                        "A transform with a subobject ID key is not compatible with a path." +
+                        "Path is: " + path);
+            }
             this.transform = transform;
             return this;
         }

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -213,14 +213,33 @@ public class IndexingRules {
                 + ", uiHidden=" + uiHidden + ", uiLinkKey=" + uiLinkKey + "]";
     }
     
+    /** Get a builder for an {@link IndexingRules} instance based on a JSON path into an object.
+     * The key name (see {@link #getKeyName()} and {@link Builder#withKeyName(String)} is set
+     * as the first portion of the path, but can be changed with
+     * {@link Builder#withKeyName(String)}.
+     * @param path the path to the value of interest in the object for the new
+     * {@link IndexingRules}.
+     * @return a new builder.
+     */
     public static Builder fromPath(final ObjectJsonPath path) {
         return new Builder(path);
     }
     
+    //TODO CODE do source key rules have to occur later in the ordering than their target key?
+    /** Get a builder for an {@link IndexingRules} instance based on another {@link IndexingRules}
+     * specified by a the sourceKey.
+     * @param sourceKey the keyName of the {@link IndexingRules} of the value of interest.
+     * @param keyName the name of the key (see {@link #getKeyName()} for this indexing rule.
+     * @return a new builder.
+     */
     public static Builder fromSourceKey(final String sourceKey, final String keyName) {
         return new Builder(sourceKey, keyName);
     }
     
+    /** A builder for {@link IndexingRules}.
+     * @author gaprice@lbl.gov
+     *
+     */
     public static class Builder {
         
         private String uiName = null;
@@ -251,18 +270,31 @@ public class IndexingRules {
             this.keyName = keyName;
         }
         
+        /** Change the key name for this indexing rule.
+         * @param keyName the new key name.
+         * @return this builder.
+         */
         public Builder withKeyName(final String keyName) {
             Utils.notNullOrEmpty(keyName, "keyName cannot be null or whitespace");
             this.keyName = keyName;
             return this;
         }
         
+        /** Set this indexing rule to a full text rule. This means that
+         * {@link IndexingRules#getKeywordType()} will return absent.
+         * @return this builder.
+         */
         public Builder withFullText() {
             this.keywordType = null;
             this.fullText = true;
             return this;
         }
         
+        /** Set the type of the key word to be indexed. Default is "keyword." Absent if full text
+         * is set.
+         * @param keywordType the keyword type.
+         * @return this builder.
+         */
         public Builder withKeywordType(final String keywordType) {
             Utils.notNullOrEmpty(keywordType, "keywordType cannot be null or whitespace");
             this.keywordType = keywordType;
@@ -270,6 +302,12 @@ public class IndexingRules {
             return this;
         }
         
+        /** Add a transform to this indexing rule. Note that GUID transforms with subobject ID keys
+         * are only allowed with source key based indexing rules (i.e. the builder creation
+         * method was {@link IndexingRules#fromSourceKey(String, String)}).
+         * @param transform the transform to add.
+         * @return this builder.
+         */
         public Builder withTransform(final Transform transform) {
             Utils.nonNull(transform, "transform");
             // not clear why this is required, but this constraint was in original code
@@ -282,16 +320,28 @@ public class IndexingRules {
             return this;
         }
         
+        /** Specify that the value produced by this indexing rule should not be indexed.
+         * @return this builder.
+         */
         public Builder withNotIndexed() {
             this.notIndexed = true;
             return this;
         }
         
+        /** Set a default value for this indexing rule.
+         * @param value the default value.
+         * @return this builder.
+         */
         public Builder withNullableDefaultValue(final Object value) {
             this.defaultValue = value;
             return this;
         }
         
+        /** Set the ui name for this indexing rule. If the ui name is not provided, it is
+         * created by capitalizing the first character of the key name.
+         * @param uiName the ui name.
+         * @return this builder.
+         */
         public Builder withNullableUIName(final String uiName) {
             this.uiName = checkString(uiName);
             return this;
@@ -301,21 +351,40 @@ public class IndexingRules {
             return Utils.isNullOrEmpty(s) ? null : s;
         }
 
+        /** Specify that the value associated with the indexing rule should not be displayed in
+         * a UI.
+         * @return this builder.
+         */
         public Builder withUIHidden() {
             this.uiHidden = true;
             return this;
         }
         
+        /** Specify that the source key or path should be applied to extract a value from the
+         * parent object of a sub object, rather than from the sub object.
+         * @return this builder.
+         */
         public Builder withFromParent() {
             this.fromParent = true;
             return this;
         }
         
+        //TODO CODE must the target indexing rule be a GUID transform?
+        /** Specify that the value associated with this indexing rule should be used as the text
+         * for a link to a data object specified by a GUID associated with another indexing rule
+         * which is specified by uiLinkKey.
+         * @param uiLinkKey the source key of the {@link IndexingRules} containing a GUID that 
+         * is the address of the data object that is the target of the link.
+         * @return this builder.
+         */
         public Builder withNullableUILinkKey(final String uiLinkKey) {
             this.uiLinkKey = checkString(uiLinkKey);
             return this;
         }
         
+        /** Build the {@link IndexingRules}.
+         * @return the rules.
+         */
         public IndexingRules build() {
             return new IndexingRules(path, fullText, keywordType, keyName,
                     transform, fromParent, notIndexed, sourceKey,

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -1,5 +1,7 @@
 package kbasesearchengine.system;
 
+import com.google.common.base.Optional;
+
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.tools.Utils;
 
@@ -15,8 +17,6 @@ import kbasesearchengine.tools.Utils;
  * content of the object (or sub-object) that it is to be indexed by the rules.
  * An indexing rule may also be based on a key-value pair formed by another
  * indexing rule.
- *
- * See {@link #validate()} for instructions on building unambigious indexing rules.
  *
  */
 public class IndexingRules {
@@ -37,7 +37,7 @@ public class IndexingRules {
      * element.
      *
      */
-    private final ObjectJsonPath path;
+    private final Optional<ObjectJsonPath> path;
     /**
      * fullText=true implies the use of the "text" type in ElasticSearch,
      * which stands for full text search (search on individual tokens) on the
@@ -69,7 +69,7 @@ public class IndexingRules {
     /** An optional transformation applied to a value.
      *
      */
-    private final Transform transform;
+    private final Optional<Transform> transform;
     
     /**
      * An optional attribute that indicates that the value is extracted from the
@@ -88,13 +88,13 @@ public class IndexingRules {
      * another (source) keyword which is set in "source-key".
      *
      */
-    private final String sourceKey;
+    private final Optional<String> sourceKey;
 
     /**
      * An optional value which is used for the keyword in case the resulting
      * array of values extracted from the document [sub-]object is empty.
      */
-    private final Object defaultValue;
+    private final Optional<Object> defaultValue;
     /**
      * Name of keyword displayed by UI.
      */
@@ -117,7 +117,7 @@ public class IndexingRules {
      * of the link, while the field provided in the uiLinkKey is expected to be a reference
      * to an object in a data store.
      */
-    private final String uiLinkKey;
+    private final Optional<String> uiLinkKey;
     
     //TODO NNOW return optionals instead of nulls
     private IndexingRules(
@@ -133,24 +133,24 @@ public class IndexingRules {
             String uiName,
             final boolean uiHidden,
             final String uiLinkKey) {
-        this.path = path;
+        this.path = Optional.fromNullable(path);
         this.fullText = fullText;
         this.keywordType = keywordType;
         this.keyName = keyName;
-        this.transform = transform;
+        this.transform = Optional.fromNullable(transform);
         this.fromParent = fromParent;
         this.notIndexed = notIndexed;
-        this.sourceKey = sourceKey;
-        this.defaultValue = defaultValue;
+        this.sourceKey = Optional.fromNullable(sourceKey);
+        this.defaultValue = Optional.fromNullable(defaultValue);
         if (uiName == null) {
             uiName = keyName.substring(0, 1).toUpperCase() + keyName.substring(1);
         }
         this.uiName = uiName;
         this.uiHidden = uiHidden;
-        this.uiLinkKey = uiLinkKey;
+        this.uiLinkKey = Optional.fromNullable(uiLinkKey);
     }
 
-    public ObjectJsonPath getPath() {
+    public Optional<ObjectJsonPath> getPath() {
         return path;
     }
     
@@ -166,7 +166,7 @@ public class IndexingRules {
         return keyName;
     }
     
-    public Transform getTransform() {
+    public Optional<Transform> getTransform() {
         return transform;
     }
     
@@ -175,18 +175,18 @@ public class IndexingRules {
     }
     
     public boolean isDerivedKey() {
-        return sourceKey != null;
+        return sourceKey.isPresent();
     }
     
     public boolean isNotIndexed() {
         return notIndexed;
     }
     
-    public String getSourceKey() {
+    public Optional<String> getSourceKey() {
         return sourceKey;
     }
     
-    public Object getDefaultValue() {
+    public Optional<Object> getDefaultValue() {
         return defaultValue;
     }
     
@@ -198,7 +198,7 @@ public class IndexingRules {
         return uiHidden;
     }
     
-    public String getUiLinkKey() {
+    public Optional<String> getUiLinkKey() {
         return uiLinkKey;
     }
     

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -21,7 +21,6 @@ import kbasesearchengine.tools.Utils;
  */
 public class IndexingRules {
     
-    //TODO JAVADOC
     //TODO TEST
 
     /**
@@ -149,68 +148,113 @@ public class IndexingRules {
         this.uiLinkKey = Optional.fromNullable(uiLinkKey);
     }
 
+    /** Returns the path into an object to a value that is the target of this indexing rule.
+     * If a path is provided, {@link #getSourceKey()} will return absent.
+     * @return the path.
+     */
     public Optional<ObjectJsonPath> getPath() {
         return path;
     }
     
+    /** Returns true if the value associated with this indexing rule should be indexed as full
+     * text rather than a keyword. If true, {@link #getKeywordType()} will return absent.
+     * @return true if this is a full text indexing rule.
+     */
     public boolean isFullText() {
         return fullText;
     }
     
+    /** Get the keyword type (e.g. integer, boolean, keyword, etc.) that specifies how the value
+     * associated with this indexing rule should be indexed. If non-absent, {@link #isFullText()}
+     * will return false.
+     * @return the keyword type.
+     */
     public String getKeywordType() {
         return keywordType;
     }
     
+    /** Get the name of the key under which the result of this indexing rule will be indexed.
+     * @return the name of the key.
+     */
     public String getKeyName() {
         return keyName;
     }
     
+    /** Get the transform associated with this indexing rule, if any.
+     * @return the transform.
+     */
     public Optional<Transform> getTransform() {
         return transform;
     }
     
+    /** Returns true if the operations specified with this indexing rule should be applied to
+     * the parent object of a subobject rather than the subobject itself.
+     * @return true if the operations should be applied to the parent object.
+     */
     public boolean isFromParent() {
         return fromParent;
     }
     
+    /** Returns true if the value associated with this indexing rule is derived from another
+     * indexing rule. In this case, {@link #getSourceKey()} will return the name of the key of the
+     * value of interest in the target indexing rule, and {@link #getPath()} will return absent.
+     * @return true if this is indexing rule operates on a value associated with another indexing
+     * rule.
+     */
     public boolean isDerivedKey() {
         return sourceKey.isPresent();
     }
     
+    /** Returns true if the value associated with this key should not be indexed.
+     * @return true if the value this indexing rule produces should not be indexed.
+     */
     public boolean isNotIndexed() {
         return notIndexed;
     }
     
+    /** Get the key name of the indexing rule associated with the value upon which this value
+     * will operate. If this method returns a non-absent value, {@link #isDerivedKey()} will
+     * return true.
+     * @return the key name for the data source for this indexing rule.
+     */
     public Optional<String> getSourceKey() {
         return sourceKey;
     }
     
+    /** Get the default value for this indexing rule if no value is available, if any.
+     * @return the default value or absent if no default value was set.
+     */
     public Optional<Object> getDefaultValue() {
         return defaultValue;
     }
     
+    /** Get the name for this indexing rule to be show in a UI context.
+     * @return the UI name.
+     */
     public String getUiName() {
         return uiName;
     }
     
+    /** Returns true if the value for this indexing rule should not be displayed in a UI
+     * context.
+     * @return true if the value should not be displayed.
+     */
     public boolean isUiHidden() {
         return uiHidden;
     }
     
+    //TODO CODE does this have to point to an indexing rule with a GUID, e.g. the indexing rule has a GUID transform?
+    /** Get, if present, the key name of an indexing rule that contains a GUID addressing a
+     * data object to which the value associated with this indexing rule should be linked in a UI
+     * context. For example, the value associated with this indexing rule might contain a product
+     * name, while the indexing rule specified by the key name returned by this method is
+     * associated with a GUID with the data store address of a data object. In the UI, the a link
+     * would be created with the target being the data store address and the name of the link
+     * the value associated with this indexing rule.
+     * @return the key name of an indexing rule associated with a GUID.
+     */
     public Optional<String> getUiLinkKey() {
         return uiLinkKey;
-    }
-    
-    @Override
-    public String toString() {
-        return "IndexingRules [path=" + path + ", fullText=" + fullText
-                + ", keywordType=" + keywordType + ", keyName=" + keyName
-                + ", transform=" + transform + ", fromParent=" + fromParent
-                + ", notIndexed=" + notIndexed
-                + ", sourceKey=" + sourceKey
-                + ", defaultValue=" + defaultValue
-                + ", uiName=" + uiName
-                + ", uiHidden=" + uiHidden + ", uiLinkKey=" + uiLinkKey + "]";
     }
     
     /** Get a builder for an {@link IndexingRules} instance based on a JSON path into an object.

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -21,8 +21,6 @@ import kbasesearchengine.tools.Utils;
  */
 public class IndexingRules {
     
-    //TODO TEST
-
     /**
      * Path to an element of the source object from which to form the keyword.
      * The path may contain "*" or "[*]" to collect an array of values for the
@@ -58,7 +56,7 @@ public class IndexingRules {
      * fullText=false.
      *
      */
-    private final String keywordType;
+    private final Optional<String> keywordType;
     /**
      * Key name for keyword. If it is not specified, then first item between
      * slashes in "path" is used.
@@ -133,7 +131,7 @@ public class IndexingRules {
             final String uiLinkKey) {
         this.path = Optional.fromNullable(path);
         this.fullText = fullText;
-        this.keywordType = keywordType;
+        this.keywordType = Optional.fromNullable(keywordType);
         this.keyName = keyName;
         this.transform = Optional.fromNullable(transform);
         this.fromParent = fromParent;
@@ -169,7 +167,7 @@ public class IndexingRules {
      * will return false.
      * @return the keyword type.
      */
-    public String getKeywordType() {
+    public Optional<String> getKeywordType() {
         return keywordType;
     }
     
@@ -257,6 +255,113 @@ public class IndexingRules {
         return uiLinkKey;
     }
     
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((defaultValue == null) ? 0 : defaultValue.hashCode());
+        result = prime * result + (fromParent ? 1231 : 1237);
+        result = prime * result + (fullText ? 1231 : 1237);
+        result = prime * result + ((keyName == null) ? 0 : keyName.hashCode());
+        result = prime * result
+                + ((keywordType == null) ? 0 : keywordType.hashCode());
+        result = prime * result + (notIndexed ? 1231 : 1237);
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        result = prime * result
+                + ((sourceKey == null) ? 0 : sourceKey.hashCode());
+        result = prime * result
+                + ((transform == null) ? 0 : transform.hashCode());
+        result = prime * result + (uiHidden ? 1231 : 1237);
+        result = prime * result
+                + ((uiLinkKey == null) ? 0 : uiLinkKey.hashCode());
+        result = prime * result + ((uiName == null) ? 0 : uiName.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        IndexingRules other = (IndexingRules) obj;
+        if (defaultValue == null) {
+            if (other.defaultValue != null) {
+                return false;
+            }
+        } else if (!defaultValue.equals(other.defaultValue)) {
+            return false;
+        }
+        if (fromParent != other.fromParent) {
+            return false;
+        }
+        if (fullText != other.fullText) {
+            return false;
+        }
+        if (keyName == null) {
+            if (other.keyName != null) {
+                return false;
+            }
+        } else if (!keyName.equals(other.keyName)) {
+            return false;
+        }
+        if (keywordType == null) {
+            if (other.keywordType != null) {
+                return false;
+            }
+        } else if (!keywordType.equals(other.keywordType)) {
+            return false;
+        }
+        if (notIndexed != other.notIndexed) {
+            return false;
+        }
+        if (path == null) {
+            if (other.path != null) {
+                return false;
+            }
+        } else if (!path.equals(other.path)) {
+            return false;
+        }
+        if (sourceKey == null) {
+            if (other.sourceKey != null) {
+                return false;
+            }
+        } else if (!sourceKey.equals(other.sourceKey)) {
+            return false;
+        }
+        if (transform == null) {
+            if (other.transform != null) {
+                return false;
+            }
+        } else if (!transform.equals(other.transform)) {
+            return false;
+        }
+        if (uiHidden != other.uiHidden) {
+            return false;
+        }
+        if (uiLinkKey == null) {
+            if (other.uiLinkKey != null) {
+                return false;
+            }
+        } else if (!uiLinkKey.equals(other.uiLinkKey)) {
+            return false;
+        }
+        if (uiName == null) {
+            if (other.uiName != null) {
+                return false;
+            }
+        } else if (!uiName.equals(other.uiName)) {
+            return false;
+        }
+        return true;
+    }
+
     /** Get a builder for an {@link IndexingRules} instance based on a JSON path into an object.
      * The key name (see {@link #getKeyName()} and {@link Builder#withKeyName(String)} is set
      * as the first portion of the path, but can be changed with
@@ -334,6 +439,7 @@ public class IndexingRules {
             return this;
         }
         
+        //TODO CODE this might be a candidate for an enum
         /** Set the type of the key word to be indexed. Default is "keyword." Absent if full text
          * is set.
          * @param keywordType the keyword type.
@@ -357,7 +463,7 @@ public class IndexingRules {
             // not clear why this is required, but this constraint was in original code
             if (transform.getSubobjectIdKey().isPresent() && path != null) {
                 throw new IllegalArgumentException(
-                        "A transform with a subobject ID key is not compatible with a path." +
+                        "A transform with a subobject ID key is not compatible with a path. " +
                         "Path is: " + path);
             }
             this.transform = transform;
@@ -382,7 +488,8 @@ public class IndexingRules {
         }
         
         /** Set the ui name for this indexing rule. If the ui name is not provided, it is
-         * created by capitalizing the first character of the key name.
+         * created by capitalizing the first character of the key name. Nulls and whitespace
+         * strings are ignored.
          * @param uiName the ui name.
          * @return this builder.
          */
@@ -416,7 +523,7 @@ public class IndexingRules {
         //TODO CODE must the target indexing rule be a GUID transform?
         /** Specify that the value associated with this indexing rule should be used as the text
          * for a link to a data object specified by a GUID associated with another indexing rule
-         * which is specified by uiLinkKey.
+         * which is specified by uiLinkKey. Nulls and whitespace strings are ignored.
          * @param uiLinkKey the source key of the {@link IndexingRules} containing a GUID that 
          * is the address of the data object that is the target of the link.
          * @return this builder.

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -2,6 +2,7 @@ package kbasesearchengine.system;
 
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.parse.ObjectParseException;
+import kbasesearchengine.tools.Utils;
 
 /**
  * This class defines the rules for parsing source data, collecting portions
@@ -37,7 +38,7 @@ public class IndexingRules {
      * element.
      *
      */
-    private ObjectJsonPath path = null;
+    private final ObjectJsonPath path;
     /**
      * fullText=true implies the use of the "text" type in ElasticSearch,
      * which stands for full text search (search on individual tokens) on the
@@ -50,7 +51,7 @@ public class IndexingRules {
      * Example: search for "New York" in the data "New York".
      *
      */
-    private boolean fullText = false;
+    private final boolean fullText;
     /**
      * The "keyword" type to use in ElasticSearch. This value must be specified
      * if fullText is set to false. Example: "integer", "string" etc.
@@ -59,13 +60,13 @@ public class IndexingRules {
      * fullText=false.
      *
      */
-    private String keywordType = null;
+    private final String keywordType;
     /**
      * Key name for keyword. If it is not specified, then first item between
      * slashes in "path" is used.
      *
      */
-    private String keyName = null;
+    private final String keyName;
     /** An optional transformation applied to values coming from a [sub-]object
      * or source keyword. The value of this property has the format of
      * <transform>[.<ret-prop>], where second part (including dot) is optional
@@ -73,36 +74,29 @@ public class IndexingRules {
      * type and a string for the ret-prop or transform property.
      *
      */
-    private TransformType transform = null;
-    private String transformProperty = null;
+    private final TransformType transform;
+    private final String transformProperty;
     
-    // TODO NNOW this means the parent type must have the key in source key. The parent type is the ObjectTypeParsingRules with the same data source type (and version if type mappings are being used) with no innersubtype specified.
     /**
      * An optional attribute that indicates that the value is extracted from the
      * parent object rather that from the sub-object.
      *
      */
-    private boolean fromParent = false;
-    /**
-     * An optional flag indicating that this rule defines a keyword formed by
-     * another (source) keyword which is set in "source-key".
-     *
-     */
-    private boolean derivedKey = false;
+    private final boolean fromParent;
     /**
      * notIndexed=true indicates that value should be included into extracted part
      * of object data but must not be present as indexed keyword.
      *
      */
-    private boolean notIndexed = false;
+    private final boolean notIndexed;
     /**
      * An optional flag indicating that this rule defines a keyword formed by
      * another (source) keyword which is set in "source-key".
      *
      */
-    private String sourceKey = null;
+    private final String sourceKey;
 
-    /** An optional attribute that can be defined for derived keywords only.
+    /** An optional attribute.
      * It is used in "guid" transform mode only. This property provides the type
      * descriptor name of [sub-]object where resulting GUID points to. In
      * addition to the validation purpose target type helps form sub-object part
@@ -111,30 +105,30 @@ public class IndexingRules {
      * is extracted from this target type descriptor.
      *
      */
-    private String targetObjectType = null;
+    private final String targetObjectType;
     // TODO NNOW subobjectIdKey constrains the target type to be a subtype. Add a check in the creation context to check this. 
     /**
-     * An optional attribute that can be defined for derived keywords only.
+     * An optional attribute.
      * Works together with "target-object-type". Is used in "guid" transform mode
      * only. This property points to keywords providing value for sub-object
      * inner ID in order to construct full GUID for sub-object.
      *
      */
-    private String subobjectIdKey = null;
+    private final String subobjectIdKey;
     /**
      * An optional value which is used for the keyword in case the resulting
      * array of values extracted from the document [sub-]object is empty.
      */
-    private Object optionalDefaultValue = null;
+    private final Object defaultValue;
     /**
      * Name of keyword displayed by UI.
      */
-    private String uiName = null;
+    private final String uiName;
     /**
      * An optional attribute that indicates that a particular keyword is not
      * supposed to be visible via UI though it could be used in API search queries.
      */
-    private boolean uiHidden = false;
+    private final boolean uiHidden;
     // TODO NNOW this should point to another indexing rule that is a guid.
     /**
      * An optional pointer to a paired keyword coupled with given one providing
@@ -144,79 +138,63 @@ public class IndexingRules {
      * values of these two keywords in order to produce clickable link
      * showing genome name (coming from one keyword) and redirecting you to
      * landing page of given genome based on GUID (coming from another keyword).
+     * The value of the indexing rule containing a uiLinkKey is expected to be the name
+     * of the link, while the field provided in the uiLinkKey is expected to be a reference
+     * to an object in a data store.
      */
-    private String uiLinkKey = null;
-
-    /** Checks if this indexing rule is valid.
-     *
-     * @throws ValidationException if these rules are found to be invalid.
-     */
-    public void validate() throws ValidationException {
-        if (!derivedKey && path == null) {
-            throw new ValidationException("Must specify either derivedKey=true " +
-                    "and source key, or non-null path to form keyword from: " +
-                    toString());
-        }
-        if (derivedKey && path != null) {
-            throw new ValidationException("Specify either derivedKey=true and " +
-                    "sourceKey or path, but not both: " + toString());
-        }
-        if (derivedKey && sourceKey == null) {
-            throw new ValidationException("derivedKey is true and source-key is " +
-                    "null expecting a non-null sourceKey to form the derived: " +
-                    "keyword from. " + toString());
-        }
-        if (fullText && keywordType != null) {
-            throw new ValidationException("Specify either fullText=true or " +
-                    "sourceKey, but not both: " + toString());
-        }
-        if (targetObjectType != null && !TransformType.guid.equals(transform)) {
-            throw new ValidationException("targetObjectType must be" +
-                    "used with guid transform only. Transform is either null or" +
-                    "not a guid transform: " + toString());
-        }
-        if (subobjectIdKey != null && !derivedKey) {
-            throw new ValidationException("subobjectIdKey can be" +
-                    "defined for derivedKey only, but derivedKey is set to " +
-                    "false: " + toString());
-        }
-        if (subobjectIdKey != null && !TransformType.guid.equals(transform)) {
-            throw new ValidationException("subobjectIdKey must be" +
-                    "used with guid transform only. Transform is either null or" +
-                    "not a guid transform: " + toString());
-        }
-    }
+    private final String uiLinkKey;
     
+    //TODO NNOW return optionals instead of nulls
+    private IndexingRules(
+            final ObjectJsonPath path,
+            final boolean fullText,
+            final String keywordType,
+            final String keyName,
+            final TransformType transform,
+            final String transformProperty,
+            final boolean fromParent,
+            final boolean notIndexed,
+            final String sourceKey,
+            final String targetObjectType,
+            final String subobjectIdKey,
+            final Object defaultValue,
+            String uiName,
+            final boolean uiHidden,
+            final String uiLinkKey) {
+        this.path = path;
+        this.fullText = fullText;
+        this.keywordType = keywordType;
+        this.keyName = keyName;
+        this.transform = transform;
+        this.transformProperty = transformProperty;
+        this.fromParent = fromParent;
+        this.notIndexed = notIndexed;
+        this.sourceKey = sourceKey;
+        this.targetObjectType = targetObjectType;
+        this.subobjectIdKey = subobjectIdKey;
+        this.defaultValue = defaultValue;
+        if (uiName == null) {
+            uiName = keyName.substring(0, 1).toUpperCase() + keyName.substring(1);
+        }
+        this.uiName = uiName;
+        this.uiHidden = uiHidden;
+        this.uiLinkKey = uiLinkKey;
+    }
+
     public ObjectJsonPath getPath() {
         return path;
-    }
-    
-    public void setPath(ObjectJsonPath path) {
-        this.path = path;
     }
     
     public boolean isFullText() {
         return fullText;
     }
     
-    public void setFullText(boolean fullText) {
-        this.fullText = fullText;
-    }
-
     public String getKeywordType() {
         return keywordType;
     }
     
-    public void setKeywordType(String keywordType) {
-        this.keywordType = keywordType;
-    }
-    
     public String getKeyName() {
         return keyName;
-    }
-    
-    public void setKeyName(String keyName) {
-        this.keyName = keyName;
     }
     
     public TransformType getTransform() {
@@ -227,109 +205,248 @@ public class IndexingRules {
         return transformProperty;
     }
     
-    public void setTransform(final String transform) throws ObjectParseException {
-        if (transform != null) {
-            final String[] tranSplt = transform.split("\\.", 2);
-            try {
-                this.transform = TransformType.valueOf(tranSplt[0]);
-            } catch (IllegalArgumentException e) {
-                // TODO CODE this exception type seems wrong
-                throw new ObjectParseException(e.getMessage(), e);
-            }
-            this.transformProperty = tranSplt.length == 1 ? null : tranSplt[1];
-        }
-    }
-    
     public boolean isFromParent() {
         return fromParent;
     }
     
-    public void setFromParent(boolean fromParent) {
-        this.fromParent = fromParent;
-    }
-    
     public boolean isDerivedKey() {
-        return derivedKey;
-    }
-    
-    public void setDerivedKey(boolean derivedKey) {
-        this.derivedKey = derivedKey;
+        return sourceKey != null;
     }
     
     public boolean isNotIndexed() {
         return notIndexed;
     }
     
-    public void setNotIndexed(boolean notIndexed) {
-        this.notIndexed = notIndexed;
-    }
-    
     public String getSourceKey() {
         return sourceKey;
-    }
-    
-    public void setSourceKey(String sourceKey) {
-        this.sourceKey = sourceKey;
     }
     
     public String getTargetObjectType() {
         return targetObjectType;
     }
     
-    public void setTargetObjectType(String targetObjectType) {
-        this.targetObjectType = targetObjectType;
-    }
-    
     public String getSubobjectIdKey() {
         return subobjectIdKey;
     }
     
-    public void setSubobjectIdKey(String subobjectIdKey) {
-        this.subobjectIdKey = subobjectIdKey;
-    }
-    
-    public Object getOptionalDefaultValue() {
-        return optionalDefaultValue;
-    }
-    
-    public void setOptionalDefaultValue(Object optionalDefaultValue) {
-        this.optionalDefaultValue = optionalDefaultValue;
+    public Object getDefaultValue() {
+        return defaultValue;
     }
     
     public String getUiName() {
         return uiName;
     }
     
-    public void setUiName(String uiName) {
-        this.uiName = uiName;
-    }
-    
     public boolean isUiHidden() {
         return uiHidden;
-    }
-    
-    public void setUiHidden(boolean uiHidden) {
-        this.uiHidden = uiHidden;
     }
     
     public String getUiLinkKey() {
         return uiLinkKey;
     }
     
-    public void setUiLinkKey(String uiLinkKey) {
-        this.uiLinkKey = uiLinkKey;
-    }
-
     @Override
     public String toString() {
         return "IndexingRules [path=" + path + ", fullText=" + fullText
                 + ", keywordType=" + keywordType + ", keyName=" + keyName
                 + ", transform=" + transform + ", fromParent=" + fromParent
-                + ", derivedKey=" + derivedKey + ", notIndexed=" + notIndexed
+                + ", notIndexed=" + notIndexed
                 + ", sourceKey=" + sourceKey + ", targetObjectType="
                 + targetObjectType + ", subobjectIdKey=" + subobjectIdKey
-                + ", optionalDefaultValue=" + optionalDefaultValue
+                + ", defaultValue=" + defaultValue
                 + ", uiName=" + uiName
                 + ", uiHidden=" + uiHidden + ", uiLinkKey=" + uiLinkKey + "]";
+    }
+    
+    public static Builder fromPath(final ObjectJsonPath path) {
+        return new Builder(path);
+    }
+    
+    public static Builder fromSourceKey(final String sourceKey, final String keyName) {
+        return new Builder(sourceKey, keyName);
+    }
+    
+    public static class Builder {
+        
+        private String uiName = null;
+        private final ObjectJsonPath path;
+        private final String sourceKey;
+        private String keyName;
+        private boolean fullText = false;
+        private String keywordType = "keyword";
+        private TransformType transform = null;
+        private String transformProperty = null;
+        private String targetObjectType = null;
+        private String subobjectIdKey = null;
+        private boolean fromParent = false;
+        private boolean notIndexed = false;
+        private Object defaultValue = null;
+        private boolean uiHidden = false;
+        private String uiLinkKey = null;
+        
+        private Builder(final ObjectJsonPath path) {
+            Utils.nonNull(path, "path");
+            this.path = path;
+            sourceKey = null;
+            keyName = path.getPathItems()[0];
+        }
+        
+        private Builder(final String sourceKey, final String keyName) {
+            Utils.notNullOrEmpty(sourceKey, "sourceKey cannot be null or whitespace");
+            Utils.notNullOrEmpty(keyName, "keyName cannot be null or whitespace");
+            this.path = null;
+            this.sourceKey = sourceKey;
+            this.keyName = keyName;
+        }
+        
+        public Builder withKeyName(final String keyName) {
+            Utils.notNullOrEmpty(keyName, "keyName cannot be null or whitespace");
+            this.keyName = keyName;
+            return this;
+        }
+        
+        public Builder withFullText() {
+            this.keywordType = null;
+            this.fullText = true;
+            return this;
+        }
+        
+        public Builder withKeywordType(final String keywordType) {
+            Utils.notNullOrEmpty(keywordType, "keywordType cannot be null or whitespace");
+            this.keywordType = keywordType;
+            this.fullText = false;
+            return this;
+        }
+        
+        public Builder withTransform(final TransformType type) {
+            Utils.nonNull(type, "type");
+            this.transform = type;
+            this.transformProperty = null;
+            this.targetObjectType = null;
+            this.subobjectIdKey = null;
+            return this;
+        }
+        
+        public Builder withTransform(final TransformType type, String transformProperty) {
+            Utils.nonNull(type, "type");
+            if (TransformType.guid.equals(type)) {
+                throw new IllegalArgumentException(
+                        "Use the specialized guid transform method for adding guid transforms");
+            }
+            //TODO CODE check transform property matches transform type?
+            // e.g. enum of props for location, any string for lookup
+            if (Utils.isNullOrEmpty(transformProperty)) {
+                transformProperty = null;
+            }
+            this.transform = type;
+            this.transformProperty = transformProperty;
+            this.targetObjectType = null;
+            this.subobjectIdKey = null;
+            return this;
+        }
+        
+        public Builder withGUIDTransform(final String targetObjectType) {
+            Utils.notNullOrEmpty(targetObjectType,
+                    "targetObjectType cannot be null or whitespace");
+            this.targetObjectType = targetObjectType;
+            this.subobjectIdKey = null;
+            this.transform = TransformType.guid;
+            this.transformProperty = null;
+            return this;
+        }
+        
+        public Builder withGUIDTransform(
+                final String targetObjectType,
+                final String subObjectIDKey) {
+            Utils.notNullOrEmpty(targetObjectType,
+                    "targetObjectType cannot be null or whitespace");
+            Utils.notNullOrEmpty(subObjectIDKey,
+                    "subObjectIDKey cannot be null or whitespace");
+            this.targetObjectType = targetObjectType;
+            this.subobjectIdKey = subObjectIDKey;
+            this.transform = TransformType.guid;
+            this.transformProperty = null;
+            return this;
+        }
+        
+        public Builder withNullableUnknownTransform(
+                final String transform,
+                String targetObjectType,
+                String subObjectIDKey)
+                throws ObjectParseException {
+            if (Utils.isNullOrEmpty(transform)) {
+                return this;
+            }
+            if (Utils.isNullOrEmpty(targetObjectType)) {
+                targetObjectType = null;
+            }
+            if (Utils.isNullOrEmpty(subObjectIDKey)) {
+                subObjectIDKey = null;
+            }
+            final String[] tranSplt = transform.split("\\.", 2);
+            final TransformType type;
+            try {
+                type = TransformType.valueOf(tranSplt[0]);
+            } catch (IllegalArgumentException e) {
+                // TODO CODE this exception type seems wrong
+                throw new ObjectParseException(e.getMessage(), e);
+            }
+            final String transProp = tranSplt.length == 1 ? null : tranSplt[1];
+            if (TransformType.guid.equals(type)) {
+                //TODO CODE throw an error if transProp != null?
+                if (subObjectIDKey != null) {
+                    return withGUIDTransform(targetObjectType, subObjectIDKey);
+                } else {
+                    return withGUIDTransform(targetObjectType);
+                }
+            }
+            if (transProp != null) {
+                //TODO CODE throw an error if guid transform params != null? 
+                return withTransform(type, transProp);
+            } else {
+                return withTransform(type);
+            }
+        }
+        
+        public Builder withNotIndexed() {
+            this.notIndexed = true;
+            return this;
+        }
+        
+        public Builder withNullableDefaultValue(final Object value) {
+            this.defaultValue = value;
+            return this;
+        }
+        
+        public Builder withNullableUIName(final String uiName) {
+            this.uiName = checkString(uiName);
+            return this;
+        }
+        
+        private String checkString(final String s) {
+            return Utils.isNullOrEmpty(s) ? null : s;
+        }
+
+        public Builder withUIHidden() {
+            this.uiHidden = true;
+            return this;
+        }
+        
+        public Builder withFromParent() {
+            this.fromParent = true;
+            return this;
+        }
+        
+        public Builder withNullableUILinkKey(final String uiLinkKey) {
+            this.uiLinkKey = checkString(uiLinkKey);
+            return this;
+        }
+        
+        public IndexingRules build() {
+            return new IndexingRules(path, fullText, keywordType, keyName,
+                    transform, transformProperty, fromParent, notIndexed, sourceKey,
+                    targetObjectType, subobjectIdKey, defaultValue, uiName, uiHidden, uiLinkKey);
+        }
+        
     }
 }

--- a/lib/src/kbasesearchengine/system/LocationTransformType.java
+++ b/lib/src/kbasesearchengine/system/LocationTransformType.java
@@ -1,0 +1,26 @@
+package kbasesearchengine.system;
+
+
+/** The subtype of a {@link TransformType#location} transform.
+ * This transform is specific to the KBase transform schema of [contig_id, start, strand, length].
+ * @author gaprice@lbl.gov
+ *
+ */
+public enum LocationTransformType {
+	
+    /** A transform that results in extracting the contig ID of the location. */
+    contig_id,
+    
+    /** A transform that results in extracting the start of the location. */
+    start,
+    
+    /** A transform that results in extracting the stop of the location. */
+    stop,
+    
+    /** A transform that results in extracting the length of the location. */
+    length,
+    
+    /** A transform that results in extracting the strand of the location. */
+    strand;
+    
+}

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -158,10 +158,15 @@ public class ObjectTypeParsingRules {
                         builder.withKeywordType(keywordType);
                     }
                     final String transform = (String) rulesObj.get("transform");
-                    final String subObjectIDKey = (String) rulesObj.get("subobject-id-key");
-                    final String targetObjectType = (String) rulesObj.get("target-object-type");
-                    builder.withNullableUnknownTransform(
-                            transform, targetObjectType, subObjectIDKey);
+                    if (!Utils.isNullOrEmpty(transform)) {
+                        final String subObjectIDKey = (String) rulesObj.get("subobject-id-key");
+                        final String targetObjectType =
+                                (String) rulesObj.get("target-object-type");
+                        final String[] tranSplt = transform.split("\\.", 2);
+                        final String transProp = tranSplt.length == 1 ? null : tranSplt[1];
+                        builder.withTransform(Transform.unknown(
+                                tranSplt[0], transProp, targetObjectType, subObjectIDKey));
+                    }
                     if (getBool(rulesObj.get("not-indexed"))) {
                         builder.withNotIndexed();
                     }

--- a/lib/src/kbasesearchengine/system/Transform.java
+++ b/lib/src/kbasesearchengine/system/Transform.java
@@ -15,8 +15,6 @@ import kbasesearchengine.tools.Utils;
  */
 public class Transform {
     
-    //TODO TESTS
-    
     private static final List<TransformType> SIMPLE_TYPES = Arrays.asList(
             TransformType.integer, TransformType.string, TransformType.values);
     
@@ -119,7 +117,7 @@ public class Transform {
      * @return the new transform.
      */
     public static Transform lookup(final String targetKey) {
-        Utils.notNullOrEmpty(targetKey, "targetKey cannot be null or empty");
+        Utils.notNullOrEmpty(targetKey, "targetKey cannot be null or whitespace");
         return new Transform(TransformType.lookup, null, targetKey, null, null);
     }
     
@@ -128,7 +126,7 @@ public class Transform {
      * @return the new transform.
      */
     public static Transform guid(final String targetObjectType) {
-        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or empty");
+        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or whitespace");
         return new Transform(TransformType.guid, null, null, targetObjectType, null);
     }
     
@@ -140,7 +138,8 @@ public class Transform {
      * @return the new transform.
      */
     public static Transform guid(final String targetObjectType, final String subObjectIDKey) {
-        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or empty");
+        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or whitespace");
+        Utils.notNullOrEmpty(subObjectIDKey, "subObjectIDKey cannot be null or whitespace");
         return new Transform(TransformType.guid, null, null, targetObjectType, subObjectIDKey);
     }
     
@@ -174,12 +173,12 @@ public class Transform {
         }
         if (type.equals(TransformType.location)) {
             Utils.notNullOrEmpty(locationOrTargetKey,
-                    "location tranform location type cannot be null or whitespace");
+                    "location transform location type cannot be null or whitespace");
             try {
                 return new Transform(type, LocationTransformType.valueOf(locationOrTargetKey),
                         null, null, null);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Illegal tranform location: " +
+                throw new IllegalArgumentException("Illegal transform location: " +
                         locationOrTargetKey);
             }
         }
@@ -197,4 +196,65 @@ public class Transform {
         }
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((location == null) ? 0 : location.hashCode());
+        result = prime * result
+                + ((subObjectIdKey == null) ? 0 : subObjectIdKey.hashCode());
+        result = prime * result
+                + ((targetKey == null) ? 0 : targetKey.hashCode());
+        result = prime * result + ((targetObjectType == null) ? 0
+                : targetObjectType.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Transform other = (Transform) obj;
+        if (location == null) {
+            if (other.location != null) {
+                return false;
+            }
+        } else if (!location.equals(other.location)) {
+            return false;
+        }
+        if (subObjectIdKey == null) {
+            if (other.subObjectIdKey != null) {
+                return false;
+            }
+        } else if (!subObjectIdKey.equals(other.subObjectIdKey)) {
+            return false;
+        }
+        if (targetKey == null) {
+            if (other.targetKey != null) {
+                return false;
+            }
+        } else if (!targetKey.equals(other.targetKey)) {
+            return false;
+        }
+        if (targetObjectType == null) {
+            if (other.targetObjectType != null) {
+                return false;
+            }
+        } else if (!targetObjectType.equals(other.targetObjectType)) {
+            return false;
+        }
+        if (type != other.type) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/lib/src/kbasesearchengine/system/Transform.java
+++ b/lib/src/kbasesearchengine/system/Transform.java
@@ -18,6 +18,14 @@ public class Transform {
     private static final List<TransformType> SIMPLE_TYPES = Arrays.asList(
             TransformType.integer, TransformType.string, TransformType.values);
     
+    private static final Transform VALUES =
+            new Transform(TransformType.values, null, null, null, null);
+    private static final Transform INTEGER =
+            new Transform(TransformType.integer, null, null, null, null);
+    private static final Transform STRING =
+            new Transform(TransformType.string, null, null, null, null);
+    
+    
     private final TransformType type;
     private final Optional<LocationTransformType> location;
     private final Optional<String> targetKey;
@@ -84,21 +92,21 @@ public class Transform {
      * @return the new transform.
      */
     public static Transform values() {
-        return new Transform(TransformType.values, null, null, null, null);
+        return VALUES;
     }
     
     /** Create a {@link TransformType#string} transform.
      * @return the new transform.
      */
     public static Transform string() {
-        return new Transform(TransformType.string, null, null, null, null);
+        return STRING;
     }
     
     /** Create a {@link TransformType#integer} transform.
      * @return the new transform.
      */
     public static Transform integer() {
-        return new Transform(TransformType.integer, null, null, null, null);
+        return INTEGER;
     }
     
     /** Create a {@link TransformType#location} transform.

--- a/lib/src/kbasesearchengine/system/Transform.java
+++ b/lib/src/kbasesearchengine/system/Transform.java
@@ -1,0 +1,200 @@
+package kbasesearchengine.system;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.base.Optional;
+
+import kbasesearchengine.common.GUID;
+import kbasesearchengine.tools.Utils;
+
+/** Specifies a transform of some data into some other data based on a {@link TransformType}
+ * and possibly more specifications depending on the transform type.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class Transform {
+    
+    //TODO TESTS
+    
+    private static final List<TransformType> SIMPLE_TYPES = Arrays.asList(
+            TransformType.integer, TransformType.string, TransformType.values);
+    
+    private final TransformType type;
+    private final Optional<LocationTransformType> location;
+    private final Optional<String> targetKey;
+    private final Optional<String> targetObjectType;
+    // TODO NNOW subobjectIdKey constrains the target type to be a subtype. Add a check in the creation context to check this. 
+    
+    private final Optional<String> subObjectIdKey;
+    
+    private Transform(
+            final TransformType type,
+            final LocationTransformType location,
+            final String targetKey,
+            final String targetObjectType,
+            final String subObjectIdKey) {
+        this.type = type;
+        this.location = Optional.fromNullable(location);
+        this.targetKey = Optional.fromNullable(targetKey);
+        this.targetObjectType = Optional.fromNullable(targetObjectType);
+        this.subObjectIdKey = Optional.fromNullable(subObjectIdKey);
+    }
+
+    /** Get the type of the transform.
+     * @return the transform type.
+     */
+    public TransformType getType() {
+        return type;
+    }
+
+    /** Return the sub type of the transform for {@link TransformType#location} transforms.
+     * For all other transforms this value is absent.
+     * @return the location type.
+     */
+    public Optional<LocationTransformType> getLocation() {
+        return location;
+    }
+
+    /** Return the key from which data will be extracted for a {@link TransformType#lookup}
+     * transforms. For all other transforms this value is absent.
+     * @return the key which contains the data of interest in the lookup object.
+     */
+    public Optional<String> getTargetKey() {
+        return targetKey;
+    }
+
+    /** Return the type of the object to which the {@link GUID} points for
+     * {@link TransformType#guid} transforms. For all other transforms this value is absent.
+     * @return the object type to which the guid created by the transform points.
+     */
+    public Optional<String> getTargetObjectType() {
+        return targetObjectType;
+    }
+
+    /** Return the key of the object in which the subobject id is stored for
+     * {@link TransformType#guid} transforms. The subobject id is used to construct the
+     * {@link GUID} in the case where the target object is a subobject in contrast to a parent
+     * object, and is not present for any other case.
+     * @return
+     */
+    public Optional<String> getSubobjectIdKey() {
+        return subObjectIdKey;
+    }
+    
+    /** Create a {@link TransformType#values} transform.
+     * @return the new transform.
+     */
+    public static Transform values() {
+        return new Transform(TransformType.values, null, null, null, null);
+    }
+    
+    /** Create a {@link TransformType#string} transform.
+     * @return the new transform.
+     */
+    public static Transform string() {
+        return new Transform(TransformType.string, null, null, null, null);
+    }
+    
+    /** Create a {@link TransformType#integer} transform.
+     * @return the new transform.
+     */
+    public static Transform integer() {
+        return new Transform(TransformType.integer, null, null, null, null);
+    }
+    
+    /** Create a {@link TransformType#location} transform.
+     * @param location the sub type of the location transform that specifies which portion of the
+     * location to extract.
+     * @return the new transform.
+     */
+    public static Transform location(final LocationTransformType location) {
+        Utils.nonNull(location, "location");
+        return new Transform(TransformType.location, location, null, null, null);
+    }
+    
+    //TODO CODE or DOCUMENTATION what is required for this to work? Does it work with a path?
+    /** Create a {@link TransformType#lookup} transform.
+     * @param targetKey the key in the target object from which data will be extracted.
+     * @return the new transform.
+     */
+    public static Transform lookup(final String targetKey) {
+        Utils.notNullOrEmpty(targetKey, "targetKey cannot be null or empty");
+        return new Transform(TransformType.lookup, null, targetKey, null, null);
+    }
+    
+    /** Create a {@link TransformType#guid} transform.
+     * @param targetObjectType the type of the object to which the guid is expected to point.
+     * @return the new transform.
+     */
+    public static Transform guid(final String targetObjectType) {
+        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or empty");
+        return new Transform(TransformType.guid, null, null, targetObjectType, null);
+    }
+    
+    /** Create a {@link TransformType#guid} transform.
+     * @param targetObjectType the type of the object to which the guid is expected to point.
+     * @param subObjectIDKey the key in the current sub object that contains the id of the target
+     * sub object (e.g. the sub object within the object that is the target of the GUID). The value
+     * of the key will be incorporated into the GUID.
+     * @return the new transform.
+     */
+    public static Transform guid(final String targetObjectType, final String subObjectIDKey) {
+        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or empty");
+        return new Transform(TransformType.guid, null, null, targetObjectType, subObjectIDKey);
+    }
+    
+    /** Create a transform without calling a transform-specific method. This method is often
+     * used when creating {@link IndexingRules} for a {@link ObjectTypeParsingRules} from a file.
+     * In this case the transform is often specified as 'transform.property' where 'property' is
+     * either the location type or the target key for an external object lookup.
+     * @param transform the transform type as a string.
+     * @param locationOrTargetKey either the {@link LocationTransformType} as a string or
+     * the target key for a {@link TransformType#lookup} transform.
+     * @param targetObjectType the target object type for a {@link TransformType#guid} transform.
+     * @param subObjectIDKey the subobject ID key for a {@link TransformType#guid transform.
+     * @return the new transform.
+     */
+    public static Transform unknown(
+            final String transform,
+            final String locationOrTargetKey,
+            final String targetObjectType,
+            final String subObjectIDKey) {
+        Utils.notNullOrEmpty(transform, "transform cannot be null or whitespace");
+        final TransformType type;
+        try {
+            type = TransformType.valueOf(transform);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Illegal transform type: " + transform);
+        }
+        //TODO CODE should this throw an exception if unused fields are specified?
+        Utils.nonNull(type, "transform");
+        if (SIMPLE_TYPES.contains(type)) {
+            return new Transform(type, null, null, null, null);
+        }
+        if (type.equals(TransformType.location)) {
+            Utils.notNullOrEmpty(locationOrTargetKey,
+                    "location tranform location type cannot be null or whitespace");
+            try {
+                return new Transform(type, LocationTransformType.valueOf(locationOrTargetKey),
+                        null, null, null);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Illegal tranform location: " +
+                        locationOrTargetKey);
+            }
+        }
+        if (type.equals(TransformType.lookup)) {
+            Utils.notNullOrEmpty(locationOrTargetKey,
+                    "lookup transform target key cannot be null or whitespace");
+            return new Transform(type, null, locationOrTargetKey, null, null);
+        }
+        // ok it's a guid
+        Utils.notNullOrEmpty(targetObjectType, "targetObjectType cannot be null or whitespace");
+        if (Utils.isNullOrEmpty(subObjectIDKey)) {
+            return new Transform(TransformType.guid, null, null, targetObjectType, null);
+        } else {
+            return new Transform(TransformType.guid, null, null, targetObjectType, subObjectIDKey);
+        }
+    }
+
+}

--- a/lib/src/kbasesearchengine/system/TransformType.java
+++ b/lib/src/kbasesearchengine/system/TransformType.java
@@ -21,8 +21,7 @@ public enum TransformType {
     /** Transforms value to Integer (Integer.parseInt of String.valueOf). */
     integer,
     
-    /** transforms value containing reference to data store object into GUID using the values
-     * {@link IndexingRules#getTargetObjectType()} and {@link IndexingRules#getSubobjectIdKey()}.
+    /** transforms value containing reference to data store object into GUID.
      */
     guid,
     

--- a/resources/types/Genome.json
+++ b/resources/types/Genome.json
@@ -35,13 +35,6 @@
 		},
 		{
 			"derived-key": true,
-			"transform": "lookup.oname",
-			"source-key": "assembly_guid",
-			"key-name": "assembly",
-			"ui-link-key": "assembly_guid"
-		},
-		{
-			"derived-key": true,
 			"transform": "lookup.key.contigs",
 			"source-key": "assembly_guid",
 			"keyword-type": "integer",

--- a/resources/types/Narrative.json
+++ b/resources/types/Narrative.json
@@ -48,7 +48,7 @@
 		},
 		{
 			"path": "cells/[*]/metadata/kbase/outputCell/jobId",
-			"keywork-type": "string",
+			"keyword-type": "string",
 			"key-name": "job_ids"
 		}
 	]

--- a/resources/types/PairedEndLibrary.json
+++ b/resources/types/PairedEndLibrary.json
@@ -25,7 +25,7 @@
 		},
 		{
 			"path": "read_count",
-			"keywork-type": "integer",
+			"keyword-type": "integer",
 			"ui-name": "Number of reads"
 		},
 		{

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -264,7 +264,6 @@ public class ElasticIndexingStorageTest {
         Assert.assertTrue(genomeIndex.keyProps.containsKey("features"));
         Assert.assertEquals("3", "" + genomeIndex.keyProps.get("features"));
         Assert.assertEquals("1", "" + genomeIndex.keyProps.get("contigs"));
-        Assert.assertEquals("MyAssembly.1", genomeIndex.keyProps.get("assembly"));
         String assemblyGuidText = genomeIndex.keyProps.get("assembly_guid");
         Assert.assertNotNull(assemblyGuidText);
         ObjectData assemblyIndex = getIndexedObject(new GUID(assemblyGuidText));

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -165,10 +165,11 @@ public class ElasticIndexingStorageTest {
     @SuppressWarnings("unchecked")
     private static void indexObject(String type, String jsonResource, GUID ref, String objName)
             throws Exception {
+        final File file = new File("resources/types/" + type + ".json");
         Map<String, Object> parsingRulesObj = UObject.getMapper().readValue(
-                new File("resources/types/" + type + ".json"), Map.class);
+                file, Map.class);
         ObjectTypeParsingRules parsingRules = ObjectTypeParsingRules
-                .fromObject(parsingRulesObj, "test");
+                .fromObject(parsingRulesObj, file.toString());
         Map<ObjectJsonPath, String> pathToJson = new LinkedHashMap<>();
         SubObjectConsumer subObjConsumer = new SimpleSubObjectConsumer(pathToJson);
         String parentJson = null;
@@ -238,7 +239,7 @@ public class ElasticIndexingStorageTest {
         Assert.assertTrue(obj.containsKey("type"));
         Assert.assertEquals("NC_000913", featureIndex.keyProps.get("contig_id"));
         String contigGuidText = featureIndex.keyProps.get("contig_guid");
-        Assert.assertNotNull(contigGuidText);
+        Assert.assertNotNull("missing contig_guid", contigGuidText);
         ObjectData contigIndex = getIndexedObject(new GUID(contigGuidText));
         //System.out.println("AssemblyContig index: " + contigIndex);
         Assert.assertEquals("NC_000913", "" + contigIndex.keyProps.get("contig_id"));
@@ -275,9 +276,8 @@ public class ElasticIndexingStorageTest {
     @Test
     public void testVersions() throws Exception {
         String objType = "Simple";
-        IndexingRules ir = new IndexingRules();
-        ir.setPath(new ObjectJsonPath("prop1"));
-        ir.setFullText(true);
+        IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop1"))
+                .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id11 = new GUID("WS:2/1/1");
         indexObject(id11, objType, "{\"prop1\":\"abc 123\"}", "obj.1", Instant.now(), null,
@@ -333,9 +333,8 @@ public class ElasticIndexingStorageTest {
     @Test
     public void testSharing() throws Exception {
         String objType = "Sharable";
-        IndexingRules ir = new IndexingRules();
-        ir.setPath(new ObjectJsonPath("prop2"));
-        ir.setKeywordType("integer");
+        IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop2"))
+                .withKeywordType("integer").build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:10/1/1");
         indexObject(id1, objType, "{\"prop2\": 123}", "obj.1", Instant.now(), null,
@@ -384,9 +383,8 @@ public class ElasticIndexingStorageTest {
     @Test
     public void testPublic() throws Exception {
         String objType = "Publishable";
-        IndexingRules ir = new IndexingRules();
-        ir.setPath(new ObjectJsonPath("prop3"));
-        ir.setFullText(true);
+        IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop3"))
+                .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:20/1/1");
         GUID id2 = new GUID("WS:20/2/1");
@@ -437,9 +435,8 @@ public class ElasticIndexingStorageTest {
     @Test
     public void testPublicDataPalettes() throws Exception {
         String objType = "ShareAndPublic";
-        IndexingRules ir = new IndexingRules();
-        ir.setPath(new ObjectJsonPath("prop4"));
-        ir.setKeywordType("integer");
+        IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop4"))
+                .withKeywordType("integer").build();
         List<IndexingRules> indexingRules = Arrays.asList(ir);
         GUID id1 = new GUID("WS:30/1/1");
         indexObject(id1, objType, "{\"prop4\": 123}", "obj.1", Instant.now(), null,
@@ -473,9 +470,8 @@ public class ElasticIndexingStorageTest {
     @Test
     public void testDeleteUndelete() throws Exception {
         String objType = "DelUndel";
-        IndexingRules ir = new IndexingRules();
-        ir.setPath(new ObjectJsonPath("myprop"));
-        ir.setFullText(true);
+        IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("myprop"))
+                .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:100/2/1");
         GUID id2 = new GUID("WS:100/2/2");
@@ -520,9 +516,8 @@ public class ElasticIndexingStorageTest {
     public void testPublishAllVersions() throws Exception {
         // tests the all versions method for setting objects public / non-public.
         String objType = "PublishAllVersions";
-        IndexingRules ir = new IndexingRules();
-        ir.setPath(new ObjectJsonPath("myprop"));
-        ir.setFullText(true);
+        IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("myprop"))
+                .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
         GUID id1 = new GUID("WS:200/2/1");
         GUID id2 = new GUID("WS:200/2/2");

--- a/test/src/kbasesearchengine/test/system/IndexingRulesTest.java
+++ b/test/src/kbasesearchengine/test/system/IndexingRulesTest.java
@@ -1,0 +1,310 @@
+package kbasesearchengine.test.system;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+
+import kbasesearchengine.common.ObjectJsonPath;
+import kbasesearchengine.system.IndexingRules;
+import kbasesearchengine.system.IndexingRules.Builder;
+import kbasesearchengine.system.Transform;
+import kbasesearchengine.test.common.TestCommon;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class IndexingRulesTest {
+    
+    @Test
+    public void equals() {
+        EqualsVerifier.forClass(IndexingRules.class).usingGetClass().verify();
+    }
+    
+    @Test
+    public void buildPathMinimal() throws Exception {
+        final IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("foo")).build();
+        assertThat("incorrect path", ir.getPath(), is(Optional.of(new ObjectJsonPath("foo"))));
+        assertThat("incorrect default", ir.getDefaultValue(), is(Optional.absent()));
+        assertThat("incorrect key name", ir.getKeyName(), is("foo"));
+        assertThat("incorrect keyword type", ir.getKeywordType(), is(Optional.of("keyword")));
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.absent()));
+        assertThat("incorrect transform", ir.getTransform(), is(Optional.absent()));
+        assertThat("incorrect link key", ir.getUiLinkKey(), is(Optional.absent()));
+        assertThat("incorrect ui name", ir.getUiName(), is("Foo"));
+        assertThat("incorrect is derived", ir.isDerivedKey(), is(false));
+        assertThat("incorrect is from parent", ir.isFromParent(), is(false));
+        assertThat("incorrect is full text", ir.isFullText(), is(false));
+        assertThat("incorrect is not indexed", ir.isNotIndexed(), is(false));
+        assertThat("incorrect is ui hidden", ir.isUiHidden(), is(false));
+    }
+    
+    @Test
+    public void buildSourceKeyMinimal() throws Exception {
+        final IndexingRules ir = IndexingRules.fromSourceKey("foo", "bar").build();
+        assertThat("incorrect path", ir.getPath(), is(Optional.absent()));
+        assertThat("incorrect default", ir.getDefaultValue(), is(Optional.absent()));
+        assertThat("incorrect key name", ir.getKeyName(), is("bar"));
+        assertThat("incorrect keyword type", ir.getKeywordType(), is(Optional.of("keyword")));
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.of("foo")));
+        assertThat("incorrect transform", ir.getTransform(), is(Optional.absent()));
+        assertThat("incorrect link key", ir.getUiLinkKey(), is(Optional.absent()));
+        assertThat("incorrect ui name", ir.getUiName(), is("Bar"));
+        assertThat("incorrect is derived", ir.isDerivedKey(), is(true));
+        assertThat("incorrect is from parent", ir.isFromParent(), is(false));
+        assertThat("incorrect is full text", ir.isFullText(), is(false));
+        assertThat("incorrect is not indexed", ir.isNotIndexed(), is(false));
+        assertThat("incorrect is ui hidden", ir.isUiHidden(), is(false));
+    }
+    
+    @Test
+    public void buildPathMaximalKeywordType() throws Exception {
+        final IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("foo"))
+                .withFromParent()
+                .withFullText()
+                .withKeyName("thunderpants")
+                .withKeywordType("thingy")
+                .withNotIndexed()
+                .withNullableDefaultValue("default")
+                .withNullableUILinkKey("linky")
+                .withNullableUIName("myname")
+                .withTransform(Transform.values())
+                .withUIHidden()
+                .build();
+        assertThat("incorrect path", ir.getPath(), is(Optional.of(new ObjectJsonPath("foo"))));
+        assertThat("incorrect default", ir.getDefaultValue(), is(Optional.of("default")));
+        assertThat("incorrect key name", ir.getKeyName(), is("thunderpants"));
+        assertThat("incorrect keyword type", ir.getKeywordType(), is(Optional.of("thingy")));
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.absent()));
+        assertThat("incorrect transform", ir.getTransform(), is(Optional.of(Transform.values())));
+        assertThat("incorrect link key", ir.getUiLinkKey(), is(Optional.of("linky")));
+        assertThat("incorrect ui name", ir.getUiName(), is("myname"));
+        assertThat("incorrect is derived", ir.isDerivedKey(), is(false));
+        assertThat("incorrect is from parent", ir.isFromParent(), is(true));
+        assertThat("incorrect is full text", ir.isFullText(), is(false));
+        assertThat("incorrect is not indexed", ir.isNotIndexed(), is(true));
+        assertThat("incorrect is ui hidden", ir.isUiHidden(), is(true));
+    }
+
+    @Test
+    public void buildPathMaximalFullText() throws Exception {
+        // also tests passing null for nullable default
+        final IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("foo"))
+                .withFromParent()
+                .withKeyName("thunderpants")
+                .withKeywordType("thingy")
+                .withFullText()
+                .withNotIndexed()
+                .withNullableDefaultValue(null)
+                .withNullableUILinkKey("linky")
+                .withNullableUIName("myname")
+                .withTransform(Transform.values())
+                .withUIHidden()
+                .build();
+        assertThat("incorrect path", ir.getPath(), is(Optional.of(new ObjectJsonPath("foo"))));
+        assertThat("incorrect default", ir.getDefaultValue(), is(Optional.absent()));
+        assertThat("incorrect key name", ir.getKeyName(), is("thunderpants"));
+        assertThat("incorrect keyword type", ir.getKeywordType(), is(Optional.absent()));
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.absent()));
+        assertThat("incorrect transform", ir.getTransform(), is(Optional.of(Transform.values())));
+        assertThat("incorrect link key", ir.getUiLinkKey(), is(Optional.of("linky")));
+        assertThat("incorrect ui name", ir.getUiName(), is("myname"));
+        assertThat("incorrect is derived", ir.isDerivedKey(), is(false));
+        assertThat("incorrect is from parent", ir.isFromParent(), is(true));
+        assertThat("incorrect is full text", ir.isFullText(), is(true));
+        assertThat("incorrect is not indexed", ir.isNotIndexed(), is(true));
+        assertThat("incorrect is ui hidden", ir.isUiHidden(), is(true));
+    }
+    
+    @Test
+    public void buildSourceKeyMaximalKeywordType() throws Exception {
+        final IndexingRules ir = IndexingRules.fromSourceKey("whoop", "tedoo")
+                .withFromParent()
+                .withFullText()
+                .withKeyName("thunderpants")
+                .withKeywordType("thingy")
+                .withNotIndexed()
+                .withNullableDefaultValue("default")
+                .withNullableUILinkKey("linky")
+                .withNullableUIName("myname")
+                .withTransform(Transform.values())
+                .withUIHidden()
+                .build();
+        assertThat("incorrect path", ir.getPath(), is(Optional.absent()));
+        assertThat("incorrect default", ir.getDefaultValue(), is(Optional.of("default")));
+        assertThat("incorrect key name", ir.getKeyName(), is("thunderpants"));
+        assertThat("incorrect keyword type", ir.getKeywordType(), is(Optional.of("thingy")));
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.of("whoop")));
+        assertThat("incorrect transform", ir.getTransform(), is(Optional.of(Transform.values())));
+        assertThat("incorrect link key", ir.getUiLinkKey(), is(Optional.of("linky")));
+        assertThat("incorrect ui name", ir.getUiName(), is("myname"));
+        assertThat("incorrect is derived", ir.isDerivedKey(), is(true));
+        assertThat("incorrect is from parent", ir.isFromParent(), is(true));
+        assertThat("incorrect is full text", ir.isFullText(), is(false));
+        assertThat("incorrect is not indexed", ir.isNotIndexed(), is(true));
+        assertThat("incorrect is ui hidden", ir.isUiHidden(), is(true));
+    }
+    
+    @Test
+    public void buildSourceKeyMaximalFullText() throws Exception {
+        final IndexingRules ir = IndexingRules.fromSourceKey("whoop", "tedoo")
+                .withFromParent()
+                .withKeyName("thunderpants")
+                .withKeywordType("thingy")
+                .withFullText()
+                .withNotIndexed()
+                .withNullableDefaultValue("default")
+                .withNullableUILinkKey("linky")
+                .withNullableUIName("myname")
+                .withTransform(Transform.values())
+                .withUIHidden()
+                .build();
+        assertThat("incorrect path", ir.getPath(), is(Optional.absent()));
+        assertThat("incorrect default", ir.getDefaultValue(), is(Optional.of("default")));
+        assertThat("incorrect key name", ir.getKeyName(), is("thunderpants"));
+        assertThat("incorrect keyword type", ir.getKeywordType(), is(Optional.absent()));
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.of("whoop")));
+        assertThat("incorrect transform", ir.getTransform(), is(Optional.of(Transform.values())));
+        assertThat("incorrect link key", ir.getUiLinkKey(), is(Optional.of("linky")));
+        assertThat("incorrect ui name", ir.getUiName(), is("myname"));
+        assertThat("incorrect is derived", ir.isDerivedKey(), is(true));
+        assertThat("incorrect is from parent", ir.isFromParent(), is(true));
+        assertThat("incorrect is full text", ir.isFullText(), is(true));
+        assertThat("incorrect is not indexed", ir.isNotIndexed(), is(true));
+        assertThat("incorrect is ui hidden", ir.isUiHidden(), is(true));
+    }
+    
+    @Test
+    public void uinameNullsAndWhitespaceIgnored() {
+        uiNameNullsAndWhitespaceIgnored(null);
+        uiNameNullsAndWhitespaceIgnored("   \t   \n   ");
+    }
+
+    private void uiNameNullsAndWhitespaceIgnored(final String uiname) {
+        final IndexingRules ir = IndexingRules.fromSourceKey("foo", "bar")
+                .withNullableUIName(uiname)
+                .build();
+        assertThat("incorrect ui name", ir.getUiName(), is("Bar"));
+    }
+    
+    @Test
+    public void uiLinnkKeyNullsAndWhitespaceIgnored() {
+        uiLinkKeyNullsAndWhitespaceIgnored(null);
+        uiLinkKeyNullsAndWhitespaceIgnored("   \t   \n   ");
+    }
+    
+    private void uiLinkKeyNullsAndWhitespaceIgnored(final String uilinkkey) {
+        final IndexingRules ir = IndexingRules.fromSourceKey("foo", "bar")
+                .withNullableUILinkKey(uilinkkey)
+                .build();
+        assertThat("incorrect ui name", ir.getUiName(), is("Bar"));
+    }
+    
+    @Test
+    public void fromPathFailNull() {
+        try {
+            IndexingRules.fromPath(null);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, new NullPointerException("path"));
+        }
+    }
+    @Test
+    public void fromSourceKeyFailNullWhitespace() {
+        failFromSourceKey(null, "k",
+                new IllegalArgumentException("sourceKey cannot be null or whitespace"));
+        failFromSourceKey("   \t  \n ", "k",
+                new IllegalArgumentException("sourceKey cannot be null or whitespace"));
+        failFromSourceKey("s", null,
+                new IllegalArgumentException("keyName cannot be null or whitespace"));
+        failFromSourceKey("s", "   \t  \n ",
+                new IllegalArgumentException("keyName cannot be null or whitespace"));
+    }
+    
+    private void failFromSourceKey(
+            final String sourceKey,
+            final String keyName,
+            final Exception expected) {
+        try {
+            IndexingRules.fromSourceKey(sourceKey, keyName);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void buildKeyNameFailNullWhitespace() {
+        failBuildKeyName(null,
+                new IllegalArgumentException("keyName cannot be null or whitespace"));
+        failBuildKeyName("   \t \n  ",
+                new IllegalArgumentException("keyName cannot be null or whitespace"));
+    }
+    
+    private void failBuildKeyName(final String keyname, final Exception expected) {
+        try {
+            IndexingRules.fromSourceKey("s", "k").withKeyName(keyname);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void buildKeywordTypeFailNullWhitespace() {
+        failBuildKeywordType(null,
+                new IllegalArgumentException("keywordType cannot be null or whitespace"));
+        failBuildKeywordType("   \t \n  ",
+                new IllegalArgumentException("keywordType cannot be null or whitespace"));
+    }
+    
+    private void failBuildKeywordType(final String keywordType, final Exception expected) {
+        try {
+            IndexingRules.fromSourceKey("s", "k").withKeywordType(keywordType);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void buildTransformWithSubobjectIDKeyAndSourceKey() {
+        // check case where sub object id key is allowed in transform
+        final IndexingRules ir = IndexingRules.fromSourceKey("k", "n")
+                .withTransform(Transform.guid("type", "idkey"))
+                .build();
+        assertThat("incorrect source key", ir.getSourceKey(), is(Optional.of("k")));
+        assertThat("incorrect key name", ir.getKeyName(), is("n"));
+        assertThat("incorrect transform", ir.getTransform(),
+                is(Optional.of(Transform.guid("type", "idkey"))));
+    }
+    
+    @Test
+    public void buildTransformFailNull() {
+        failBuildTransform(IndexingRules.fromSourceKey("s", "k"), null,
+                new NullPointerException("transform"));
+    }
+    
+    @Test
+    public void buildTransformFailSubObjectIDConstraint() throws Exception {
+        failBuildTransform(IndexingRules.fromPath(new ObjectJsonPath("foo")),
+                Transform.guid("type", "idkey"), new IllegalArgumentException(
+                        "A transform with a subobject ID key is not compatible with a path. " +
+                        "Path is: /foo"));
+    }
+    
+    private void failBuildTransform(
+            final Builder b,
+            final Transform transform,
+            final Exception expected) {
+        try {
+            b.withTransform(transform);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+        
+    }
+    
+}

--- a/test/src/kbasesearchengine/test/system/TransformTest.java
+++ b/test/src/kbasesearchengine/test/system/TransformTest.java
@@ -1,0 +1,277 @@
+package kbasesearchengine.test.system;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+
+import kbasesearchengine.system.LocationTransformType;
+import kbasesearchengine.system.Transform;
+import kbasesearchengine.system.TransformType;
+import kbasesearchengine.test.common.TestCommon;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class TransformTest {
+    
+    @Test
+    public void equals() {
+        EqualsVerifier.forClass(Transform.class).usingGetClass().verify();
+    }
+
+    @Test
+    public void string() {
+        final Transform t = Transform.string();
+        assertThat("incorrect type", t.getType(), is(TransformType.string));
+        assertEmptyFields(t);
+    }
+
+    private void assertEmptyFields(final Transform t) {
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.absent()));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void integer() {
+        final Transform t = Transform.integer();
+        assertThat("incorrect type", t.getType(), is(TransformType.integer));
+        assertEmptyFields(t);
+    }
+    
+    @Test
+    public void value() {
+        final Transform t = Transform.values();
+        assertThat("incorrect type", t.getType(), is(TransformType.values));
+        assertEmptyFields(t);
+    }
+    
+    @Test
+    public void location() {
+        final Transform t = Transform.location(LocationTransformType.contig_id);
+        assertThat("incorrect type", t.getType(), is(TransformType.location));
+        assertThat("incorrect location", t.getLocation(),
+                is(Optional.of(LocationTransformType.contig_id)));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.absent()));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    
+    }
+    
+    @Test
+    public void locationFail() {
+        try {
+            Transform.location(null);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, new NullPointerException("location"));
+        }
+    }
+    
+    @Test
+    public void lookup() {
+        final Transform t = Transform.lookup("foo");
+        assertThat("incorrect type", t.getType(), is(TransformType.lookup));
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.of("foo")));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.absent()));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void lookupFail() {
+        failLookup(null, new IllegalArgumentException("targetKey cannot be null or whitespace"));
+        failLookup("   \t   \n ",
+                new IllegalArgumentException("targetKey cannot be null or whitespace"));
+    }
+    
+    private void failLookup(final String lookup, final Exception expected) {
+        try {
+            Transform.lookup(lookup);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void guid() {
+        final Transform t = Transform.guid("foo");
+        assertThat("incorrect type", t.getType(), is(TransformType.guid));
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.of("foo")));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void guidWithSubobject() {
+        final Transform t = Transform.guid("foo", "bar");
+        assertThat("incorrect type", t.getType(), is(TransformType.guid));
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.of("foo")));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.of("bar")));
+    }
+    
+    @Test
+    public void guidFail() {
+        failGuid(null,
+                new IllegalArgumentException("targetObjectType cannot be null or whitespace"));
+        failGuid("   \n   \t  ",
+                new IllegalArgumentException("targetObjectType cannot be null or whitespace"));
+        failGuid(null, "foo",
+                new IllegalArgumentException("targetObjectType cannot be null or whitespace"));
+        failGuid("   \n   \t  ", "foo",
+                new IllegalArgumentException("targetObjectType cannot be null or whitespace"));
+        failGuid("foo", null,
+                new IllegalArgumentException("subObjectIDKey cannot be null or whitespace"));
+        failGuid("foo", "  \n   \t  ",
+                new IllegalArgumentException("subObjectIDKey cannot be null or whitespace"));
+    }
+    
+    private void failGuid(
+            final String targetObjectType,
+            final Exception expected) {
+        try {
+            Transform.guid(targetObjectType);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    private void failGuid(
+            final String targetObjectType,
+            final String subObjectIDKey,
+            final Exception expected) {
+        try {
+            Transform.guid(targetObjectType, subObjectIDKey);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void unknownValues() {
+        final Transform t = Transform.unknown("values", "foo", "bar", "baz");
+        assertThat("incorrect type", t.getType(), is(TransformType.values));
+        assertEmptyFields(t);
+    }
+    
+    @Test
+    public void unknownString() {
+        final Transform t = Transform.unknown("string", "foo", "bar", "baz");
+        assertThat("incorrect type", t.getType(), is(TransformType.string));
+        assertEmptyFields(t);
+    }
+    
+    @Test
+    public void unknownInteger() {
+        final Transform t = Transform.unknown("integer", "foo", "bar", "baz");
+        assertThat("incorrect type", t.getType(), is(TransformType.integer));
+        assertEmptyFields(t);
+    }
+    
+    @Test
+    public void unknownLocation() {
+        final Transform t = Transform.unknown("location", "start", "bar", "baz");
+        assertThat("incorrect type", t.getType(), is(TransformType.location));
+        assertThat("incorrect location", t.getLocation(),
+                is(Optional.of(LocationTransformType.start)));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.absent()));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void unknownLookup() {
+        final Transform t = Transform.unknown("lookup", "whee", "bar", "baz");
+        assertThat("incorrect type", t.getType(), is(TransformType.lookup));
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.of("whee")));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(), is(Optional.absent()));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void unknownGuid() {
+        unknownGuid(null);
+        unknownGuid("  \t  \n  ");
+    }
+
+    private void unknownGuid(final String subObjectIDKey) {
+        final Transform t = Transform.unknown("guid", "foo", "whoo", subObjectIDKey);
+        assertThat("incorrect type", t.getType(), is(TransformType.guid));
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(),
+                is(Optional.of("whoo")));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void unknownGuidWithSubObjectIDKey() {
+        final Transform t = Transform.unknown("guid", "foo", "whoo", "whoop");
+        assertThat("incorrect type", t.getType(), is(TransformType.guid));
+        assertThat("incorrect location", t.getLocation(), is(Optional.absent()));
+        assertThat("incorrect targetKey", t.getTargetKey(), is(Optional.absent()));
+        assertThat("incorrect targetObjectType", t.getTargetObjectType(),
+                is(Optional.of("whoo")));
+        assertThat("incorrect subObjectIDKey", t.getSubobjectIdKey(), is(Optional.of("whoop")));
+    }
+    
+    @Test
+    public void unknownFailTransformType() {
+        failUnknown(null, null, null, null,
+                new IllegalArgumentException("transform cannot be null or whitespace"));
+        failUnknown("   \t  \n  ", null, null, null,
+                new IllegalArgumentException("transform cannot be null or whitespace"));
+        failUnknown("foo", null, null, null,
+                new IllegalArgumentException("Illegal transform type: foo"));
+    }
+    
+    @Test
+    public void unknownFailLocation() {
+        failUnknown("location", null, "foo", "bar", new IllegalArgumentException(
+                "location transform location type cannot be null or whitespace"));
+        failUnknown("location", "   \t   \n  ", "foo", "bar", new IllegalArgumentException(
+                "location transform location type cannot be null or whitespace"));
+        failUnknown("location", "badloc", "foo", "bar", new IllegalArgumentException(
+                "Illegal transform location: badloc"));
+    }
+    
+    @Test
+    public void unknownFailLookup() {
+        failUnknown("lookup", null, "foo", "bar", new IllegalArgumentException(
+                "lookup transform target key cannot be null or whitespace"));
+        failUnknown("lookup", "   \t   \n  ", "foo", "bar", new IllegalArgumentException(
+                "lookup transform target key cannot be null or whitespace"));
+    }
+    
+    @Test
+    public void unknownFailGuid() {
+        failUnknown("guid", "bleah", null, "bar", new IllegalArgumentException(
+                "targetObjectType cannot be null or whitespace"));
+        failUnknown("guid", "bleah", "  \t   \n  ", "bar", new IllegalArgumentException(
+                "targetObjectType cannot be null or whitespace"));
+    }
+    
+    private void failUnknown(
+            final String transform,
+            final String locationOrTargetKey,
+            final String targetObjectType,
+            final String subObjectIDKey,
+            final Exception expected) {
+        try {
+            Transform.unknown(transform, locationOrTargetKey, targetObjectType, subObjectIDKey);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+}


### PR DESCRIPTION
* immutable
* fluent builder
* constraints enforced at build time rather than later in various places in the code
* defaults set at build time rather than calculated later in various places in the code
* separate out transform class
* no nulls returned from API

Also removed the lookup.oname transform from Genome.json because that inserts a mutable object name into an index that will not get updated. If we want to find Genomes by the the name of their source Assembly we need some other solution, not this.