### PR TITLE
SCT-178 Add a version int to search types

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -167,6 +167,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
             <include name="kbasesearchengine/test/search/ElasticIndexingStorageTest.java"/>
             <include name="kbasesearchengine/test/system/IndexingRulesTest.java"/>
             <include name="kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java"/>
+            <include name="kbasesearchengine/test/system/SearchObjectTypeTest.java"/>
             <include name="kbasesearchengine/test/system/StorageObjectTypeTest.java"/>
             <include name="kbasesearchengine/test/system/TypeMappingTest.java"/>
             <include name="kbasesearchengine/test/system/TransformTest.java"/>

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -47,6 +47,7 @@ import kbasesearchengine.parse.ParsedObject;
 import kbasesearchengine.parse.KeywordParser.ObjectLookupProvider;
 import kbasesearchengine.search.IndexingStorage;
 import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.StorageObjectType;
 import kbasesearchengine.system.TypeStorage;
 import kbasesearchengine.tools.Utils;
@@ -500,19 +501,23 @@ public class IndexerWorker implements Stoppable {
                 final ParseObjectsRet parsedRet = parseObjects(guid, indexLookup,
                         newRefPath, obj, rule);
                 long parsingTime = System.currentTimeMillis() - t2;
-                logger.logInfo("[Indexer]   " + rule.getGlobalObjectType() + ", parsing " +
-                        "time: " + parsingTime + " ms.");
+                logger.logInfo("[Indexer]   " + toVerRep(rule.getGlobalObjectType()) +
+                        ", parsing time: " + parsingTime + " ms.");
                 long t3 = System.currentTimeMillis();
                 indexObjectInStorage(guid, timestamp, isPublic, obj, rule,
                         parsedRet.guidToObj, parsedRet.parentJson);
                 long indexTime = System.currentTimeMillis() - t3;
-                logger.logInfo("[Indexer]   " + rule.getGlobalObjectType() + ", indexing " +
-                        "time: " + indexTime + " ms.");
+                logger.logInfo("[Indexer]   " + toVerRep(rule.getGlobalObjectType()) +
+                        ", indexing time: " + indexTime + " ms.");
                 logger.timeStat(guid, 0, parsingTime, indexTime);
             }
         } finally {
             tempFile.delete();
         }
+    }
+
+    private String toVerRep(final SearchObjectType globalObjectType) {
+        return globalObjectType.getType() + "_" + globalObjectType.getVersion();
     }
 
     private void indexObjectInStorage(

--- a/lib/src/kbasesearchengine/main/SearchMethods.java
+++ b/lib/src/kbasesearchengine/main/SearchMethods.java
@@ -35,6 +35,7 @@ import kbasesearchengine.search.FoundHits;
 import kbasesearchengine.search.IndexingStorage;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.TypeStorage;
 import us.kbase.common.service.UObject;
 
@@ -278,8 +279,9 @@ public class SearchMethods {
         kbasesearchengine.search.Pagination pagination = toSearch(params.getPagination());
         kbasesearchengine.search.PostProcessing postProcessing = 
                 toSearch(params.getPostProcessing());
-        FoundHits hits = indexingStorage.searchObjects(params.getObjectType(), matchFilter, 
-                sorting, accessFilter, pagination, postProcessing);
+        FoundHits hits = indexingStorage.searchObjects(
+                new SearchObjectType(params.getObjectType(), 1), //TODO VERS specify that all versions should be searched
+                matchFilter, sorting, accessFilter, pagination, postProcessing);
         SearchObjectsOutput ret = new SearchObjectsOutput();
         ret.withPagination(fromSearch(hits.pagination));
         ret.withSortingRules(hits.sortingRules.stream().map(this::fromSearch).collect(
@@ -323,7 +325,7 @@ public class SearchMethods {
     public Map<String, TypeDescriptor> listTypes(String uniqueType) throws Exception {
         Map<String, TypeDescriptor> ret = new LinkedHashMap<>();
         for (ObjectTypeParsingRules otpr : typeStorage.listObjectTypes()) {
-            String typeName = otpr.getGlobalObjectType();
+            String typeName = otpr.getGlobalObjectType().getType();
             if (uniqueType != null && !uniqueType.equals(typeName)) {
                 continue;
             }

--- a/lib/src/kbasesearchengine/parse/KeywordParser.java
+++ b/lib/src/kbasesearchengine/parse/KeywordParser.java
@@ -20,6 +20,7 @@ import kbasesearchengine.search.ObjectData;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.LocationTransformType;
 import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.Transform;
 import kbasesearchengine.tools.Utils;
 import us.kbase.common.service.UObject;
@@ -29,7 +30,7 @@ public class KeywordParser {
     //TODO EXP handle all exceptions
     
     public static ParsedObject extractKeywords(
-            final String type,
+            final SearchObjectType searchObjectType,
             final String json,
             final String parentJson,
             final List<IndexingRules> indexingRules, 
@@ -48,7 +49,7 @@ public class KeywordParser {
             public void addValue(List<IndexingRules> rulesList, Object value)
                     throws IndexingException, InterruptedException, ObjectParseException {
                 for (IndexingRules rule : rulesList) {
-                    processRule(type, rule, rule.getKeyName(), value, keywords, lookup, 
+                    processRule(rule, rule.getKeyName(), value, keywords, lookup, 
                             objectRefPath);
                 }
             }
@@ -68,7 +69,7 @@ public class KeywordParser {
                     List<Object> values = keywords.containsKey(key) ? keywords.get(key).values : 
                         null;
                     if (isEmpty(values)) {
-                        processRule(type, rule, key, null, keywords, lookup, objectRefPath);
+                        processRule(rule, key, null, keywords, lookup, objectRefPath);
                     }
                 }
             }
@@ -76,7 +77,7 @@ public class KeywordParser {
         for (String key : ruleMap.keySet()) {
             for (IndexingRules rule : ruleMap.get(key)) {
                 if (rule.isDerivedKey()) {
-                    processDerivedRule(type, key, rule, ruleMap, keywords, lookup, 
+                    processDerivedRule(searchObjectType, key, rule, ruleMap, keywords, lookup, 
                             new LinkedHashSet<>(), objectRefPath);
                 }
             }
@@ -88,53 +89,66 @@ public class KeywordParser {
         return ret;
     }
 
-    private static List<Object> processDerivedRule(String type, 
-            Map<String, List<IndexingRules>> ruleMap, String key, 
-            Map<String, InnerKeyValue> keywords, ObjectLookupProvider lookup, 
-            Set<String> keysWaitingInStack, List<GUID> callerRefPath)
+    private static List<Object> processDerivedRule(
+            final SearchObjectType searchObjectType, 
+            final Map<String, List<IndexingRules>> ruleMap,
+            final String key, 
+            final Map<String, InnerKeyValue> keywords,
+            final ObjectLookupProvider lookup, 
+            final Set<String> keysWaitingInStack,
+            final List<GUID> callerRefPath)
             throws IndexingException, InterruptedException, ObjectParseException {
         if (!ruleMap.containsKey(key)) {
             throw new IllegalStateException("Unknown source-key in derived keywords: " + 
-                    type + "/" + key);
+                    toVerRep(searchObjectType) + "/" + key);
         }
         List<Object> ret = null;
         for (IndexingRules rule : ruleMap.get(key)) {
-            ret = processDerivedRule(type, key, rule, ruleMap, keywords, lookup, 
+            ret = processDerivedRule(searchObjectType, key, rule, ruleMap, keywords, lookup, 
                     keysWaitingInStack, callerRefPath);
         }
         return ret;
     }
     
-    private static List<Object> processDerivedRule(String type, String key, IndexingRules rule,
-            Map<String, List<IndexingRules>> ruleMap, Map<String, InnerKeyValue> keywords, 
-            ObjectLookupProvider lookup, Set<String> keysWaitingInStack,
-            List<GUID> objectRefPath)
+    private static String toVerRep(final SearchObjectType searchObjectType) {
+        return searchObjectType.getType() + "_" + searchObjectType.getVersion();
+    }
+
+    private static List<Object> processDerivedRule(
+            final SearchObjectType searchObjectType,
+            final String key,
+            final IndexingRules rule,
+            final Map<String, List<IndexingRules>> ruleMap,
+            final Map<String, InnerKeyValue> keywords, 
+            final ObjectLookupProvider lookup,
+            final Set<String> keysWaitingInStack,
+            final List<GUID> objectRefPath)
             throws IndexingException, InterruptedException, ObjectParseException {
         if (!ruleMap.containsKey(key) || rule == null) {
             throw new IllegalStateException("Unknown source-key in derived keywords: " + 
-                    type + "/" + key);
+                    toVerRep(searchObjectType) + "/" + key);
         }
         if (keywords.containsKey(key)) {
             return keywords.get(key).values;
         }
         if (keysWaitingInStack.contains(key)) {
             throw new IllegalStateException("Circular dependency in derived keywords: " +
-                    type + " / " + keysWaitingInStack);
+                    toVerRep(searchObjectType) + " / " + keysWaitingInStack);
         }
         if (!rule.isDerivedKey()) {
             throw new IllegalStateException("Reference to not derived keyword with no value: " +
-                    type + "/" + key);
+                    toVerRep(searchObjectType) + "/" + key);
         }
         keysWaitingInStack.add(key);
-        List<Object> values = processDerivedRule(type, ruleMap, rule.getSourceKey().get(),
+        List<Object> values = processDerivedRule(searchObjectType, ruleMap, rule.getSourceKey().get(),
                 keywords, lookup, keysWaitingInStack, objectRefPath);
         if (rule.getTransform().isPresent() &&
                 rule.getTransform().get().getSubobjectIdKey().isPresent()) {
-            processDerivedRule(type, ruleMap, rule.getTransform().get().getSubobjectIdKey().get(),
+            processDerivedRule(searchObjectType, ruleMap, rule.getTransform().get().getSubobjectIdKey().get(),
                     keywords, lookup, keysWaitingInStack, objectRefPath);
         }
         for (Object value : values) {
-            processRule(type, rule, key, value, keywords, lookup, objectRefPath);
+            processRule(rule, key, value, keywords, lookup, objectRefPath);
         }
         keysWaitingInStack.remove(key);
         List<Object> ret = keywords.containsKey(key) ? keywords.get(key).values : new ArrayList<>();
@@ -148,9 +162,13 @@ public class KeywordParser {
         return value == null || (value instanceof List && ((List<?>)value).isEmpty());
     }
     
-    private static void processRule(String type, IndexingRules rule, String key, Object value,
-            Map<String, InnerKeyValue> keywords, ObjectLookupProvider lookup,
-            List<GUID> objectRefPath)
+    private static void processRule(
+            final IndexingRules rule,
+            final String key,
+            final Object value,
+            final Map<String, InnerKeyValue> keywords,
+            final ObjectLookupProvider lookup,
+            final List<GUID> objectRefPath)
             throws IndexingException, InterruptedException, ObjectParseException {
         Object valueFinal = value;
         if (valueFinal == null) {

--- a/lib/src/kbasesearchengine/parse/ObjectParser.java
+++ b/lib/src/kbasesearchengine/parse/ObjectParser.java
@@ -53,8 +53,9 @@ public class ObjectParser {
                 if (idConsumer.getPrimaryKey() == null) {
                     throw new ObjectParseException(String.format(
                             "Could not find the subobject id for one or more of the subobjects " +
-                                    "for object %s when applying search specification %s",
-                                    guid, parsingRules.getGlobalObjectType())); 
+                                    "for object %s when applying search specification %s_%s",
+                                    guid, parsingRules.getGlobalObjectType().getType(),
+                                    parsingRules.getGlobalObjectType().getVersion())); 
                 }
             }
             GUID subid = prepareGUID(parsingRules, guid, path, idConsumer);

--- a/lib/src/kbasesearchengine/search/IndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/IndexingStorage.java
@@ -10,6 +10,7 @@ import kbasesearchengine.common.GUID;
 import kbasesearchengine.events.handler.SourceData;
 import kbasesearchengine.parse.ParsedObject;
 import kbasesearchengine.system.IndexingRules;
+import kbasesearchengine.system.SearchObjectType;
 
 public interface IndexingStorage {
     
@@ -26,16 +27,18 @@ public interface IndexingStorage {
      * @param indexingRules  indexing rules
      * @throws IOException
      */
-    public void indexObject(GUID guid, String objectType, ParsedObject obj, SourceData source,
+    public void indexObject(GUID guid, SearchObjectType objectType, ParsedObject obj, SourceData source,
             Instant timestamp, String parentJsonValue, boolean isPublic,
             List<IndexingRules> indexingRules) throws IOException;
 
-    public void indexObjects(String objectType, SourceData obj, Instant timestamp,
+    public void indexObjects(SearchObjectType objectType, SourceData obj, Instant timestamp,
             String parentJsonValue, GUID pguid, Map<GUID, ParsedObject> idToObj,
             boolean isPublic, List<IndexingRules> indexingRules) 
                     throws IOException;
     
-    public Map<GUID, Boolean> checkParentGuidsExist(String objectType, Set<GUID> parentGuids) 
+    public Map<GUID, Boolean> checkParentGuidsExist(
+            SearchObjectType objectType,
+            Set<GUID> parentGuids) 
             throws IOException;
     
     /** Check that the parent objects (e.g. the access information) exists for a set of GUIDS.
@@ -47,7 +50,7 @@ public interface IndexingStorage {
     public Map<GUID, Boolean> checkParentGuidsExist(Set<GUID> parentGuids)
             throws IOException;
 
-    public void flushIndexing(String objectType) throws IOException;
+    public void flushIndexing(SearchObjectType objectType) throws IOException;
     
     public void shareObjects(Set<GUID> guids, int accessGroupId, boolean isPublicGroup) throws IOException;
 
@@ -69,11 +72,11 @@ public interface IndexingStorage {
     public Map<String, Integer> searchTypes(MatchFilter matchFilter,
             AccessFilter accessFilter) throws IOException;
 
-    public FoundHits searchIds(String objectType, MatchFilter matchFilter, 
+    public FoundHits searchIds(SearchObjectType objectType, MatchFilter matchFilter, 
             List<SortingRule> sorting, AccessFilter accessFilter, Pagination pagination) 
                     throws IOException;
 
-    public FoundHits searchObjects(String objectType, MatchFilter matchFilter, 
+    public FoundHits searchObjects(SearchObjectType objectType, MatchFilter matchFilter, 
             List<SortingRule> sorting, AccessFilter accessFilter, Pagination pagination,
             PostProcessing postProcessing) throws IOException;
 

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -26,7 +26,7 @@ public class ObjectTypeParsingRules {
     //TODO IDXRULE what if there are two parent types for a single type? need to error out?
     //TODO IDXRULE if subobject spec, there must be a path based indexing rule that matches the subobject id path. Make this automatic in some way?
     
-    private final String globalObjectType;
+    private final SearchObjectType globalObjectType;
     private final String uiTypeName;
     private final StorageObjectType storageObjectType;
     private final List<IndexingRules> indexingRules;
@@ -36,7 +36,7 @@ public class ObjectTypeParsingRules {
     
     
     private ObjectTypeParsingRules(
-            final String globalObjectType,
+            final SearchObjectType globalObjectType,
             String uiTypeName,
             final StorageObjectType storageObjectType,
             final List<IndexingRules> indexingRules,
@@ -45,8 +45,8 @@ public class ObjectTypeParsingRules {
             final ObjectJsonPath subObjectIDPath) {
         this.globalObjectType = globalObjectType;
         if (uiTypeName == null) {
-            uiTypeName = globalObjectType.substring(0, 1).toUpperCase() +
-                    globalObjectType.substring(1);
+            uiTypeName = globalObjectType.getType().substring(0, 1).toUpperCase() +
+                    globalObjectType.getType().substring(1);
         }
         this.uiTypeName = uiTypeName;
         this.storageObjectType = storageObjectType;
@@ -59,7 +59,7 @@ public class ObjectTypeParsingRules {
     /** Get the type of object this rule set applies to as known to the search system.
      * @return the search object type.
      */
-    public String getGlobalObjectType() {
+    public SearchObjectType getGlobalObjectType() {
         return globalObjectType;
     }
     
@@ -199,14 +199,14 @@ public class ObjectTypeParsingRules {
      * @return a new builder.
      */
     public static Builder getBuilder(
-            final String globalObjectType,
+            final SearchObjectType globalObjectType,
             final StorageObjectType storageType) {
         return new Builder(globalObjectType, storageType);
     }
     
     public static class Builder {
         
-        private final String globalObjectType;
+        private final SearchObjectType globalObjectType;
         private String uiTypeName; 
         private final StorageObjectType storageObjectType;
         private final List<IndexingRules> indexingRules = new LinkedList<>();
@@ -214,9 +214,8 @@ public class ObjectTypeParsingRules {
         private ObjectJsonPath subObjectPath = null;
         private ObjectJsonPath subObjectIDPath = null;
         
-        private Builder(final String globalObjectType, final StorageObjectType storageType) {
-            Utils.notNullOrEmpty(globalObjectType,
-                    "globalObjectType cannot be null or whitespace");
+        private Builder(final SearchObjectType globalObjectType, final StorageObjectType storageType) {
+            Utils.nonNull(globalObjectType, "globalObjectType");
             Utils.nonNull(storageType, "storageType");
             this.globalObjectType = globalObjectType;
             this.storageObjectType = storageType;

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
@@ -75,7 +75,9 @@ public class ObjectTypeParsingRulesUtils {
                 throw new ObjectParseException(getMissingKeyParseMessage("storage-object-type"));
             }
             final Builder builder = ObjectTypeParsingRules.getBuilder(
-                    (String) obj.get("global-object-type"), //TODO CODE better error if missing
+                    new SearchObjectType( //TODO CODE better error if missing elements
+                            (String) obj.get("global-object-type"),
+                            (int) obj.get("global-object-type-version")),
                     new StorageObjectType(storageCode, type))
                     .withNullableUITypeName((String)obj.get("ui-type-name"));
             final String subType = (String)obj.get("inner-sub-type");

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
@@ -17,7 +17,6 @@ import kbasesearchengine.tools.Utils;
 
 /** Utilities for creating {@link ObjectTypeParsingRules} from various data sources.
  * 
- * This class is not thread-safe.
  * @author gaprice@lbl.gov
  *
  */
@@ -55,7 +54,7 @@ public class ObjectTypeParsingRulesUtils {
         }
         if (!(predata instanceof Map)) {
             throw new TypeParseException(
-                    "Expected mapping in top level YAML/JSON." + sourceInfo);
+                    "Expected mapping in top level YAML/JSON in source: " + sourceInfo);
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> obj = (Map<String, Object>) predata;

--- a/lib/src/kbasesearchengine/system/SearchObjectType.java
+++ b/lib/src/kbasesearchengine/system/SearchObjectType.java
@@ -1,0 +1,103 @@
+package kbasesearchengine.system;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import kbasesearchengine.tools.Utils;
+
+/** A name and version of a search system data type.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class SearchObjectType {
+
+    private final static Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z\\d]+");
+    
+    private final String type;
+    private final int version;
+    
+    // consider supporting unicode later
+    /** Create a new type.
+     * @param type the type name. Names may include numbers and lower and uppercase ASCII letters.
+     * The first character must be a letter.
+     * @param version the version of the type.
+     * @throws IllegalArgumentException if the type name is null or whitespace or the version is
+     * less than one.
+     */
+    public SearchObjectType(final String type, final int version) {
+        Utils.notNullOrEmpty(type, "search type cannot be null or whitespace");
+        if (version < 1) {
+            throw new IllegalArgumentException("search type version must be greater than zero");
+        }
+        this.type = type.trim();
+        final Matcher m = INVALID_CHARS.matcher(this.type);
+        if (m.find()) {
+            throw new IllegalArgumentException(String.format(
+                    "Illegal character in search type name %s: %s", this.type, m.group()));
+        }
+        if (!Character.isLetter(this.type.codePointAt(0))) {
+            throw new IllegalArgumentException(String.format(
+                    "Search type name %s must start with a letter", this.type));
+        }
+        this.version = version;
+    }
+
+    /** Get the type name.
+     * @return the type name.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /** Get the version of the type.
+     * @return the version.
+     */
+    public int getVersion() {
+        return version;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + version;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SearchObjectType other = (SearchObjectType) obj;
+        if (type == null) {
+            if (other.type != null) {
+                return false;
+            }
+        } else if (!type.equals(other.type)) {
+            return false;
+        }
+        if (version != other.version) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SearchObjectType [type=");
+        builder.append(type);
+        builder.append(", version=");
+        builder.append(version);
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/resources/types/Assembly.json
+++ b/resources/types/Assembly.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "Assembly",
+    "global-object-type-version": 1,
     "storage-type": "WS",
     "storage-object-type": "KBaseGenomeAnnotations.Assembly",
     "indexing-rules": [

--- a/resources/types/AssemblyContig.json
+++ b/resources/types/AssemblyContig.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "AssemblyContig",
+    "global-object-type-version": 1,
     "ui-type-name": "Assembly Contig",
     "storage-type": "WS",
     "storage-object-type": "KBaseGenomeAnnotations.Assembly",

--- a/resources/types/Genome.yaml
+++ b/resources/types/Genome.yaml
@@ -33,8 +33,8 @@ indexing-rules:
         full-text: true
     -
         # Extract the number of features from a list at the /features path. The special {size}
-        # element directs the parser to return the size of list or mapping. Since this number
-        # will be an integer, the keyword type is set a such.
+        # element directs the parser to return the size of a list or mapping. Since this number
+        # will be an integer, the keyword type is set as such.
         # The key name is explicitly set to features, rather than implicitly set by the first
         # section of the path.
         path: features/{size}

--- a/resources/types/Genome.yaml
+++ b/resources/types/Genome.yaml
@@ -3,6 +3,7 @@
 
 # The name of the type in the search system.
 global-object-type: Genome
+global-object-type-version: 1
 # The data source of the objects, in this case the Workspace.
 storage-type: WS
 # The name of the type in the data source.

--- a/resources/types/GenomeFeature.json
+++ b/resources/types/GenomeFeature.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "GenomeFeature",
+    "global-object-type-version": 1,
     "ui-type-name": "Genome Feature",
     "storage-type": "WS",
     "storage-object-type": "KBaseGenomes.Genome",

--- a/resources/types/Narrative.json
+++ b/resources/types/Narrative.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "Narrative",
+    "global-object-type-version": 1,
     "storage-type": "WS",
     "storage-object-type": "KBaseNarrative.Narrative",
     "indexing-rules": [

--- a/resources/types/PairedEndLibrary.json
+++ b/resources/types/PairedEndLibrary.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "PairedEndLibrary",
+    "global-object-type-version": 1,
     "ui-type-name": "Paired End Library",
     "storage-type": "WS",
     "storage-object-type": "KBaseFile.PairedEndLibrary",

--- a/resources/types/SeedOntologyTerm.json
+++ b/resources/types/SeedOntologyTerm.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "SeedOntologyTerm",
+    "global-object-type-version": 1,
     "storage-type": "SeedOntologyDataSource",
     "storage-object-type": "fake",
     "primary-key-path": "id",

--- a/resources/types/SingleEndLibrary.json
+++ b/resources/types/SingleEndLibrary.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "SingleEndLibrary",
+    "global-object-type-version": 1,
     "ui-type-name": "Single End Library",
     "storage-type": "WS",
     "storage-object-type": "KBaseFile.SingleEndLibrary",

--- a/test/src/kbasesearchengine/test/data/EmptyAType.json
+++ b/test/src/kbasesearchengine/test/data/EmptyAType.json
@@ -1,5 +1,6 @@
 {
     "global-object-type": "EmptyAType",
+    "global-object-type-version": 1,
     "ui-type-name": "A Type",
     "storage-type": "WS",
     "storage-object-type": "Empty.AType",

--- a/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
+++ b/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
@@ -45,6 +45,7 @@ import kbasesearchengine.search.MatchFilter;
 import kbasesearchengine.search.ObjectData;
 import kbasesearchengine.search.PostProcessing;
 import kbasesearchengine.system.TypeFileStorage;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.StorageObjectType;
 import kbasesearchengine.system.TypeStorage;
 import kbasesearchengine.system.TypeMappingParser;
@@ -292,7 +293,7 @@ public class IndexerWorkerIntegrationTest {
         pp.objectData = true;
         pp.objectKeys = true;
         System.out.println("Genome: " + storage.getObjectsByIds(
-                storage.searchIds("Genome", 
+                storage.searchIds(new SearchObjectType("Genome", 1),
                         MatchFilter.create().withFullTextInAll("test"), null, 
                         AccessFilter.create().withAdmin(true), null).guids, pp).get(0));
         String query = "TrkA";
@@ -304,7 +305,7 @@ public class IndexerWorkerIntegrationTest {
             return;
         }
         String type = typeToCount.keySet().iterator().next();
-        Set<GUID> guids = storage.searchIds(type, 
+        Set<GUID> guids = storage.searchIds(new SearchObjectType(type, 1),
                 MatchFilter.create().withFullTextInAll(query), null, 
                 AccessFilter.create().withAdmin(true), null).guids;
         System.out.println("GUIDs found: " + guids);
@@ -332,8 +333,13 @@ public class IndexerWorkerIntegrationTest {
         }
     }
     
-    private void checkSearch(int expectedCount, String type, String query, int accessGroupId,
-            boolean debugOutput) throws Exception {
+    private void checkSearch(
+            final int expectedCount,
+            final SearchObjectType type,
+            final String query,
+            final int accessGroupId,
+            final boolean debugOutput)
+            throws Exception {
         Set<GUID> ids = storage.searchIds(type, 
                 MatchFilter.create().withFullTextInAll(query), null, 
                 AccessFilter.create().withAccessGroups(accessGroupId), null).guids;
@@ -360,8 +366,9 @@ public class IndexerWorkerIntegrationTest {
                 .build();
         indexFewVersions(new StoredStatusEvent(ev, new StatusEventID("-1"),
                 StatusEventProcessingState.UNPROC, null, null));
-        checkSearch(1, "Narrative", "tree", wsid, false);
-        checkSearch(1, "Narrative", "species", wsid, false);
+        final SearchObjectType type = new SearchObjectType("Narrative", 1);
+        checkSearch(1, type, "tree", wsid, false);
+        checkSearch(1, type, "species", wsid, false);
         /*indexFewVersions(new ObjectStatusEvent("-1", "WS", 10455, "1", 78, null, 
                 System.currentTimeMillis(), "KBaseNarrative.Narrative", 
                 ObjectStatusEventType.CREATED, false));
@@ -387,8 +394,9 @@ public class IndexerWorkerIntegrationTest {
                 .build();
         indexFewVersions(new StoredStatusEvent(ev, new StatusEventID("-1"),
                 StatusEventProcessingState.UNPROC, null, null));
-        checkSearch(1, "PairedEndLibrary", "Illumina", wsid, true);
-        checkSearch(1, "PairedEndLibrary", "sample1se.fastq.gz", wsid, false);
+        final SearchObjectType type = new SearchObjectType("PairedEndLibrary", 1);
+        checkSearch(1, type, "Illumina", wsid, true);
+        checkSearch(1, type, "sample1se.fastq.gz", wsid, false);
         final StatusEvent ev2 = StatusEvent.getBuilder(
                 new StorageObjectType("WS", "KBaseFile.SingleEndLibrary"),
                 Instant.now(),
@@ -400,7 +408,8 @@ public class IndexerWorkerIntegrationTest {
                 .build();
         indexFewVersions(new StoredStatusEvent(ev2, new StatusEventID("-1"),
                 StatusEventProcessingState.UNPROC, null, null));
-        checkSearch(1, "SingleEndLibrary", "PacBio", wsid, true);
-        checkSearch(1, "SingleEndLibrary", "reads.2", wsid, false);
+        final SearchObjectType setype = new SearchObjectType("SingleEndLibrary", 1);
+        checkSearch(1, setype, "PacBio", wsid, true);
+        checkSearch(1, setype, "reads.2", wsid, false);
     }
 }

--- a/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
@@ -38,6 +38,7 @@ import kbasesearchengine.parse.ParsedObject;
 import kbasesearchengine.search.IndexingStorage;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.StorageObjectType;
 import kbasesearchengine.system.TypeStorage;
 import kbasesearchengine.test.common.TestCommon;
@@ -103,7 +104,8 @@ public class IndexerWorkerTest {
         
         when(typeStore.listObjectTypesByStorageObjectType(storageObjectType))
                 .thenReturn(Arrays.asList(
-                        ObjectTypeParsingRules.getBuilder("foo", storageObjectType)
+                        ObjectTypeParsingRules.getBuilder(
+                                new SearchObjectType("foo", 1), storageObjectType)
                                 .toSubObjectRule("subfoo", new ObjectJsonPath("/subobjs/[*]/"),
                                         new ObjectJsonPath("id"))
                                 .withIndexingRule(IndexingRules.fromPath(
@@ -134,7 +136,7 @@ public class IndexerWorkerTest {
                 "id", Arrays.asList("an id2"));
         
         verify(idxStore).indexObjects(
-                eq("foo"),
+                eq(new SearchObjectType("foo", 1)),
                 any(SourceData.class),
                 eq(Instant.ofEpochMilli(10000)),
                 eq(null),
@@ -159,7 +161,7 @@ public class IndexerWorkerTest {
         final StorageObjectType storageObjectType = StorageObjectType
                 .fromNullableVersion("code", "sometype", 3);
         final ObjectTypeParsingRules rules = ObjectTypeParsingRules.getBuilder(
-                "foo", storageObjectType)
+                new SearchObjectType("foo", 1), storageObjectType)
                 .toSubObjectRule("subfoo", new ObjectJsonPath("/subobjs/[*]/"),
                         new ObjectJsonPath("idx"))
                 .withIndexingRule(IndexingRules.fromPath(
@@ -182,7 +184,7 @@ public class IndexerWorkerTest {
         final StorageObjectType storageObjectType = StorageObjectType
                 .fromNullableVersion("code", "sometype", 3);
         final ObjectTypeParsingRules rules = ObjectTypeParsingRules.getBuilder(
-                "foo", storageObjectType)
+                new SearchObjectType("foo", 1), storageObjectType)
                 .toSubObjectRule("subfoo", new ObjectJsonPath("/subobjs/[*]/"),
                         new ObjectJsonPath("id"))
                 .withIndexingRule(IndexingRules.fromPath(
@@ -253,7 +255,7 @@ public class IndexerWorkerTest {
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, new UnprocessableEventIndexingException(
                     "Could not find the subobject id for one or more of the subobjects for " +
-                    "object code:1/2/3 when applying search specification foo"));
+                    "object code:1/2/3 when applying search specification foo_1"));
         }
     }
     

--- a/test/src/kbasesearchengine/test/main/PerformanceTester.java
+++ b/test/src/kbasesearchengine/test/main/PerformanceTester.java
@@ -38,6 +38,7 @@ import kbasesearchengine.search.IndexingStorage;
 import kbasesearchengine.search.MatchFilter;
 import kbasesearchengine.search.MatchValue;
 import kbasesearchengine.system.TypeFileStorage;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.StorageObjectType;
 import kbasesearchengine.system.TypeStorage;
 import kbasesearchengine.system.TypeMappingParser;
@@ -260,7 +261,7 @@ public class PerformanceTester {
     }
     
     private int countGenomes() throws Exception {
-        return storage.searchIds("Genome", 
+        return storage.searchIds(new SearchObjectType("Genome", 1), 
                 MatchFilter.create().withLookupInKey("features", new MatchValue(1, null)), null,
                 AccessFilter.create().withPublic(true).withAdmin(true), null).total;
     }

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -51,6 +51,7 @@ import kbasesearchengine.search.PostProcessing;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
 import kbasesearchengine.system.ObjectTypeParsingRulesUtils;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.test.common.TestCommon;
 import kbasesearchengine.test.controllers.elasticsearch.ElasticSearchController;
 import kbasesearchengine.test.parse.SubObjectExtractorTest;
@@ -149,7 +150,7 @@ public class ElasticIndexingStorageTest {
         return MatchFilter.create().withFullTextInAll(fullText);
     }
     
-    private static void indexObject(GUID id, String objectType, String json, String objectName,
+    private static void indexObject(GUID id, SearchObjectType objectType, String json, String objectName,
             Instant timestamp, String parentJsonValue, boolean isPublic,
             List<IndexingRules> indexingRules)
             throws IOException, ObjectParseException, IndexingException, InterruptedException {
@@ -203,8 +204,8 @@ public class ElasticIndexingStorageTest {
         Map<String, Integer> typeToCount = indexStorage.searchTypes(ft("Rfah"), 
                 AccessFilter.create().withAdmin(true));
         Assert.assertEquals(1, typeToCount.size());
-        String type = typeToCount.keySet().iterator().next();
-        Assert.assertEquals(1, (int)typeToCount.get(type));
+        SearchObjectType type = new SearchObjectType(typeToCount.keySet().iterator().next(), 1);
+        Assert.assertEquals(1, (int)typeToCount.get(type.getType()));
         GUID expectedGUID = new GUID("WS:1/1/1:feature/NewGenome.CDS.6210");
         // Admin mode
         Set<GUID> ids = indexStorage.searchIds(type, ft("RfaH"), null, 
@@ -253,8 +254,10 @@ public class ElasticIndexingStorageTest {
     public void testGenome() throws Exception {
         System.out.println("*** start testGenome***");
         indexObject("Genome", "genome01", new GUID("WS:1/1/1"), "MyGenome.1");
-        Set<GUID> guids = indexStorage.searchIds("Genome", MatchFilter.create().withLookupInKey(
-                "features", new MatchValue(1, null)), null, AccessFilter.create().withAdmin(true));
+        Set<GUID> guids = indexStorage.searchIds(new SearchObjectType("Genome", 1),
+                MatchFilter.create().withLookupInKey(
+                        "features", new MatchValue(1, null)),
+                null, AccessFilter.create().withAdmin(true));
         Assert.assertEquals(1, guids.size());
         ObjectData genomeIndex = indexStorage.getObjectsByIds(guids).get(0);
         //System.out.println("Genome index: " + genomeIndex);
@@ -271,7 +274,7 @@ public class ElasticIndexingStorageTest {
     
     @Test
     public void testVersions() throws Exception {
-        String objType = "Simple";
+        SearchObjectType objType = new SearchObjectType("Simple", 1);
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop1"))
                 .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
@@ -314,7 +317,7 @@ public class ElasticIndexingStorageTest {
                 AccessFilter.create().withAccessGroups(2).withAllHistory(true)).size());
     }
     
-    private Set<GUID> lookupIdsByKey(String objType, String keyName, Object value, 
+    private Set<GUID> lookupIdsByKey(SearchObjectType objType, String keyName, Object value, 
             AccessFilter af) throws IOException {
         Set<GUID> ret = indexStorage.searchIds(objType, MatchFilter.create().withLookupInKey(
                 keyName, new MatchValue(value)), null, af);
@@ -328,7 +331,7 @@ public class ElasticIndexingStorageTest {
     
     @Test
     public void testSharing() throws Exception {
-        String objType = "Sharable";
+        SearchObjectType objType = new SearchObjectType("Sharable",1 );
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop2"))
                 .withKeywordType("integer").build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
@@ -378,7 +381,7 @@ public class ElasticIndexingStorageTest {
     
     @Test
     public void testPublic() throws Exception {
-        String objType = "Publishable";
+        SearchObjectType objType = new SearchObjectType("Publishable", 1);
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop3"))
                 .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
@@ -430,7 +433,7 @@ public class ElasticIndexingStorageTest {
     
     @Test
     public void testPublicDataPalettes() throws Exception {
-        String objType = "ShareAndPublic";
+        SearchObjectType objType = new SearchObjectType("ShareAndPublic", 1);
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop4"))
                 .withKeywordType("integer").build();
         List<IndexingRules> indexingRules = Arrays.asList(ir);
@@ -465,7 +468,7 @@ public class ElasticIndexingStorageTest {
     
     @Test
     public void testDeleteUndelete() throws Exception {
-        String objType = "DelUndel";
+        SearchObjectType objType = new SearchObjectType("DelUndel", 1);
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("myprop"))
                 .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
@@ -511,7 +514,7 @@ public class ElasticIndexingStorageTest {
     @Test
     public void testPublishAllVersions() throws Exception {
         // tests the all versions method for setting objects public / non-public.
-        String objType = "PublishAllVersions";
+        SearchObjectType objType = new SearchObjectType("PublishAllVersions", 1);
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("myprop"))
                 .withFullText().build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);

--- a/test/src/kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java
+++ b/test/src/kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java
@@ -13,6 +13,7 @@ import com.google.common.base.Optional;
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.StorageObjectType;
 import kbasesearchengine.test.common.TestCommon;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -27,11 +28,13 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void buildMinimal() {
         final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
-                "foo", new StorageObjectType("bar", "baz"))
+                new SearchObjectType("foo", 1),
+                new StorageObjectType("bar", "baz"))
                 .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
                 .build();
         
-        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect global type", r.getGlobalObjectType(),
+                is(new SearchObjectType("foo", 1)));
         assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
         assertThat("incorrect storage type", r.getStorageObjectType(),
                 is(new StorageObjectType("bar", "baz")));
@@ -45,12 +48,14 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void buildWithUIName() {
         final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
-                "foo", new StorageObjectType("bar", "baz"))
+                new SearchObjectType("foo", 1),
+                new StorageObjectType("bar", "baz"))
                 .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
                 .withNullableUITypeName("whee whoo")
                 .build();
         
-        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect global type", r.getGlobalObjectType(),
+                is(new SearchObjectType("foo", 1)));
         assertThat("incorrect UI name", r.getUiTypeName(), is("whee whoo"));
         assertThat("incorrect storage type", r.getStorageObjectType(),
                 is(new StorageObjectType("bar", "baz")));
@@ -65,7 +70,8 @@ public class ObjectTypeParsingRulesTest {
     public void buildSubObjectRules() throws Exception {
         // also tests indexing rule with from parent happy path
         final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
-                "foo", new StorageObjectType("bar", "baz"))
+                new SearchObjectType("foo", 1),
+                new StorageObjectType("bar", "baz"))
                 .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
                 .toSubObjectRule("sotype", new ObjectJsonPath("path"),
                         new ObjectJsonPath("idpath"))
@@ -73,7 +79,8 @@ public class ObjectTypeParsingRulesTest {
                         .withFromParent().build())
                 .build();
         
-        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect global type", r.getGlobalObjectType(),
+                is(new SearchObjectType("foo", 1)));
         assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
         assertThat("incorrect storage type", r.getStorageObjectType(),
                 is(new StorageObjectType("bar", "baz")));
@@ -96,12 +103,14 @@ public class ObjectTypeParsingRulesTest {
 
     private void buildWithUITypeNameNullOrWhitespace(final String uiTypeName) {
         final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
-                "foo", new StorageObjectType("bar", "baz"))
+                new SearchObjectType("foo", 1),
+                new StorageObjectType("bar", "baz"))
                 .withNullableUITypeName(uiTypeName)
                 .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
                 .build();
         
-        assertThat("incorrect global type", r.getGlobalObjectType(), is("foo"));
+        assertThat("incorrect global type", r.getGlobalObjectType(),
+                is(new SearchObjectType("foo", 1)));
         assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
         assertThat("incorrect storage type", r.getStorageObjectType(),
                 is(new StorageObjectType("bar", "baz")));
@@ -115,7 +124,8 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void builderSize() {
         final ObjectTypeParsingRules.Builder b = ObjectTypeParsingRules.getBuilder(
-                "foo", new StorageObjectType("bar", "baz"));
+                new SearchObjectType("foo", 1),
+                new StorageObjectType("bar", "baz"));
         
         assertThat("incorrect size", b.numberOfIndexingRules(), is(0));
         
@@ -129,14 +139,13 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void getBuilderFail() {
         failGetBuilder(null, new StorageObjectType("c", "t"),
-                new IllegalArgumentException("globalObjectType cannot be null or whitespace"));
-        failGetBuilder("  \t   \n ", new StorageObjectType("c", "t"),
-                new IllegalArgumentException("globalObjectType cannot be null or whitespace"));
-        failGetBuilder("t", null, new NullPointerException("storageType"));
+                new NullPointerException("globalObjectType"));
+        failGetBuilder(new SearchObjectType("t", 1), null,
+                new NullPointerException("storageType"));
     }
     
     private void failGetBuilder(
-            final String globalObjectType,
+            final SearchObjectType globalObjectType,
             final StorageObjectType storageType,
             final Exception expected) {
         try {
@@ -157,7 +166,9 @@ public class ObjectTypeParsingRulesTest {
     
     private void failWithIndexingRule(final IndexingRules rule, final Exception expected) {
         try {
-            ObjectTypeParsingRules.getBuilder("t", new StorageObjectType("c", "t"))
+            ObjectTypeParsingRules.getBuilder(
+                    new SearchObjectType("t", 1),
+                    new StorageObjectType("c", "t"))
                     .withIndexingRule(rule);
             fail("expected exception");
         } catch (Exception got) {
@@ -182,7 +193,9 @@ public class ObjectTypeParsingRulesTest {
             final ObjectJsonPath subObjectIDPath,
             final Exception expected) {
         try {
-            ObjectTypeParsingRules.getBuilder("t", new StorageObjectType("c", "t"))
+            ObjectTypeParsingRules.getBuilder(
+                    new SearchObjectType("t", 1),
+                    new StorageObjectType("c", "t"))
                     .toSubObjectRule(subObjectType, subObjectPath, subObjectIDPath);
             fail("expected exception");
         } catch (Exception got) {
@@ -193,7 +206,9 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void buildFail() {
         try {
-            ObjectTypeParsingRules.getBuilder("t", new StorageObjectType("c", "t")).build();
+            ObjectTypeParsingRules.getBuilder(
+                    new SearchObjectType("t", 1),
+                    new StorageObjectType("c", "t")).build();
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, new IllegalStateException(
@@ -204,7 +219,8 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void immutable() {
         final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
-                "foo", new StorageObjectType("bar", "baz"))
+                new SearchObjectType("foo", 1),
+                new StorageObjectType("bar", "baz"))
                 .withIndexingRule(IndexingRules.fromSourceKey("k", "n").build())
                 .build();
         

--- a/test/src/kbasesearchengine/test/system/SearchObjectTypeTest.java
+++ b/test/src/kbasesearchengine/test/system/SearchObjectTypeTest.java
@@ -1,0 +1,63 @@
+package kbasesearchengine.test.system;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import kbasesearchengine.system.SearchObjectType;
+import kbasesearchengine.test.common.TestCommon;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class SearchObjectTypeTest {
+
+    @Test
+    public void equals() {
+        EqualsVerifier.forClass(SearchObjectType.class).usingGetClass().verify();
+    }
+    
+    @Test
+    public void construct() {
+        final SearchObjectType type = new SearchObjectType("   \t   fo9O  \n ", 1);
+        
+        assertThat("incorrect type", type.getType(), is("fo9O"));
+        assertThat("incorrect version", type.getVersion(), is(1));
+        assertThat("incorrect toString", type.toString(),
+                is("SearchObjectType [type=fo9O, version=1]"));
+    }
+    
+    @Test
+    public void constructFail() {
+        failConstruct(null, 1, new IllegalArgumentException(
+                "search type cannot be null or whitespace"));
+        failConstruct("   \t \n  ", 1, new IllegalArgumentException(
+                "search type cannot be null or whitespace"));
+        failConstruct("t", 0, new IllegalArgumentException(
+                "search type version must be greater than zero"));
+    }
+    
+    @Test
+    public void constructFailIllegalName() {
+        failConstruct("   foo_bar  ", "Illegal character in search type name foo_bar: _");
+        failConstruct("   foo\u0980bar  ",
+                "Illegal character in search type name foo\u0980bar: \u0980");
+        failConstruct("   foo*bar  ", "Illegal character in search type name foo*bar: *");
+        
+        failConstruct("   7oobar  ", "Search type name 7oobar must start with a letter");
+    }
+
+    private void failConstruct(final String type, final String exceptionString) {
+        failConstruct(type, 1, new IllegalArgumentException(exceptionString));
+    }
+    
+    private void failConstruct(final String type, final int ver, final Exception expected) {
+        try {
+            new SearchObjectType(type, ver);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+    
+}


### PR DESCRIPTION
First step of making the search system aware of search type versions.

Lots still to do, and the version is ignored in most places.

* Update elastic search to take the version into account for indexes and
returned data
* Update TypeMappings to take the version of the type into account
* Update TypeFileStorage
* Add versions to type files (multiple versions per file), remove version key
* Add target type version to GUID transform