### PR TITLE
SCT-157 Fix subobject ID mangling bug

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -170,6 +170,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
             <include name="kbasesearchengine/test/system/TypeMappingTest.java"/>
             <include name="kbasesearchengine/test/system/TransformTest.java"/>
             <include name="kbasesearchengine/test/main/IndexerCoordinatorTest.java"/>
+            <include name="kbasesearchengine/test/main/IndexerWorkerTest.java"/>
           </fileset>
         </batchtest>
       </junit>

--- a/lib/src/kbasesearchengine/parse/ObjectParser.java
+++ b/lib/src/kbasesearchengine/parse/ObjectParser.java
@@ -32,10 +32,12 @@ public class ObjectParser {
             final GUID guid, 
             final ObjectTypeParsingRules parsingRules)
             throws IOException, ObjectParseException, IndexingException, InterruptedException {
+        /* note that in opposition to the name, objects with no subobject specs get run through
+         * this method.
+         */
         Map<ObjectJsonPath, String> pathToJson = new LinkedHashMap<>();
-        SubObjectConsumer subObjConsumer = new SimpleSubObjectConsumer(pathToJson);
         try (JsonParser jts = obj.getData().getPlacedStream()) {
-            extractSubObjects(parsingRules, subObjConsumer, jts);
+            extractSubObjects(parsingRules, new SimpleSubObjectConsumer(pathToJson), jts);
         }
         Map<GUID, String> guidToJson = new LinkedHashMap<>();
         for (ObjectJsonPath path : pathToJson.keySet()) {
@@ -44,6 +46,15 @@ public class ObjectParser {
             if (parsingRules.getSubObjectIDPath().isPresent()) {
                 try (JsonParser subJts = UObject.getMapper().getFactory().createParser(subJson)) {
                     IdMapper.mapKeys(parsingRules.getSubObjectIDPath().get(), subJts, idConsumer);
+                }
+                /* if this if block is outside the parent if block, standard objects without
+                 * subobjects fail to parse
+                 */
+                if (idConsumer.getPrimaryKey() == null) {
+                    throw new ObjectParseException(String.format(
+                            "Could not find the subobject id for one or more of the subobjects " +
+                                    "for object %s when applying search specification %s",
+                                    guid, parsingRules.getGlobalObjectType())); 
                 }
             }
             GUID subid = prepareGUID(parsingRules, guid, path, idConsumer);

--- a/lib/src/kbasesearchengine/parse/ParsedObject.java
+++ b/lib/src/kbasesearchengine/parse/ParsedObject.java
@@ -4,6 +4,57 @@ import java.util.List;
 import java.util.Map;
 
 public class ParsedObject {
+    
+    //TODO CODE everything about this class
+    
     public String json;
     public Map<String, List<Object>> keywords;
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((json == null) ? 0 : json.hashCode());
+        result = prime * result
+                + ((keywords == null) ? 0 : keywords.hashCode());
+        return result;
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ParsedObject other = (ParsedObject) obj;
+        if (json == null) {
+            if (other.json != null) {
+                return false;
+            }
+        } else if (!json.equals(other.json)) {
+            return false;
+        }
+        if (keywords == null) {
+            if (other.keywords != null) {
+                return false;
+            }
+        } else if (!keywords.equals(other.keywords)) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ParsedObject [json=");
+        builder.append(json);
+        builder.append(", keywords=");
+        builder.append(keywords);
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -24,6 +24,7 @@ import kbasesearchengine.tools.Utils;
 public class ObjectTypeParsingRules {
     
     //TODO IDXRULE what if there are two parent types for a single type? need to error out?
+    //TODO IDXRULE if subobject spec, there must be a path based indexing rule that matches the subobject id path. Make this automatic in some way?
     
     private final String globalObjectType;
     private final String uiTypeName;

--- a/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
@@ -1,0 +1,159 @@
+package kbasesearchengine.test.main;
+
+import static kbasesearchengine.test.common.TestCommon.set;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import kbasesearchengine.common.GUID;
+import kbasesearchengine.common.ObjectJsonPath;
+import kbasesearchengine.events.StatusEvent;
+import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.handler.EventHandler;
+import kbasesearchengine.events.handler.SourceData;
+import kbasesearchengine.events.storage.StatusEventStorage;
+import kbasesearchengine.main.IndexerWorker;
+import kbasesearchengine.main.LineLogger;
+import kbasesearchengine.parse.ParsedObject;
+import kbasesearchengine.search.IndexingStorage;
+import kbasesearchengine.system.IndexingRules;
+import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.StorageObjectType;
+import kbasesearchengine.system.TypeStorage;
+import kbasesearchengine.test.common.TestCommon;
+import us.kbase.common.service.UObject;
+
+public class IndexerWorkerTest {
+    
+    //TODO TEST add more worker tests
+    
+    /* these are strictly unit tests. */
+    
+    @Test
+    public void idManglingBugPass() throws Exception {
+        /* tests a bug where subobject ids would be mangled when primary-key-path was not
+         * present or incorrect in the spec, or there was no indexing rule that caused the
+         * primary-key-path part of the subobject to be extracted.
+         * This is a happy path test where everything is right.
+         */
+        
+        final Map<String, Object> data = ImmutableMap.of(
+                "thingy", 1,
+                "thingy2", "foo",
+                "subobjs", Arrays.asList(
+                        ImmutableMap.of("id", "an id", "somedata", "data"),
+                        ImmutableMap.of("id", "an id2", "somedata", "data2")
+                        )
+                );
+        
+        final EventHandler ws = mock(EventHandler.class);
+        final StatusEventStorage storage = mock(StatusEventStorage.class);
+        final IndexingStorage idxStore = mock(IndexingStorage.class);
+        final TypeStorage typeStore = mock(TypeStorage.class);
+        final LineLogger logger = mock(LineLogger.class);
+        
+        final Path tempDir = Paths.get(TestCommon.getTempDir()).toAbsolutePath()
+                .resolve("IndexerWorkerTest");
+        deleteRecursively(tempDir);
+        
+        when(ws.getStorageCode()).thenReturn("code");
+        
+        final IndexerWorker worker = new IndexerWorker(
+                "myid", Arrays.asList(ws), storage, idxStore, typeStore, tempDir.toFile(), logger);
+        
+        final GUID guid = new GUID("code:1/2/3");
+        when(idxStore.checkParentGuidsExist(set(guid))).thenReturn(ImmutableMap.of(guid, false));
+        
+        when(ws.load(eq(Arrays.asList(guid)), any(Path.class)))
+                .thenAnswer(new Answer<SourceData>() {
+
+                        @Override
+                        public SourceData answer(final InvocationOnMock inv) throws Throwable {
+                            final Path path = inv.getArgument(1);
+                            new ObjectMapper().writeValue(path.toFile(), data);
+                            return SourceData.getBuilder(
+                                    new UObject(path.toFile()), "myobj", "somedude")
+                                    .withNullableMD5("md5")
+                                    .build();
+                        }
+        });
+
+        final StorageObjectType storageObjectType = StorageObjectType
+                .fromNullableVersion("code", "sometype", 3);
+        
+        when(typeStore.listObjectTypesByStorageObjectType(storageObjectType))
+                .thenReturn(Arrays.asList(
+                        ObjectTypeParsingRules.getBuilder("foo", storageObjectType)
+                                .toSubObjectRule("subfoo", new ObjectJsonPath("/subobjs/[*]/"),
+                                        new ObjectJsonPath("id"))
+                                .withIndexingRule(IndexingRules.fromPath(
+                                        new ObjectJsonPath("somedata"))
+                                        .build())
+                                .withIndexingRule(IndexingRules.fromPath(new ObjectJsonPath("id"))
+                                        .build())
+                                .build()));
+        
+        worker.processOneEvent(StatusEvent.getBuilder(
+                storageObjectType,
+                Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                .withNullableAccessGroupID(1)
+                .withNullableObjectID("2")
+                .withNullableVersion(3)
+                .withNullableisPublic(false)
+                .build());
+        
+        final ParsedObject po1 = new ParsedObject();
+        po1.json = new ObjectMapper().writeValueAsString(
+                ImmutableMap.of( "id", "an id", "somedata", "data"));
+        po1.keywords = ImmutableMap.of("somedata", Arrays.asList("data"),
+                "id", Arrays.asList("an id"));
+        final ParsedObject po2 = new ParsedObject();
+        po2.json = new ObjectMapper().writeValueAsString(
+                ImmutableMap.of("id", "an id2", "somedata", "data2"));
+        po2.keywords = ImmutableMap.of("somedata", Arrays.asList("data2"),
+                "id", Arrays.asList("an id2"));
+        
+        verify(idxStore).indexObjects(
+                eq("foo"),
+                any(SourceData.class),
+                eq(Instant.ofEpochMilli(10000)),
+                eq(null),
+                eq(guid),
+                eq(ImmutableMap.of(
+                        new GUID(guid, "subfoo", "an id2"), po2,
+                        new GUID(guid, "subfoo", "an id"), po1)),
+                eq(false),
+                eq(Arrays.asList(
+                        IndexingRules.fromPath(new ObjectJsonPath("somedata")).build(),
+                        IndexingRules.fromPath(new ObjectJsonPath("id")).build())));
+    }
+    
+    private void deleteRecursively(final Path path) throws Exception {
+        // https://stackoverflow.com/a/35989142/643675
+        if (Files.exists(path)) {
+            Files.walk(path)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+    }
+
+}


### PR DESCRIPTION
It turns out that the 'bug' was as designed. When creating GUIDs for subobjects, if the parsing code can't find an id for the subobject, as a default it uses the path to the subobject, including the leading slash, in the parent object as an id for the last portion of the GUID (e.g. WS:1/2/3:AssemblyContig/[id]).

The problem is that this behavior occurs if the id can't be found for any reason, including if there are unintentional errors in the spec. Things I've found so far that can cause the default behavior include:
1) leaving out primary-id-path
2) misspelling primary-id-path
3) misspelling the value of primary-id-path
4) not including an indexing rule that causes the value of the key at primary-id-path to be extracted
5) including an indexing rule with an error such that the key does not get extracted

Hence, this PR removes the ability to use the path to the subobject as an ID and the code will now throw an error if an id for a subobject cannot be found. No specs provided in the repo use the path based id. If the path based id is needed in the future, it should be explicitly set in the spec rather than occurring silently.