### PR TITLE
SCT-157 Refactor ObjectTypeParsingRules

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -165,6 +165,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
             <include name="kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java"/>
             <include name="kbasesearchengine/test/search/ElasticIndexingStorageTest.java"/>
             <include name="kbasesearchengine/test/system/IndexingRulesTest.java"/>
+            <include name="kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java"/>
             <include name="kbasesearchengine/test/system/StorageObjectTypeTest.java"/>
             <include name="kbasesearchengine/test/system/TypeMappingTest.java"/>
             <include name="kbasesearchengine/test/system/TransformTest.java"/>

--- a/lib/src/kbasesearchengine/parse/KeywordParser.java
+++ b/lib/src/kbasesearchengine/parse/KeywordParser.java
@@ -252,7 +252,8 @@ public class KeywordParser {
             Set<GUID> guids = lookup.resolveRefs(objectRefPath, unresolvedGUIDs);
             Set<String> subIds = null;
             if (transform.getSubobjectIdKey().isPresent()) {
-                if (typeDescr.getInnerSubType() == null) {
+                if (!typeDescr.getInnerSubType().isPresent()) {
+                    //TODO CODE check this in parsing rules creation context if possible
                     throw new IllegalStateException("Subobject GUID transform should correspond " +
                             "to subobject type descriptor: " + rule);
                 }
@@ -268,7 +269,7 @@ public class KeywordParser {
                     guids.add(new GUID(typeDescr.getStorageObjectType().getStorageCode(),
                             parentGuid.getAccessGroupId(),
                             parentGuid.getAccessGroupObjectId(), parentGuid.getVersion(), 
-                            typeDescr.getInnerSubType(), subId));
+                            typeDescr.getInnerSubType().get(), subId));
                 }
             }
             Map<GUID, String> guidToType = lookup.getTypesForGuids(guids);

--- a/lib/src/kbasesearchengine/parse/KeywordParser.java
+++ b/lib/src/kbasesearchengine/parse/KeywordParser.java
@@ -194,6 +194,7 @@ public class KeywordParser {
         case location:
             List<List<Object>> loc = (List<List<Object>>)value;
             Map<LocationTransformType, Object> retLoc = new LinkedHashMap<>();
+            //TODO CODE if the subobject stuff in the ObjectParsingRules is left out this throws an indexing exception. Need to figure out cause.
             retLoc.put(LocationTransformType.contig_id, loc.get(0).get(0));
             String strand = (String)loc.get(0).get(2);
             retLoc.put(LocationTransformType.strand, strand);

--- a/lib/src/kbasesearchengine/parse/KeywordParser.java
+++ b/lib/src/kbasesearchengine/parse/KeywordParser.java
@@ -252,7 +252,7 @@ public class KeywordParser {
             Set<GUID> guids = lookup.resolveRefs(objectRefPath, unresolvedGUIDs);
             Set<String> subIds = null;
             if (transform.getSubobjectIdKey().isPresent()) {
-                if (!typeDescr.getInnerSubType().isPresent()) {
+                if (!typeDescr.getSubObjectType().isPresent()) {
                     //TODO CODE check this in parsing rules creation context if possible
                     throw new IllegalStateException("Subobject GUID transform should correspond " +
                             "to subobject type descriptor: " + rule);
@@ -269,7 +269,7 @@ public class KeywordParser {
                     guids.add(new GUID(typeDescr.getStorageObjectType().getStorageCode(),
                             parentGuid.getAccessGroupId(),
                             parentGuid.getAccessGroupObjectId(), parentGuid.getVersion(), 
-                            typeDescr.getInnerSubType().get(), subId));
+                            typeDescr.getSubObjectType().get(), subId));
                 }
             }
             Map<GUID, String> guidToType = lookup.getTypesForGuids(guids);

--- a/lib/src/kbasesearchengine/parse/ObjectParser.java
+++ b/lib/src/kbasesearchengine/parse/ObjectParser.java
@@ -41,9 +41,9 @@ public class ObjectParser {
         for (ObjectJsonPath path : pathToJson.keySet()) {
             String subJson = pathToJson.get(path);
             SimpleIdConsumer idConsumer = new SimpleIdConsumer();
-            if (parsingRules.getPrimaryKeyPath() != null) {
+            if (parsingRules.getPrimaryKeyPath().isPresent()) {
                 try (JsonParser subJts = UObject.getMapper().getFactory().createParser(subJson)) {
-                    IdMapper.mapKeys(parsingRules.getPrimaryKeyPath(), subJts, idConsumer);
+                    IdMapper.mapKeys(parsingRules.getPrimaryKeyPath().get(), subJts, idConsumer);
                 }
             }
             GUID subid = prepareGUID(parsingRules, guid, path, idConsumer);
@@ -57,18 +57,17 @@ public class ObjectParser {
             SimpleIdConsumer idConsumer) {
         String innerSubType = null;
         String innerID = null;
-        if (parsingRules.getPathToSubObjects() != null) {
+        if (parsingRules.getPathToSubObjects().isPresent()) {
             innerID = idConsumer.getPrimaryKey() == null ? path.toString() : 
                 String.valueOf(idConsumer.getPrimaryKey());
-            innerSubType = parsingRules.getInnerSubType() == null ? "_" : 
-                parsingRules.getInnerSubType();
+            innerSubType = parsingRules.getInnerSubType().get();
         }
         return new GUID(guid, innerSubType, innerID);
     }
     
     public static String extractParentFragment(ObjectTypeParsingRules parsingRules,
             JsonParser jts) throws ObjectParseException, IOException {
-        if (parsingRules.getPathToSubObjects() == null) {
+        if (!parsingRules.getPathToSubObjects().isPresent()) {
             return null;
         }
         List<ObjectJsonPath> indexingPaths = new ArrayList<>();
@@ -101,8 +100,8 @@ public class ObjectParser {
                 indexingPaths.add(rules.getPath().get());
             }
         }
-        ObjectJsonPath pathToSubObjects = parsingRules.getPathToSubObjects() == null ?
-                new ObjectJsonPath("/") : parsingRules.getPathToSubObjects();
+        ObjectJsonPath pathToSubObjects = parsingRules.getPathToSubObjects()
+                .or(new ObjectJsonPath("/"));
         SubObjectExtractor.extract(pathToSubObjects, indexingPaths, jts, subObjConsumer);
     }
 }

--- a/lib/src/kbasesearchengine/parse/ObjectParser.java
+++ b/lib/src/kbasesearchengine/parse/ObjectParser.java
@@ -41,9 +41,9 @@ public class ObjectParser {
         for (ObjectJsonPath path : pathToJson.keySet()) {
             String subJson = pathToJson.get(path);
             SimpleIdConsumer idConsumer = new SimpleIdConsumer();
-            if (parsingRules.getPrimaryKeyPath().isPresent()) {
+            if (parsingRules.getSubObjectIDPath().isPresent()) {
                 try (JsonParser subJts = UObject.getMapper().getFactory().createParser(subJson)) {
-                    IdMapper.mapKeys(parsingRules.getPrimaryKeyPath().get(), subJts, idConsumer);
+                    IdMapper.mapKeys(parsingRules.getSubObjectIDPath().get(), subJts, idConsumer);
                 }
             }
             GUID subid = prepareGUID(parsingRules, guid, path, idConsumer);
@@ -57,17 +57,17 @@ public class ObjectParser {
             SimpleIdConsumer idConsumer) {
         String innerSubType = null;
         String innerID = null;
-        if (parsingRules.getPathToSubObjects().isPresent()) {
+        if (parsingRules.getSubObjectPath().isPresent()) {
             innerID = idConsumer.getPrimaryKey() == null ? path.toString() : 
                 String.valueOf(idConsumer.getPrimaryKey());
-            innerSubType = parsingRules.getInnerSubType().get();
+            innerSubType = parsingRules.getSubObjectType().get();
         }
         return new GUID(guid, innerSubType, innerID);
     }
     
     public static String extractParentFragment(ObjectTypeParsingRules parsingRules,
             JsonParser jts) throws ObjectParseException, IOException {
-        if (!parsingRules.getPathToSubObjects().isPresent()) {
+        if (!parsingRules.getSubObjectPath().isPresent()) {
             return null;
         }
         List<ObjectJsonPath> indexingPaths = new ArrayList<>();
@@ -100,7 +100,7 @@ public class ObjectParser {
                 indexingPaths.add(rules.getPath().get());
             }
         }
-        ObjectJsonPath pathToSubObjects = parsingRules.getPathToSubObjects()
+        ObjectJsonPath pathToSubObjects = parsingRules.getSubObjectPath()
                 .or(new ObjectJsonPath("/"));
         SubObjectExtractor.extract(pathToSubObjects, indexingPaths, jts, subObjConsumer);
     }

--- a/lib/src/kbasesearchengine/system/IndexingRules.java
+++ b/lib/src/kbasesearchengine/system/IndexingRules.java
@@ -101,7 +101,7 @@ public class IndexingRules {
      * supposed to be visible via UI though it could be used in API search queries.
      */
     private final boolean uiHidden;
-    // TODO NNOW this should point to another indexing rule that is a guid.
+    // TODO IDXRULE this should point to another indexing rule that is a guid.
     /**
      * An optional pointer to a paired keyword coupled with given one providing
      * GUID for making clickable URL for value provided.
@@ -241,7 +241,7 @@ public class IndexingRules {
         return uiHidden;
     }
     
-    //TODO CODE does this have to point to an indexing rule with a GUID, e.g. the indexing rule has a GUID transform?
+    //TODO IDXRULE does this have to point to an indexing rule with a GUID, e.g. the indexing rule has a GUID transform?
     /** Get, if present, the key name of an indexing rule that contains a GUID addressing a
      * data object to which the value associated with this indexing rule should be linked in a UI
      * context. For example, the value associated with this indexing rule might contain a product
@@ -374,7 +374,7 @@ public class IndexingRules {
         return new Builder(path);
     }
     
-    //TODO CODE do source key rules have to occur later in the ordering than their target key?
+    //TODO IDXRULE do source key rules have to occur later in the ordering than their target key?
     /** Get a builder for an {@link IndexingRules} instance based on another {@link IndexingRules}
      * specified by a the sourceKey.
      * @param sourceKey the keyName of the {@link IndexingRules} of the value of interest.
@@ -520,7 +520,7 @@ public class IndexingRules {
             return this;
         }
         
-        //TODO CODE must the target indexing rule be a GUID transform?
+        //TODO IDXRULE must the target indexing rule be a GUID transform?
         /** Specify that the value associated with this indexing rule should be used as the text
          * for a link to a data object specified by a GUID associated with another indexing rule
          * which is specified by uiLinkKey. Nulls and whitespace strings are ignored.

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -23,8 +23,6 @@ import kbasesearchengine.tools.Utils;
  */
 public class ObjectTypeParsingRules {
     
-    //TODO JAVADOC
-    //TODO TEST
     //TODO IDXRULE what if there are two parent types for a single type? need to error out?
     
     private final String globalObjectType;

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -25,7 +25,7 @@ public class ObjectTypeParsingRules {
     
     //TODO JAVADOC
     //TODO TEST
-    //TODO NNOW what if there are two parent types for a single type? need to error out?
+    //TODO IDXRULE what if there are two parent types for a single type? need to error out?
     
     private final String globalObjectType;
     private final String uiTypeName;
@@ -245,12 +245,19 @@ public class ObjectTypeParsingRules {
          */
         public Builder withIndexingRule(final IndexingRules rules) {
             Utils.nonNull(rules, "rules");
+            if (rules.isFromParent() && subObjectType == null) {
+                throw new IllegalArgumentException("Cannot supply an indexing rule that " +
+                        "extracts data from a parent to a rule set that applies to the parent");
+            }
             indexingRules.add(rules);
             return this;
         }
         
         /** Convert this rule set to a set that applies to a subobject of the parent object as
          * opposed to the parent object itself.
+         * Call this method before adding any indexing rules
+         * ({@link #withIndexingRule(IndexingRules)})
+         * where {@link IndexingRules#isFromParent()} is true.
          * @param subObjectType the local, search type of the subobject.
          * @param subObjectPath the path to the subobjects inside the parent object.
          * @param subObjectIDPath the path from the root of the subobject to the id to be used

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -1,26 +1,24 @@
 package kbasesearchengine.system;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import com.google.common.base.Optional;
 
 import kbasesearchengine.common.ObjectJsonPath;
-import kbasesearchengine.parse.ObjectParseException;
 import kbasesearchengine.tools.Utils;
-import us.kbase.common.service.UObject;
 
+/**
+ * 
+ * @see ObjectTypeParsingRulesUtils
+ * @author gaprice@lbl.gov
+ *
+ */
 public class ObjectTypeParsingRules {
     
     //TODO JAVADOC
     //TODO TEST
-    //TODO CODE not sure if throwing ObjectParseException makes sense here
     //TODO NNOW what if there are two parent types for a single type? need to error out?
     
     private final String globalObjectType;
@@ -79,124 +77,6 @@ public class ObjectTypeParsingRules {
     
     public Optional<ObjectJsonPath> getPrimaryKeyPath() {
         return primaryKeyPath;
-    }
-    
-    public static ObjectTypeParsingRules fromFile(final File file) 
-            throws ObjectParseException, IOException {
-        try (final InputStream is = new FileInputStream(file)) {
-            return fromStream(is, file.toString());
-        }
-    }
-
-    private static ObjectTypeParsingRules fromStream(InputStream is, String sourceInfo) 
-            throws IOException, ObjectParseException {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> obj = UObject.getMapper().readValue(is, Map.class);
-        return fromObject(obj, sourceInfo);
-    }
-
-    private static ObjectTypeParsingRules fromObject(
-            final Map<String, Object> obj,
-            final String sourceInfo) 
-            throws ObjectParseException {
-        try {
-            final String storageCode = (String)obj.get("storage-type");
-            final String type = (String)obj.get("storage-object-type");
-            if (Utils.isNullOrEmpty(storageCode)) {
-                throw new ObjectParseException(getMissingKeyParseMessage("storage-type"));
-            }
-            if (Utils.isNullOrEmpty(type)) {
-                throw new ObjectParseException(getMissingKeyParseMessage("storage-object-type"));
-            }
-            final Builder builder = ObjectTypeParsingRules.getBuilder(
-                    (String) obj.get("global-object-type"), //TODO CODE better error if missing
-                    new StorageObjectType(storageCode, type))
-                    .withNullableUITypeName((String)obj.get("ui-type-name"));
-            final String subType = (String)obj.get("inner-sub-type");
-            if (!Utils.isNullOrEmpty(subType)) {
-                builder.toSubObjectRule(
-                        //TODO CODE add checks to ensure these exist
-                        getPath((String)obj.get("path-to-sub-objects")),
-                        getPath((String)obj.get("primary-key-path")),
-                        subType);
-            } // throw exception if the other subobj values exist?
-            // Indexing
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> indexingRules =
-                    (List<Map<String, Object>>)obj.get("indexing-rules");
-            if (indexingRules != null) {
-                for (Map<String, Object> rulesObj : indexingRules) {
-                    builder.withIndexingRule(buildRule(rulesObj));
-                }
-            }
-            return builder.build();
-        } catch (ObjectParseException | IllegalArgumentException | NullPointerException e) {
-            throw new ObjectParseException(String.format("Error in source %s: %s",
-                    sourceInfo, e.getMessage()), e);
-        }
-    }
-
-    private static IndexingRules buildRule(
-            final Map<String, Object> rulesObj)
-            throws ObjectParseException {
-        final String path = (String) rulesObj.get("path");
-        final String keyName = (String) rulesObj.get("key-name");
-        final IndexingRules.Builder irBuilder;
-        if (Utils.isNullOrEmpty(path)) {
-            final String sourceKey = (String)rulesObj.get("source-key");
-            irBuilder = IndexingRules.fromSourceKey(sourceKey, keyName);
-        } else {
-            //TODO CODE throw exception if sourceKey != null?
-            irBuilder = IndexingRules.fromPath(new ObjectJsonPath(path));
-            if (!Utils.isNullOrEmpty(keyName)) {
-                irBuilder.withKeyName(keyName);
-            }
-        }
-        if (getBool((Boolean) rulesObj.get("from-parent"))) {
-            //TODO NNOW throw exception if not a sub type
-            irBuilder.withFromParent();
-        }
-        if (getBool(rulesObj.get("full-text"))) {
-            irBuilder.withFullText();
-        }
-        final String keywordType = (String)rulesObj.get("keyword-type");
-        if (!Utils.isNullOrEmpty(keywordType)) {
-            //TODO CODE throw an error if fullText is true?
-            irBuilder.withKeywordType(keywordType);
-        }
-        final String transform = (String) rulesObj.get("transform");
-        if (!Utils.isNullOrEmpty(transform)) {
-            final String subObjectIDKey = (String) rulesObj.get("subobject-id-key");
-            final String targetObjectType =
-                    (String) rulesObj.get("target-object-type");
-            final String[] tranSplt = transform.split("\\.", 2);
-            final String transProp = tranSplt.length == 1 ? null : tranSplt[1];
-            irBuilder.withTransform(Transform.unknown(
-                    tranSplt[0], transProp, targetObjectType, subObjectIDKey));
-        }
-        if (getBool(rulesObj.get("not-indexed"))) {
-            irBuilder.withNotIndexed();
-        }
-        irBuilder.withNullableDefaultValue(rulesObj.get("optional-default-value"));
-        irBuilder.withNullableUIName((String) rulesObj.get("ui-name"));
-        if (getBool(rulesObj.get("ui-hidden"))) {
-            irBuilder.withUIHidden();
-        }
-        irBuilder.withNullableUILinkKey((String) rulesObj.get("ui-link-key"));
-        return irBuilder.build();
-    }
-    
-    private static boolean getBool(final Object putativeBool) {
-        //TODO CODE precheck cast exception
-        return putativeBool != null && (Boolean) putativeBool; 
-    }
-    
-    private static String getMissingKeyParseMessage(final String key) {
-        return String.format("Missing key %s", key);
-    }
-
-    private static ObjectJsonPath getPath(String path) throws ObjectParseException {
-        return path == null ? null : new ObjectJsonPath(path);
     }
 
     @Override

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -9,6 +9,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Optional;
+
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.parse.ObjectParseException;
 import kbasesearchengine.tools.Utils;
@@ -16,18 +18,18 @@ import us.kbase.common.service.UObject;
 
 public class ObjectTypeParsingRules {
     
+    //TODO JAVADOC
     //TODO TEST
     //TODO CODE not sure if throwing ObjectParseException makes sense here
     //TODO NNOW what if there are two parent types for a single type? need to error out?
-    //TODO NNOW return optionals vs. nulls
     
     private final String globalObjectType;
     private final String uiTypeName;
     private final StorageObjectType storageObjectType;
-    private final String innerSubType;
-    private final ObjectJsonPath pathToSubObjects;
+    private final Optional<String> innerSubType;
+    private final Optional<ObjectJsonPath> pathToSubObjects;
     private final List<IndexingRules> indexingRules;
-    private final ObjectJsonPath primaryKeyPath;
+    private final Optional<ObjectJsonPath> primaryKeyPath;
     
     
     private ObjectTypeParsingRules(
@@ -45,10 +47,10 @@ public class ObjectTypeParsingRules {
         }
         this.uiTypeName = uiTypeName;
         this.storageObjectType = storageObjectType;
-        this.innerSubType = innerSubType;
-        this.pathToSubObjects = pathToSubObjects;
+        this.innerSubType = Optional.fromNullable(innerSubType);
+        this.pathToSubObjects = Optional.fromNullable(pathToSubObjects);
         this.indexingRules = Collections.unmodifiableList(indexingRules);
-        this.primaryKeyPath = primaryKeyPath;
+        this.primaryKeyPath = Optional.fromNullable(primaryKeyPath);
     }
 
     public String getGlobalObjectType() {
@@ -63,11 +65,11 @@ public class ObjectTypeParsingRules {
         return storageObjectType;
     }
     
-    public String getInnerSubType() {
+    public Optional<String> getInnerSubType() {
         return innerSubType;
     }
     
-    public ObjectJsonPath getPathToSubObjects() {
+    public Optional<ObjectJsonPath> getPathToSubObjects() {
         return pathToSubObjects;
     }
     
@@ -75,7 +77,7 @@ public class ObjectTypeParsingRules {
         return indexingRules;
     }
     
-    public ObjectJsonPath getPrimaryKeyPath() {
+    public Optional<ObjectJsonPath> getPrimaryKeyPath() {
         return primaryKeyPath;
     }
     

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -88,20 +88,14 @@ public class ObjectTypeParsingRules {
         }
     }
 
-    public static ObjectTypeParsingRules fromJson(String json) throws ObjectParseException {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> obj = UObject.transformStringToObject(json, Map.class);
-        return fromObject(obj, "json");
-    }
-
-    public static ObjectTypeParsingRules fromStream(InputStream is, String sourceInfo) 
+    private static ObjectTypeParsingRules fromStream(InputStream is, String sourceInfo) 
             throws IOException, ObjectParseException {
         @SuppressWarnings("unchecked")
         Map<String, Object> obj = UObject.getMapper().readValue(is, Map.class);
         return fromObject(obj, sourceInfo);
     }
 
-    public static ObjectTypeParsingRules fromObject(
+    private static ObjectTypeParsingRules fromObject(
             final Map<String, Object> obj,
             final String sourceInfo) 
             throws ObjectParseException {

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
@@ -1,0 +1,151 @@
+package kbasesearchengine.system;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import kbasesearchengine.common.ObjectJsonPath;
+import kbasesearchengine.parse.ObjectParseException;
+import kbasesearchengine.system.ObjectTypeParsingRules.Builder;
+import kbasesearchengine.tools.Utils;
+import us.kbase.common.service.UObject;
+
+/** Utilities for creating {@link ObjectTypeParsingRules} from various data sources.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class ObjectTypeParsingRulesUtils {
+
+    //TODO CODE not sure if throwing ObjectParseException makes sense here
+    //TODO TEST
+
+    /** Create an ObjectTypeParsingRules instance from a file.
+     * 
+     * TODO document the file structure.
+     * @param file the file containing the parsing rules.
+     * @return a new set of parsing rules.
+     * @throws ObjectParseException if the file contains erroneous parsing rules.
+     * @throws IOException if an IO error occurs reading the file.
+     */
+    public static ObjectTypeParsingRules fromFile(final File file) 
+            throws ObjectParseException, IOException {
+        try (final InputStream is = new FileInputStream(file)) {
+            return fromStream(is, file.toString());
+        }
+    }
+
+    private static ObjectTypeParsingRules fromStream(InputStream is, String sourceInfo) 
+            throws IOException, ObjectParseException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> obj = UObject.getMapper().readValue(is, Map.class);
+        return fromObject(obj, sourceInfo);
+    }
+
+    private static ObjectTypeParsingRules fromObject(
+            final Map<String, Object> obj,
+            final String sourceInfo) 
+            throws ObjectParseException {
+        try {
+            final String storageCode = (String)obj.get("storage-type");
+            final String type = (String)obj.get("storage-object-type");
+            if (Utils.isNullOrEmpty(storageCode)) {
+                throw new ObjectParseException(getMissingKeyParseMessage("storage-type"));
+            }
+            if (Utils.isNullOrEmpty(type)) {
+                throw new ObjectParseException(getMissingKeyParseMessage("storage-object-type"));
+            }
+            final Builder builder = ObjectTypeParsingRules.getBuilder(
+                    (String) obj.get("global-object-type"), //TODO CODE better error if missing
+                    new StorageObjectType(storageCode, type))
+                    .withNullableUITypeName((String)obj.get("ui-type-name"));
+            final String subType = (String)obj.get("inner-sub-type");
+            if (!Utils.isNullOrEmpty(subType)) {
+                builder.toSubObjectRule(
+                        //TODO CODE add checks to ensure these exist
+                        getPath((String)obj.get("path-to-sub-objects")),
+                        getPath((String)obj.get("primary-key-path")),
+                        subType);
+            } // throw exception if the other subobj values exist?
+            // Indexing
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> indexingRules =
+                    (List<Map<String, Object>>)obj.get("indexing-rules");
+            if (indexingRules != null) {
+                for (Map<String, Object> rulesObj : indexingRules) {
+                    builder.withIndexingRule(buildRule(rulesObj));
+                }
+            }
+            return builder.build();
+        } catch (ObjectParseException | IllegalArgumentException | NullPointerException e) {
+            throw new ObjectParseException(String.format("Error in source %s: %s",
+                    sourceInfo, e.getMessage()), e);
+        }
+    }
+
+    private static IndexingRules buildRule(
+            final Map<String, Object> rulesObj)
+            throws ObjectParseException {
+        final String path = (String) rulesObj.get("path");
+        final String keyName = (String) rulesObj.get("key-name");
+        final IndexingRules.Builder irBuilder;
+        if (Utils.isNullOrEmpty(path)) {
+            final String sourceKey = (String)rulesObj.get("source-key");
+            irBuilder = IndexingRules.fromSourceKey(sourceKey, keyName);
+        } else {
+            //TODO CODE throw exception if sourceKey != null?
+            irBuilder = IndexingRules.fromPath(new ObjectJsonPath(path));
+            if (!Utils.isNullOrEmpty(keyName)) {
+                irBuilder.withKeyName(keyName);
+            }
+        }
+        if (getBool((Boolean) rulesObj.get("from-parent"))) {
+            //TODO NNOW throw exception if not a sub type
+            irBuilder.withFromParent();
+        }
+        if (getBool(rulesObj.get("full-text"))) {
+            irBuilder.withFullText();
+        }
+        final String keywordType = (String)rulesObj.get("keyword-type");
+        if (!Utils.isNullOrEmpty(keywordType)) {
+            //TODO CODE throw an error if fullText is true?
+            irBuilder.withKeywordType(keywordType);
+        }
+        final String transform = (String) rulesObj.get("transform");
+        if (!Utils.isNullOrEmpty(transform)) {
+            final String subObjectIDKey = (String) rulesObj.get("subobject-id-key");
+            final String targetObjectType =
+                    (String) rulesObj.get("target-object-type");
+            final String[] tranSplt = transform.split("\\.", 2);
+            final String transProp = tranSplt.length == 1 ? null : tranSplt[1];
+            irBuilder.withTransform(Transform.unknown(
+                    tranSplt[0], transProp, targetObjectType, subObjectIDKey));
+        }
+        if (getBool(rulesObj.get("not-indexed"))) {
+            irBuilder.withNotIndexed();
+        }
+        irBuilder.withNullableDefaultValue(rulesObj.get("optional-default-value"));
+        irBuilder.withNullableUIName((String) rulesObj.get("ui-name"));
+        if (getBool(rulesObj.get("ui-hidden"))) {
+            irBuilder.withUIHidden();
+        }
+        irBuilder.withNullableUILinkKey((String) rulesObj.get("ui-link-key"));
+        return irBuilder.build();
+    }
+    
+    private static boolean getBool(final Object putativeBool) {
+        //TODO CODE precheck cast exception
+        return putativeBool != null && (Boolean) putativeBool; 
+    }
+    
+    private static String getMissingKeyParseMessage(final String key) {
+        return String.format("Missing key %s", key);
+    }
+
+    private static ObjectJsonPath getPath(String path) throws ObjectParseException {
+        return path == null ? null : new ObjectJsonPath(path);
+    }
+    
+}

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
@@ -64,10 +64,10 @@ public class ObjectTypeParsingRulesUtils {
             final String subType = (String)obj.get("inner-sub-type");
             if (!Utils.isNullOrEmpty(subType)) {
                 builder.toSubObjectRule(
+                        subType,
                         //TODO CODE add checks to ensure these exist
                         getPath((String)obj.get("path-to-sub-objects")),
-                        getPath((String)obj.get("primary-key-path")),
-                        subType);
+                        getPath((String)obj.get("primary-key-path")));
             } // throw exception if the other subobj values exist?
             // Indexing
             @SuppressWarnings("unchecked")

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
@@ -102,7 +102,6 @@ public class ObjectTypeParsingRulesUtils {
             }
         }
         if (getBool((Boolean) rulesObj.get("from-parent"))) {
-            //TODO NNOW throw exception if not a sub type
             irBuilder.withFromParent();
         }
         if (getBool(rulesObj.get("full-text"))) {

--- a/lib/src/kbasesearchengine/system/Transform.java
+++ b/lib/src/kbasesearchengine/system/Transform.java
@@ -30,8 +30,7 @@ public class Transform {
     private final Optional<LocationTransformType> location;
     private final Optional<String> targetKey;
     private final Optional<String> targetObjectType;
-    // TODO NNOW subobjectIdKey constrains the target type to be a subtype. Add a check in the creation context to check this. 
-    
+    // TODO IDXRULE subobjectIdKey constrains the target type to be a subtype. Add a check in the creation context to check this. 
     private final Optional<String> subObjectIdKey;
     
     private Transform(

--- a/lib/src/kbasesearchengine/system/TypeFileStorage.java
+++ b/lib/src/kbasesearchengine/system/TypeFileStorage.java
@@ -36,7 +36,8 @@ public class TypeFileStorage implements TypeStorage {
         // this is gross, but works. https://stackoverflow.com/a/20130475/643675
         for (Path file : (Iterable<Path>) Files.list(typesDir)::iterator) {
             if (Files.isRegularFile(file) && file.toString().endsWith(".json")) {
-                final ObjectTypeParsingRules type = ObjectTypeParsingRules.fromFile(file.toFile());
+                final ObjectTypeParsingRules type = ObjectTypeParsingRulesUtils
+                        .fromFile(file.toFile());
                 final String searchType = type.getGlobalObjectType();
                 if (typeToFile.containsKey(searchType)) {
                     throw new TypeParseException(String.format(

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -110,10 +110,8 @@ public class ElasticIndexingStorageTest {
             @Override
             public ObjectTypeParsingRules getTypeDescriptor(String type) {
                 try {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> parsingRulesObj = UObject.getMapper().readValue(
-                            new File("resources/types/" + type + ".json"), Map.class);
-                    return ObjectTypeParsingRules.fromObject(parsingRulesObj, "test");
+                    final File rulesFile = new File("resources/types/" + type + ".json");
+                    return ObjectTypeParsingRules.fromFile(rulesFile);
                 } catch (Exception ex) {
                     throw new IllegalStateException(ex);
                 }
@@ -162,14 +160,10 @@ public class ElasticIndexingStorageTest {
                 isPublic, indexingRules);
     }
     
-    @SuppressWarnings("unchecked")
     private static void indexObject(String type, String jsonResource, GUID ref, String objName)
             throws Exception {
         final File file = new File("resources/types/" + type + ".json");
-        Map<String, Object> parsingRulesObj = UObject.getMapper().readValue(
-                file, Map.class);
-        ObjectTypeParsingRules parsingRules = ObjectTypeParsingRules
-                .fromObject(parsingRulesObj, file.toString());
+        ObjectTypeParsingRules parsingRules = ObjectTypeParsingRules.fromFile(file);
         Map<ObjectJsonPath, String> pathToJson = new LinkedHashMap<>();
         SubObjectConsumer subObjConsumer = new SimpleSubObjectConsumer(pathToJson);
         String parentJson = null;

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -50,6 +50,7 @@ import kbasesearchengine.search.ObjectData;
 import kbasesearchengine.search.PostProcessing;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.ObjectTypeParsingRulesUtils;
 import kbasesearchengine.test.common.TestCommon;
 import kbasesearchengine.test.controllers.elasticsearch.ElasticSearchController;
 import kbasesearchengine.test.parse.SubObjectExtractorTest;
@@ -111,7 +112,7 @@ public class ElasticIndexingStorageTest {
             public ObjectTypeParsingRules getTypeDescriptor(String type) {
                 try {
                     final File rulesFile = new File("resources/types/" + type + ".json");
-                    return ObjectTypeParsingRules.fromFile(rulesFile);
+                    return ObjectTypeParsingRulesUtils.fromFile(rulesFile);
                 } catch (Exception ex) {
                     throw new IllegalStateException(ex);
                 }
@@ -163,7 +164,7 @@ public class ElasticIndexingStorageTest {
     private static void indexObject(String type, String jsonResource, GUID ref, String objName)
             throws Exception {
         final File file = new File("resources/types/" + type + ".json");
-        ObjectTypeParsingRules parsingRules = ObjectTypeParsingRules.fromFile(file);
+        ObjectTypeParsingRules parsingRules = ObjectTypeParsingRulesUtils.fromFile(file);
         Map<ObjectJsonPath, String> pathToJson = new LinkedHashMap<>();
         SubObjectConsumer subObjConsumer = new SimpleSubObjectConsumer(pathToJson);
         String parentJson = null;

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -177,9 +177,9 @@ public class ElasticIndexingStorageTest {
         for (ObjectJsonPath path : pathToJson.keySet()) {
             String subJson = pathToJson.get(path);
             SimpleIdConsumer idConsumer = new SimpleIdConsumer();
-            if (parsingRules.getPrimaryKeyPath().isPresent()) {
+            if (parsingRules.getSubObjectIDPath().isPresent()) {
                 try (JsonParser subJts = UObject.getMapper().getFactory().createParser(subJson)) {
-                    IdMapper.mapKeys(parsingRules.getPrimaryKeyPath().get(), subJts, idConsumer);
+                    IdMapper.mapKeys(parsingRules.getSubObjectIDPath().get(), subJts, idConsumer);
                 }
             }
             GUID id = ObjectParser.prepareGUID(parsingRules, ref, path, idConsumer);

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -182,9 +182,9 @@ public class ElasticIndexingStorageTest {
         for (ObjectJsonPath path : pathToJson.keySet()) {
             String subJson = pathToJson.get(path);
             SimpleIdConsumer idConsumer = new SimpleIdConsumer();
-            if (parsingRules.getPrimaryKeyPath() != null) {
+            if (parsingRules.getPrimaryKeyPath().isPresent()) {
                 try (JsonParser subJts = UObject.getMapper().getFactory().createParser(subJson)) {
-                    IdMapper.mapKeys(parsingRules.getPrimaryKeyPath(), subJts, idConsumer);
+                    IdMapper.mapKeys(parsingRules.getPrimaryKeyPath().get(), subJts, idConsumer);
                 }
             }
             GUID id = ObjectParser.prepareGUID(parsingRules, ref, path, idConsumer);

--- a/test/src/kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java
+++ b/test/src/kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java
@@ -1,0 +1,219 @@
+package kbasesearchengine.test.system;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+
+import kbasesearchengine.common.ObjectJsonPath;
+import kbasesearchengine.system.IndexingRules;
+import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.StorageObjectType;
+import kbasesearchengine.test.common.TestCommon;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class ObjectTypeParsingRulesTest {
+
+    @Test
+    public void equals() {
+        EqualsVerifier.forClass(ObjectTypeParsingRules.class).usingGetClass().verify();
+    }
+    
+    @Test
+    public void buildMinimal() {
+        final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
+                "foo", new StorageObjectType("bar", "baz"))
+                .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
+                .build();
+        
+        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
+        assertThat("incorrect storage type", r.getStorageObjectType(),
+                is(new StorageObjectType("bar", "baz")));
+        assertThat("incorrect index rules", r.getIndexingRules(), is(Arrays.asList(
+                IndexingRules.fromSourceKey("k", "n").build())));
+        assertThat("incorrect subobj type", r.getSubObjectType(), is(Optional.absent()));
+        assertThat("incorrect subobj path", r.getSubObjectPath(), is(Optional.absent()));
+        assertThat("incorrect subobj id path", r.getSubObjectIDPath(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void buildWithUIName() {
+        final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
+                "foo", new StorageObjectType("bar", "baz"))
+                .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
+                .withNullableUITypeName("whee whoo")
+                .build();
+        
+        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect UI name", r.getUiTypeName(), is("whee whoo"));
+        assertThat("incorrect storage type", r.getStorageObjectType(),
+                is(new StorageObjectType("bar", "baz")));
+        assertThat("incorrect index rules", r.getIndexingRules(), is(Arrays.asList(
+                IndexingRules.fromSourceKey("k", "n").build())));
+        assertThat("incorrect subobj type", r.getSubObjectType(), is(Optional.absent()));
+        assertThat("incorrect subobj path", r.getSubObjectPath(), is(Optional.absent()));
+        assertThat("incorrect subobj id path", r.getSubObjectIDPath(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void buildSubObjectRules() throws Exception {
+        // also tests indexing rule with from parent happy path
+        final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
+                "foo", new StorageObjectType("bar", "baz"))
+                .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
+                .toSubObjectRule("sotype", new ObjectJsonPath("path"),
+                        new ObjectJsonPath("idpath"))
+                .withIndexingRule(IndexingRules.fromPath(new ObjectJsonPath("wugga"))
+                        .withFromParent().build())
+                .build();
+        
+        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
+        assertThat("incorrect storage type", r.getStorageObjectType(),
+                is(new StorageObjectType("bar", "baz")));
+        assertThat("incorrect index rules", r.getIndexingRules(), is(Arrays.asList(
+                IndexingRules.fromSourceKey("k", "n").build(),
+                IndexingRules.fromPath(new ObjectJsonPath("wugga"))
+                        .withFromParent().build())));
+        assertThat("incorrect subobj type", r.getSubObjectType(), is(Optional.of("sotype")));
+        assertThat("incorrect subobj path", r.getSubObjectPath(),
+                is(Optional.of(new ObjectJsonPath("path"))));
+        assertThat("incorrect subobj id path", r.getSubObjectIDPath(),
+                is(Optional.of(new ObjectJsonPath("idpath"))));
+    }
+    
+    @Test
+    public void buildWithUINameNullOrWhitespace() {
+        buildWithUITypeNameNullOrWhitespace(null);
+        buildWithUITypeNameNullOrWhitespace("  \t   \n  ");
+    }
+
+    private void buildWithUITypeNameNullOrWhitespace(final String uiTypeName) {
+        final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
+                "foo", new StorageObjectType("bar", "baz"))
+                .withNullableUITypeName(uiTypeName)
+                .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
+                .build();
+        
+        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
+        assertThat("incorrect storage type", r.getStorageObjectType(),
+                is(new StorageObjectType("bar", "baz")));
+        assertThat("incorrect index rules", r.getIndexingRules(), is(Arrays.asList(
+                IndexingRules.fromSourceKey("k", "n").build())));
+        assertThat("incorrect subobj type", r.getSubObjectType(), is(Optional.absent()));
+        assertThat("incorrect subobj path", r.getSubObjectPath(), is(Optional.absent()));
+        assertThat("incorrect subobj id path", r.getSubObjectIDPath(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void builderSize() {
+        final ObjectTypeParsingRules.Builder b = ObjectTypeParsingRules.getBuilder(
+                "foo", new StorageObjectType("bar", "baz"));
+        
+        assertThat("incorrect size", b.numberOfIndexingRules(), is(0));
+        
+        b.withIndexingRule(IndexingRules.fromSourceKey("k", "n").build());
+        assertThat("incorrect size", b.numberOfIndexingRules(), is(1));
+        
+        b.withIndexingRule(IndexingRules.fromSourceKey("l", "o").build());
+        assertThat("incorrect size", b.numberOfIndexingRules(), is(2));
+    }
+    
+    @Test
+    public void getBuilderFail() {
+        failGetBuilder(null, new StorageObjectType("c", "t"),
+                new IllegalArgumentException("globalObjectType cannot be null or whitespace"));
+        failGetBuilder("  \t   \n ", new StorageObjectType("c", "t"),
+                new IllegalArgumentException("globalObjectType cannot be null or whitespace"));
+        failGetBuilder("t", null, new NullPointerException("storageType"));
+    }
+    
+    private void failGetBuilder(
+            final String globalObjectType,
+            final StorageObjectType storageType,
+            final Exception expected) {
+        try {
+            ObjectTypeParsingRules.getBuilder(globalObjectType, storageType);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void withIndexingRuleFail() {
+        failWithIndexingRule(null, new NullPointerException("rules"));
+        failWithIndexingRule(IndexingRules.fromSourceKey("k", "n").withFromParent().build(),
+                new IllegalArgumentException("Cannot supply an indexing rule that extracts data " +
+                        "from a parent to a rule set that applies to the parent"));
+    }
+    
+    private void failWithIndexingRule(final IndexingRules rule, final Exception expected) {
+        try {
+            ObjectTypeParsingRules.getBuilder("t", new StorageObjectType("c", "t"))
+                    .withIndexingRule(rule);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void toSubObjectRuleFail() throws Exception {
+        final ObjectJsonPath p = new ObjectJsonPath("foo");
+        failToSubObjectRule(null, p, p, new IllegalArgumentException(
+                "subObjectType cannot be null or whitespace"));
+        failToSubObjectRule("   \t   \n  ", p, p, new IllegalArgumentException(
+                "subObjectType cannot be null or whitespace"));
+        failToSubObjectRule("t", null, p, new NullPointerException("subObjectPath"));
+        failToSubObjectRule("t", p, null, new NullPointerException("subObjectIDPath"));
+    }
+    
+    private void failToSubObjectRule(
+            final String subObjectType,
+            final ObjectJsonPath subObjectPath,
+            final ObjectJsonPath subObjectIDPath,
+            final Exception expected) {
+        try {
+            ObjectTypeParsingRules.getBuilder("t", new StorageObjectType("c", "t"))
+                    .toSubObjectRule(subObjectType, subObjectPath, subObjectIDPath);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+    @Test
+    public void buildFail() {
+        try {
+            ObjectTypeParsingRules.getBuilder("t", new StorageObjectType("c", "t")).build();
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, new IllegalStateException(
+                    "Must supply at least one indexing rule"));
+        }
+    }
+    
+    @Test
+    public void immutable() {
+        final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
+                "foo", new StorageObjectType("bar", "baz"))
+                .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
+                .build();
+        
+        try {
+            r.getIndexingRules().add(IndexingRules.fromSourceKey("k", "n").build());
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, new UnsupportedOperationException());
+        }
+    }
+    
+}


### PR DESCRIPTION
* immutable
* fluent builder
* constraints enforced at build time rather than later in various places in the code
* defaults set at build time rather than calculated later in various places in the code
* no nulls returned from API
* split secondary utility code that builds OTPRs from various input sources into a separate class for cohesivity of the core OTPR value class
* rename methods to better reflect fuction
