### PR TITLE
SCT-178 Add versions to search spec files

### DIFF
--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1369,7 +1369,8 @@ public class ElasticIndexingStorage implements IndexingStorage {
             List<SortingRule> sorting,
             final AccessFilter accessFilter,
             final Pagination pg,
-            final PostProcessing pp) throws IOException {
+            final PostProcessing pp)
+            throws IOException {
         int pgStart = pg == null || pg.start == null ? 0 : pg.start;
         int pgCount = pg == null || pg.count == null ? 50 : pg.count;
         Pagination pagination = new Pagination(pgStart, pgCount);

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRulesUtils.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -24,22 +25,24 @@ public class ObjectTypeParsingRulesUtils {
 
     //TODO TEST
 
-    /** Create an ObjectTypeParsingRules instance from a file.
+    /** Create a set ObjectTypeParsingRules version instances from a file.
+     * 
+     * The rules will have the same storage object type, search type, and ui name.
      * 
      * TODO document the file structure.
      * @param file the file containing the parsing rules.
-     * @return a new set of parsing rules.
+     * @return a new set of parsing rules ordered by version.
      * @throws IOException if an IO error occurs reading the file.
      * @throws TypeParseException if the file contains erroneous parsing rules.
      */
-    public static ObjectTypeParsingRules fromFile(final File file) 
+    public static List<ObjectTypeParsingRules> fromFile(final File file) 
             throws IOException, TypeParseException {
         try (final InputStream is = new FileInputStream(file)) {
             return fromStream(is, file.toString());
         }
     }
 
-    private static ObjectTypeParsingRules fromStream(InputStream is, String sourceInfo) 
+    private static List<ObjectTypeParsingRules> fromStream(InputStream is, String sourceInfo) 
             throws IOException, TypeParseException {
         final Yaml yaml = new Yaml(new SafeConstructor());
         final Object predata;
@@ -61,7 +64,8 @@ public class ObjectTypeParsingRulesUtils {
         return fromObject(obj, sourceInfo);
     }
 
-    private static ObjectTypeParsingRules fromObject(
+    //TODO CODE should look at json schema for validating the object data prior to building objects, avoids a lot of typechecking code
+    private static List<ObjectTypeParsingRules> fromObject(
             final Map<String, Object> obj,
             final String sourceInfo) 
             throws TypeParseException {
@@ -74,34 +78,50 @@ public class ObjectTypeParsingRulesUtils {
             if (Utils.isNullOrEmpty(type)) {
                 throw new ObjectParseException(getMissingKeyParseMessage("storage-object-type"));
             }
-            final Builder builder = ObjectTypeParsingRules.getBuilder(
-                    new SearchObjectType( //TODO CODE better error if missing elements
-                            (String) obj.get("global-object-type"),
-                            (int) obj.get("global-object-type-version")),
-                    new StorageObjectType(storageCode, type))
-                    .withNullableUITypeName((String)obj.get("ui-type-name"));
-            final String subType = (String)obj.get("inner-sub-type");
-            if (!Utils.isNullOrEmpty(subType)) {
-                builder.toSubObjectRule(
-                        subType,
-                        //TODO CODE add checks to ensure these exist
-                        getPath((String)obj.get("path-to-sub-objects")),
-                        getPath((String)obj.get("primary-key-path")));
-            } // throw exception if the other subobj values exist?
-            // Indexing
+            final StorageObjectType storageType = new StorageObjectType(storageCode, type);
+            //TODO CODE better error if missing elements
+            final String searchType = (String) obj.get("global-object-type");
+            final String uiTypeName = (String) obj.get("ui-type-name");
             @SuppressWarnings("unchecked")
-            List<Map<String, Object>> indexingRules =
-                    (List<Map<String, Object>>)obj.get("indexing-rules");
-            if (indexingRules != null) {
-                for (Map<String, Object> rulesObj : indexingRules) {
-                    builder.withIndexingRule(buildRule(rulesObj));
-                }
+            final List<Map<String, Object>> versions =
+                    (List<Map<String, Object>>) obj.get("versions");
+            final List<ObjectTypeParsingRules> ret = new LinkedList<>();
+            for (int i = 0; i < versions.size(); i++) {
+                final Builder builder = ObjectTypeParsingRules.getBuilder(
+                        new SearchObjectType(searchType, i + 1), storageType)
+                        .withNullableUITypeName(uiTypeName);
+                ret.add(processVersion(builder, versions.get(i)));
             }
-            return builder.build();
+            return ret;
         } catch (ObjectParseException | IllegalArgumentException | NullPointerException e) {
             throw new TypeParseException(String.format("Error in source %s: %s",
                     sourceInfo, e.getMessage()), e);
         }
+    }
+
+    private static ObjectTypeParsingRules processVersion(
+            final Builder builder,
+            final Map<String, Object> versionObj)
+            throws ObjectParseException {
+        
+        final String subType = (String) versionObj.get("inner-sub-type");
+        if (!Utils.isNullOrEmpty(subType)) {
+            builder.toSubObjectRule(
+                    subType,
+                    //TODO CODE add checks to ensure these exist
+                    getPath((String) versionObj.get("path-to-sub-objects")),
+                    getPath((String) versionObj.get("primary-key-path")));
+        } // throw exception if the other subobj values exist?
+        // Indexing
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> indexingRules =
+                (List<Map<String, Object>>) versionObj.get("indexing-rules");
+        if (indexingRules != null) {
+            for (Map<String, Object> rulesObj : indexingRules) {
+                builder.withIndexingRule(buildRule(rulesObj));
+            }
+        }
+        return builder.build();
     }
 
     private static IndexingRules buildRule(

--- a/resources/types/Assembly.json
+++ b/resources/types/Assembly.json
@@ -1,32 +1,33 @@
 {
     "global-object-type": "Assembly",
-    "global-object-type-version": 1,
     "storage-type": "WS",
     "storage-object-type": "KBaseGenomeAnnotations.Assembly",
-    "indexing-rules": [
-        {
-            "path": "name",
-            "full-text": true
-        },
-        {
-            "path": "dna_size",
-            "keyword-type": "integer",
-            "ui-name": "DNA size"
-        },
-        {
-            "path": "gc_content",
-            "keyword-type": "double",
-            "ui-name": "GC-content"
-        },
-        {
-            "path": "external_source_id",
-            "full-text": true,
-            "ui-name": "External Source"
-        },
-        {
-            "path": "contigs/{size}",
-            "keyword-type": "integer",
-            "key-name": "contigs"
-        }
-    ]
+    "versions": [{
+        "indexing-rules": [
+            {
+                "path": "name",
+                "full-text": true
+            },
+            {
+                "path": "dna_size",
+                "keyword-type": "integer",
+                "ui-name": "DNA size"
+            },
+            {
+                "path": "gc_content",
+                "keyword-type": "double",
+                "ui-name": "GC-content"
+            },
+            {
+                "path": "external_source_id",
+                "full-text": true,
+                "ui-name": "External Source"
+            },
+            {
+                "path": "contigs/{size}",
+                "keyword-type": "integer",
+                "key-name": "contigs"
+            }
+        ]
+    }]
 }

--- a/resources/types/AssemblyContig.json
+++ b/resources/types/AssemblyContig.json
@@ -1,30 +1,31 @@
 {
     "global-object-type": "AssemblyContig",
-    "global-object-type-version": 1,
     "ui-type-name": "Assembly Contig",
     "storage-type": "WS",
     "storage-object-type": "KBaseGenomeAnnotations.Assembly",
-    "inner-sub-type": "contig",
-    "path-to-sub-objects": "/contigs/*/",
-    "indexing-rules": [
-        {
-            "path": "contig_id",
-            "keyword-type": "string",
-            "ui-name": "ID"
-        },
-        {
-            "path": "description",
-            "full-text": true
-        },
-        {
-            "path": "gc_content",
-            "keyword-type": "double",
-            "ui-name": "GC-content"
-        },
-        {
-            "path": "length",
-            "keyword-type": "integer"
-        }
-    ],
-    "primary-key-path": "contig_id"
+    "versions": [{
+        "inner-sub-type": "contig",
+        "path-to-sub-objects": "/contigs/*/",
+        "primary-key-path": "contig_id",
+        "indexing-rules": [
+            {
+                "path": "contig_id",
+                "keyword-type": "string",
+                "ui-name": "ID"
+            },
+            {
+                "path": "description",
+                "full-text": true
+            },
+            {
+                "path": "gc_content",
+                "keyword-type": "double",
+                "ui-name": "GC-content"
+            },
+            {
+                "path": "length",
+                "keyword-type": "integer"
+            }
+        ]
+    }]
 }

--- a/resources/types/Genome.yaml
+++ b/resources/types/Genome.yaml
@@ -3,73 +3,76 @@
 
 # The name of the type in the search system.
 global-object-type: Genome
-global-object-type-version: 1
 # The data source of the objects, in this case the Workspace.
 storage-type: WS
 # The name of the type in the data source.
 storage-object-type: KBaseGenomes.Genome
 
-# The following rules describe which fields are extracted from the source object and transforms
-# performed upon said fields.
-indexing-rules:
+# This list contains the versions of the specification, ordered by version.
+versions:
     -
-        # Extract a string from the /id path. The key name will be id.
-        path: id
-        keyword-type: string
-    -
-        # Extract a string from the /domain path. The key name will be domain.
-        path: domain
-        keyword-type: string
-    -
-        # Extract a full-text search field from the /taxonomy path. A full-text field is parsed
-        # into tokens which can be searched on individually, as opposed to a string field which is
-        # an opaque block and must be matched in its entirety.
-        # The key name will be taxonomy.
-        path: taxonomy
-        full-text: true
-    -
-        # Extract a full-text search field from the /scientific_name path.
-        # The key name will be scientific_name.
-        path: scientific_name
-        full-text: true
-    -
-        # Extract the number of features from a list at the /features path. The special {size}
-        # element directs the parser to return the size of a list or mapping. Since this number
-        # will be an integer, the keyword type is set as such.
-        # The key name is explicitly set to features, rather than implicitly set by the first
-        # section of the path.
-        path: features/{size}
-        keyword-type: integer
-        key-name: features
-    -
-        # Extract a reference to an Assembly object and transform it into a Globally Unique ID
-        # (GUID).
-        # The reference is at the /assembly_ref path.
-        path: assembly_ref
-        # The reference will be transformed into a GUID.
-        transform: guid
-        # The expected type of the object to which the reference refers is an Assembly. This is
-        # a search system type, not a data source type.
-        target-object-type: Assembly
-        target-object-type-version: 1
-        # If there is no value at the path location, substitute an empty list instead.
-        optional-default-value: []
-        # Index the transformed GUID as a string.
-        keyword-type: string
-        # The key for the transformed GUID in the search document will be assembly_guid.
-        key-name: assembly_guid
-        # Don't show the guid in any UI context when displaying search data.
-        ui-hidden: true
-    -
-        # Extract a value from an object referred to by the object that is currently being indexed,
-        # and include it in the current object.
-        # The object can be found via the GUID in the assembly_guid key above. The source key
-        # must match the key name of another indexing rule in this spec that produces a GUID.
-        source-key: assembly_guid
-        # Extract the contigs field from the target object. 'contigs' must match a key name in
-        # the search type for the target object.
-        transform: lookup.key.contigs
-        # Index the extracted field as an integer.
-        keyword-type: integer
-        # The key for the extracted field will be contigs.
-        key-name: contigs
+        # The following rules describe which fields are extracted from the source object and
+        # transforms performed upon said fields.
+        indexing-rules:
+            -
+                # Extract a string from the /id path. The key name will be id.
+                path: id
+                keyword-type: string
+            -
+                # Extract a string from the /domain path. The key name will be domain.
+                path: domain
+                keyword-type: string
+            -
+                # Extract a full-text search field from the /taxonomy path. A full-text field is
+                # parsed into tokens which can be searched on individually, as opposed to a string
+                # field which is an opaque block and must be matched in its entirety.
+                # The key name will be taxonomy.
+                path: taxonomy
+                full-text: true
+            -
+                # Extract a full-text search field from the /scientific_name path.
+                # The key name will be scientific_name.
+                path: scientific_name
+                full-text: true
+            -
+                # Extract the number of features from a list at the /features path. The special
+                # {size} element directs the parser to return the size of a list or mapping. Since
+                # this number will be an integer, the keyword type is set as such.
+                # The key name is explicitly set to features, rather than implicitly set by the
+                # first section of the path.
+                path: features/{size}
+                keyword-type: integer
+                key-name: features
+            -
+                # Extract a reference to an Assembly object and transform it into a Globally
+                # Unique ID (GUID).
+                # The reference is at the /assembly_ref path.
+                path: assembly_ref
+                # The reference will be transformed into a GUID.
+                transform: guid
+                # The expected type of the object to which the reference refers is an Assembly.
+                # This is a search system type, not a data source type.
+                target-object-type: Assembly
+                target-object-type-version: 1
+                # If there is no value at the path location, substitute an empty list instead.
+                optional-default-value: []
+                # Index the transformed GUID as a string.
+                keyword-type: string
+                # The key for the transformed GUID in the search document will be assembly_guid.
+                key-name: assembly_guid
+                # Don't show the guid in any UI context when displaying search data.
+                ui-hidden: true
+            -
+                # Extract a value from an object referred to by the object that is currently being
+                # indexed, and include it in the current object.
+                # The object can be found via the GUID in the assembly_guid key above. The source
+                # key must match the key name of another indexing rule in this spec that produces
+                # a GUID.
+                source-key: assembly_guid
+                # Extract the contigs field from the target object. 'contigs' must match a key
+                # name in the search type for the target object.
+                transform: lookup.key.contigs
+                # Index the extracted field as an integer.
+                keyword-type: integer
+                # The key for the extracted field will be contigs.
+                key-name: contigs

--- a/resources/types/GenomeFeature.json
+++ b/resources/types/GenomeFeature.json
@@ -1,105 +1,106 @@
 {
     "global-object-type": "GenomeFeature",
-    "global-object-type-version": 1,
     "ui-type-name": "Genome Feature",
     "storage-type": "WS",
     "storage-object-type": "KBaseGenomes.Genome",
-    "inner-sub-type": "feature",
-    "path-to-sub-objects": "/features/[*]/",
-    "indexing-rules": [
-        {
-            "path": "id",
-            "keyword-type": "string"
-        },
-        {
-            "path": "function",
-            "full-text": true
-        },
-        {
-            "path": "aliases/[*]",
-            "full-text": true,
-            "key-name": "aliases"
-        },
-        {
-            "path": "location",
-            "transform": "location.contig_id",
-            "full-text": true,
-            "key-name": "contig_id",
-            "ui-name": "Contig",
-            "ui-link-key": "contig_ref"
-        },
-        {
-            "derived-key": true,
-            "transform": "guid",
-            "target-object-type": "AssemblyContig",
-            "target-object-type-version": 1,
-            "source-key": "assembly_guid",
-            "subobject-id-key": "contig_id",
-            "key-name": "contig_guid",
-            "ui-hidden": true
-        },
-        {
-            "path": "location",
-            "transform": "location.start",
-            "keyword-type": "integer",
-            "key-name": "start"
-        },
-        {
-            "path": "location",
-            "transform": "location.strand",
-            "keyword-type": "string",
-            "key-name": "strand"
-        },
-        {
-            "path": "location",
-            "transform": "location.stop",
-            "keyword-type": "integer",
-            "key-name": "stop"
-        },
-        {
-            "path": "protein_translation",
-            "not-indexed": true
-        },
-        {
-            "path": "type",
-            "keyword-type": "string",
-            "key-name": "feature_type"
-        },
-        {
-            "path": "ontology_terms/*/*/id",
-            "keyword-type": "string",
-            "key-name": "ontology_terms"
-        },
-        {
-            "from-parent": true,
-            "path": "domain",
-            "keyword-type": "string",
-            "key-name": "genome_domain"
-        },
-        {
-            "from-parent": true,
-            "path": "taxonomy",
-            "full-text": true,
-            "key-name": "genome_taxonomy"
-        },
-        {
-            "from-parent": true,
-            "path": "scientific_name",
-            "full-text": true,
-            "key-name": "genome_scientific_name"
-        },
-        {
-            "from-parent": true,
-            "path": "assembly_ref",
-            "transform": "guid",
-            "target-object-type": "Assembly",
-            "target-object-type-version": 1,
-            "optional-default-value": [],
-            "keyword-type": "string",
-            "key-name": "assembly_guid",
-            "ui-hidden": true,
-            "not-indexed": true
-        }
-    ],
-    "primary-key-path": "id"
+    "versions": [{
+        "inner-sub-type": "feature",
+        "path-to-sub-objects": "/features/[*]/",
+        "primary-key-path": "id",
+        "indexing-rules": [
+            {
+                "path": "id",
+                "keyword-type": "string"
+            },
+            {
+                "path": "function",
+                "full-text": true
+            },
+            {
+                "path": "aliases/[*]",
+                "full-text": true,
+                "key-name": "aliases"
+            },
+            {
+                "path": "location",
+                "transform": "location.contig_id",
+                "full-text": true,
+                "key-name": "contig_id",
+                "ui-name": "Contig",
+                "ui-link-key": "contig_ref"
+            },
+            {
+                "derived-key": true,
+                "transform": "guid",
+                "target-object-type": "AssemblyContig",
+                "target-object-type-version": 1,
+                "source-key": "assembly_guid",
+                "subobject-id-key": "contig_id",
+                "key-name": "contig_guid",
+                "ui-hidden": true
+            },
+            {
+                "path": "location",
+                "transform": "location.start",
+                "keyword-type": "integer",
+                "key-name": "start"
+            },
+            {
+                "path": "location",
+                "transform": "location.strand",
+                "keyword-type": "string",
+                "key-name": "strand"
+            },
+            {
+                "path": "location",
+                "transform": "location.stop",
+                "keyword-type": "integer",
+                "key-name": "stop"
+            },
+            {
+                "path": "protein_translation",
+                "not-indexed": true
+            },
+            {
+                "path": "type",
+                "keyword-type": "string",
+                "key-name": "feature_type"
+            },
+            {
+                "path": "ontology_terms/*/*/id",
+                "keyword-type": "string",
+                "key-name": "ontology_terms"
+            },
+            {
+                "from-parent": true,
+                "path": "domain",
+                "keyword-type": "string",
+                "key-name": "genome_domain"
+            },
+            {
+                "from-parent": true,
+                "path": "taxonomy",
+                "full-text": true,
+                "key-name": "genome_taxonomy"
+            },
+            {
+                "from-parent": true,
+                "path": "scientific_name",
+                "full-text": true,
+                "key-name": "genome_scientific_name"
+            },
+            {
+                "from-parent": true,
+                "path": "assembly_ref",
+                "transform": "guid",
+                "target-object-type": "Assembly",
+                "target-object-type-version": 1,
+                "optional-default-value": [],
+                "keyword-type": "string",
+                "key-name": "assembly_guid",
+                "ui-hidden": true,
+                "not-indexed": true
+            }
+        ]
+    }]
 }

--- a/resources/types/Narrative.json
+++ b/resources/types/Narrative.json
@@ -1,56 +1,57 @@
 {
     "global-object-type": "Narrative",
-    "global-object-type-version": 1,
     "storage-type": "WS",
     "storage-object-type": "KBaseNarrative.Narrative",
-    "indexing-rules": [
-        {
-            "path": "metadata/name",
-            "full-text": true,
-            "key-name": "title"
-        },
-        {
-            "path": "cells/[*]/source",
-            "full-text": true,
-            "key-name": "source"
-        },
-        {
-            "path": "cells/[*]/outputs/[*]/text",
-            "full-text": true,
-            "key-name": "code_output",
-            "ui-name": "Code Output"
-        },
-        {
-            "path": "cells/[*]/outputs/[*]/data",
-            "full-text": true,
-            "transform": "string",
-            "key-name": "code_output",
-            "ui-name": "Code Output"
-        },
-        {
-            "path": "cells/[*]/metadata/kbase/outputCell/widget/params",
-            "full-text": true,
-            "transform": "values",
-            "key-name": "app_output",
-            "ui-name": "App Output"
-        },
-        {
-            "path": "cells/[*]/metadata/kbase/appCell/app/spec/info",
-            "full-text": true,
-            "transform": "values",
-            "key-name": "app_info",
-            "ui-name": "App Info"
-        },
-        {
-            "path": "cells/[*]/metadata/kbase/appCell/params",
-            "full-text": true,
-            "transform": "values",
-            "key-name": "app_input"
-        },
-        {
-            "path": "cells/[*]/metadata/kbase/outputCell/jobId",
-            "keyword-type": "string",
-            "key-name": "job_ids"
-        }
-    ]
+    "versions": [{
+        "indexing-rules": [
+            {
+                "path": "metadata/name",
+                "full-text": true,
+                "key-name": "title"
+            },
+            {
+                "path": "cells/[*]/source",
+                "full-text": true,
+                "key-name": "source"
+            },
+            {
+                "path": "cells/[*]/outputs/[*]/text",
+                "full-text": true,
+                "key-name": "code_output",
+                "ui-name": "Code Output"
+            },
+            {
+                "path": "cells/[*]/outputs/[*]/data",
+                "full-text": true,
+                "transform": "string",
+                "key-name": "code_output",
+                "ui-name": "Code Output"
+            },
+            {
+                "path": "cells/[*]/metadata/kbase/outputCell/widget/params",
+                "full-text": true,
+                "transform": "values",
+                "key-name": "app_output",
+                "ui-name": "App Output"
+            },
+            {
+                "path": "cells/[*]/metadata/kbase/appCell/app/spec/info",
+                "full-text": true,
+                "transform": "values",
+                "key-name": "app_info",
+                "ui-name": "App Info"
+            },
+            {
+                "path": "cells/[*]/metadata/kbase/appCell/params",
+                "full-text": true,
+                "transform": "values",
+                "key-name": "app_input"
+            },
+            {
+                "path": "cells/[*]/metadata/kbase/outputCell/jobId",
+                "keyword-type": "string",
+                "key-name": "job_ids"
+            }
+        ]
+    }]
 }

--- a/resources/types/PairedEndLibrary.json
+++ b/resources/types/PairedEndLibrary.json
@@ -1,55 +1,56 @@
 {
     "global-object-type": "PairedEndLibrary",
-    "global-object-type-version": 1,
     "ui-type-name": "Paired End Library",
     "storage-type": "WS",
     "storage-object-type": "KBaseFile.PairedEndLibrary",
-    "indexing-rules": [
-        {
-            "path": "sequencing_tech",
-            "full-text": true,
-            "key-name": "technology"
-        },
-        {
-            "path": "lib1/file/file_name",
-            "full-text": true,
-            "key-name": "files"
-        },
-        {
-            "path": "lib2/file/file_name",
-            "full-text": true,
-            "key-name": "files"
-        },
-        {
-            "path": "phred_type",
-            "keyword-type": "string"
-        },
-        {
-            "path": "read_count",
-            "keyword-type": "integer",
-            "ui-name": "Number of reads"
-        },
-        {
-            "path": "read_length_mean",
-            "keyword-type": "integer",
-            "key-name": "read_length",
-            "ui-name": "Read length"
-        },
-        {
-            "path": "insert_size_mean",
-            "keyword-type": "integer",
-            "key-name": "insert_size",
-            "ui-name": "Insert size"
-        },
-        {
-            "path": "qual_mean",
-            "keyword-type": "double",
-            "key-name": "quality"
-        },
-        {
-            "path": "gc_content",
-            "keyword-type": "double",
-            "ui-name": "GC-content"
-        }
-    ]
+    "versions": [{
+        "indexing-rules": [
+            {
+                "path": "sequencing_tech",
+                "full-text": true,
+                "key-name": "technology"
+            },
+            {
+                "path": "lib1/file/file_name",
+                "full-text": true,
+                "key-name": "files"
+            },
+            {
+                "path": "lib2/file/file_name",
+                "full-text": true,
+                "key-name": "files"
+            },
+            {
+                "path": "phred_type",
+                "keyword-type": "string"
+            },
+            {
+                "path": "read_count",
+                "keyword-type": "integer",
+                "ui-name": "Number of reads"
+            },
+            {
+                "path": "read_length_mean",
+                "keyword-type": "integer",
+                "key-name": "read_length",
+                "ui-name": "Read length"
+            },
+            {
+                "path": "insert_size_mean",
+                "keyword-type": "integer",
+                "key-name": "insert_size",
+                "ui-name": "Insert size"
+            },
+            {
+                "path": "qual_mean",
+                "keyword-type": "double",
+                "key-name": "quality"
+            },
+            {
+                "path": "gc_content",
+                "keyword-type": "double",
+                "ui-name": "GC-content"
+            }
+        ]
+    }]
 }

--- a/resources/types/SeedOntologyTerm.json
+++ b/resources/types/SeedOntologyTerm.json
@@ -1,14 +1,13 @@
 {
     "global-object-type": "SeedOntologyTerm",
-    "global-object-type-version": 1,
     "storage-type": "SeedOntologyDataSource",
     "storage-object-type": "fake",
-    "primary-key-path": "id",
-    "indexing-rules": [
-        {
-            "path": "id",
-            "keyword-type": "string"
-        }
-    ],
-    "primary-key-path": "id"
+    "versions": [{
+        "indexing-rules": [
+            {
+                "path": "id",
+                "keyword-type": "string"
+            }
+        ]
+    }]
 }

--- a/resources/types/SingleEndLibrary.json
+++ b/resources/types/SingleEndLibrary.json
@@ -1,44 +1,45 @@
 {
     "global-object-type": "SingleEndLibrary",
-    "global-object-type-version": 1,
     "ui-type-name": "Single End Library",
     "storage-type": "WS",
     "storage-object-type": "KBaseFile.SingleEndLibrary",
-    "indexing-rules": [
-        {
-            "path": "sequencing_tech",
-            "full-text": true,
-            "key-name": "technology"
-        },
-        {
-            "path": "lib/file/file_name",
-            "full-text": true,
-            "key-name": "file"
-        },
-        {
-            "path": "phred_type",
-            "keyword-type": "string"
-        },
-        {
-            "path": "read_count",
-            "keywork-type": "integer",
-            "ui-name": "Number of reads"
-        },
-        {
-            "path": "read_length_mean",
-            "keyword-type": "integer",
-            "key-name": "read_length",
-            "ui-name": "Read length"
-        },
-        {
-            "path": "qual_mean",
-            "keyword-type": "double",
-            "key-name": "quality"
-        },
-        {
-            "path": "gc_content",
-            "keyword-type": "double",
-            "ui-name": "GC-content"
-        }
-    ]
+    "versions": [{
+        "indexing-rules": [
+            {
+                "path": "sequencing_tech",
+                "full-text": true,
+                "key-name": "technology"
+            },
+            {
+                "path": "lib/file/file_name",
+                "full-text": true,
+                "key-name": "file"
+            },
+            {
+                "path": "phred_type",
+                "keyword-type": "string"
+            },
+            {
+                "path": "read_count",
+                "keywork-type": "integer",
+                "ui-name": "Number of reads"
+            },
+            {
+                "path": "read_length_mean",
+                "keyword-type": "integer",
+                "key-name": "read_length",
+                "ui-name": "Read length"
+            },
+            {
+                "path": "qual_mean",
+                "keyword-type": "double",
+                "key-name": "quality"
+            },
+            {
+                "path": "gc_content",
+                "keyword-type": "double",
+                "ui-name": "GC-content"
+            }
+        ]
+    }]
 }

--- a/test/src/kbasesearchengine/test/data/EmptyAType.json
+++ b/test/src/kbasesearchengine/test/data/EmptyAType.json
@@ -1,13 +1,14 @@
 {
     "global-object-type": "EmptyAType",
-    "global-object-type-version": 1,
     "ui-type-name": "A Type",
     "storage-type": "WS",
     "storage-object-type": "Empty.AType",
-    "indexing-rules": [
-        {
-            "path": "whee",
-            "keyword-type": "string"
-        }
-    ]
+    "versions": [{
+        "indexing-rules": [
+            {
+                "path": "whee",
+                "keyword-type": "string"
+            }
+        ]
+    }]
 }

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -113,7 +113,8 @@ public class ElasticIndexingStorageTest {
             public ObjectTypeParsingRules getTypeDescriptor(SearchObjectType type) {
                 try {
                     final File rulesFile = new File("resources/types/" + type.getType() + ".json");
-                    return ObjectTypeParsingRulesUtils.fromFile(rulesFile);
+                    return ObjectTypeParsingRulesUtils.fromFile(rulesFile)
+                            .get(type.getVersion() - 1);
                 } catch (Exception ex) {
                     throw new IllegalStateException(ex);
                 }
@@ -167,7 +168,7 @@ public class ElasticIndexingStorageTest {
         // yuck
         final String extension = type.equals("Genome") ? ".yaml" : ".json";
         final File file = new File("resources/types/" + type + extension);
-        ObjectTypeParsingRules parsingRules = ObjectTypeParsingRulesUtils.fromFile(file);
+        ObjectTypeParsingRules parsingRules = ObjectTypeParsingRulesUtils.fromFile(file).get(0);
         Map<ObjectJsonPath, String> pathToJson = new LinkedHashMap<>();
         SubObjectConsumer subObjConsumer = new SimpleSubObjectConsumer(pathToJson);
         String parentJson = null;


### PR DESCRIPTION
Files now support multiple versions per type in one file.

TODO:

* Need to add some tests here, but adding cases for incorrectly
formatted files is a real pain. Preferably add JSONSchema check for file
contents after a YAML parse.
* Make TypeMappings version aware.