### PR TITLE
SCT-178 Make type mappings version aware

### DIFF
--- a/lib/src/kbasesearchengine/system/YAMLTypeMappingParser.java
+++ b/lib/src/kbasesearchengine/system/YAMLTypeMappingParser.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,7 +27,8 @@ import kbasesearchengine.tools.Utils;
 public class YAMLTypeMappingParser implements TypeMappingParser {
     
     //TODO TEST
-    // there's got to be some code to validate the structure of arbitrary java objects, have a look around
+    //TODO CODE there's got to be some code to validate the structure of arbitrary java objects, have a look around. Try jsonschema 
+    //TODO CODE error checking sucks
     
     private static final String TYPES_PATH = "/types";
     
@@ -69,17 +69,14 @@ public class YAMLTypeMappingParser implements TypeMappingParser {
         final TypeMapping.Builder b = TypeMapping.getBuilder(storageCode, type)
                 .withNullableSourceInfo(sourceInfo);
         String pathPrefix = TYPES_PATH + "/" + type + "/";
-        final List<String> searchTypes = getStringList(
-                typeinfo, "types", pathPrefix + "type", sourceInfo, false);
+        final List<SearchObjectType> searchTypes = getSearchTypes(
+                typeinfo, "types", pathPrefix + "types", sourceInfo, false);
         if (!searchTypes.isEmpty()) {
-            for (final String s: searchTypes) {
-                b.withNullableDefaultSearchType(s);
-            }
+            searchTypes.stream().forEach(t -> b.withDefaultSearchType(t));
             return b.build();
         }
-        final List<String> default_ = getStringList(
-                typeinfo, "default", pathPrefix + "default", sourceInfo, false);
-        default_.stream().forEach(i -> b.withNullableDefaultSearchType(i));
+        getSearchTypes(typeinfo, "default", pathPrefix + "default", sourceInfo, false).stream()
+                .forEach(t -> b.withDefaultSearchType(t));
         final String verPathPrefix = pathPrefix + "versions";
         final Map<Integer, Object> versions = getIntMap(
                 typeinfo, "versions", verPathPrefix, sourceInfo);
@@ -89,9 +86,8 @@ public class YAMLTypeMappingParser implements TypeMappingParser {
                 throw new TypeParseException(String.format(
                         "Version less than 0 at %s.%s", verpath, fmt(sourceInfo)));
             }
-            final List<String> searchVerType = getStringList(
-                    versions, v, verpath, sourceInfo, true);
-            searchVerType.stream().forEach(i -> b.withVersion(v, i));
+            getSearchTypes(versions, v, verpath, sourceInfo, true).stream()
+                    .forEach(t -> b.withVersion(v, t));
         }
         if (!b.isBuildReady()) {
             throw new TypeParseException(String.format(
@@ -100,12 +96,13 @@ public class YAMLTypeMappingParser implements TypeMappingParser {
         return b.build();
     }
 
-    private List<String> getStringList(
+    private List<SearchObjectType> getSearchTypes(
             final Map<?, Object> map,
             final Object key,
             final String path,
             final String sourceInfo,
-            final boolean required) throws TypeParseException {
+            final boolean required)
+            throws TypeParseException {
         final Object value = map.get(key);
         if (value == null) {
             if (required) {
@@ -114,36 +111,36 @@ public class YAMLTypeMappingParser implements TypeMappingParser {
                 return Collections.emptyList();
             }
         }
-        if (value instanceof String) {
-            if (Utils.isNullOrEmpty((String) value)) {
-                if (required) {
-                    throw new TypeParseException(
-                            "Missing value at " + path + "." + fmt(sourceInfo));
-                }
-                return Collections.emptyList();
-            }
-            return Arrays.asList((String) value);
+        if (!(value instanceof List)) {
+            throw new TypeParseException("Expected list at " + path + "." + fmt(sourceInfo));
         }
-        if (value instanceof List) {
+        @SuppressWarnings("unchecked")
+        final List<Object> otypes = (List<Object>) value;
+        final List<SearchObjectType> ret = new LinkedList<>();
+        for (int i = 0; i < otypes.size(); i++) {
+            final Object putativeType = otypes.get(i);
+            if (!(putativeType instanceof Map)) {
+                throw new TypeParseException(String.format(
+                        "Expected mapping at %s position %s.%s", path, i, fmt(sourceInfo)));
+            }
             @SuppressWarnings("unchecked")
-            final List<Object> value2 = (List<Object>) value;
-            final List<String> ret = new LinkedList<>();
-            int count = 0;
-            for (final Object o: value2) {
-                if (o == null || !(o instanceof String) || Utils.isNullOrEmpty((String) o)) {
-                    throw new TypeParseException(String.format(
-                            "Expected non-whitespace string, got [%s] at %s.%s",
-                            o, path + "/" + count, fmt(sourceInfo)));
-                }
-                ret.add((String) o);
-                count++;
+            final Map<Object, Object> putativeType2 = (Map<Object, Object>) putativeType;
+            final Object typeName = putativeType2.get("type");
+            final Object typeVer = putativeType2.get("version");
+            if (typeName == null || !(typeName instanceof String) ||
+                    Utils.isNullOrEmpty((String) typeName)) {
+                throw new TypeParseException(String.format(
+                        "Expected type name at %s/%s/type.%s", path, i, fmt(sourceInfo)));
             }
-            return ret;
+            if (typeVer == null || !(typeVer instanceof Integer)) {
+                throw new TypeParseException(String.format(
+                        "Expected type version at %s/%s/version.%s", path, i, fmt(sourceInfo)));
+            }
+            ret.add(new SearchObjectType((String) typeName, (int) typeVer));
         }
-        throw new TypeParseException(String.format(
-                "Expected list or string, got %s at %s.%s", value, path, fmt(sourceInfo)));
+        return ret;
     }
-
+    
     private String fmt(final String sourceInfo) {
         return sourceInfo == null ? "" : 
             sourceInfo.trim().isEmpty() ? "" : " Source: " + sourceInfo;

--- a/resources/typemappings/GenomeAndAssembly.yaml.example
+++ b/resources/typemappings/GenomeAndAssembly.yaml.example
@@ -3,12 +3,13 @@
 # parameters).
 
 # Type mappings specified in a mappings file override any equivalent mappings in the type
-# transformation files.
+# transformation files. If no type mappings exist for the transformation files, the latest
+# version of the parsing rules embedded in the file is used.
 
 # Type mappings can be split or combined among files as desired, except that only one storage
 # type can be specified per mapping file.
 
-# Currently only YAML files are supported for type mappings.
+# Currently only YAML-compatible files are supported for type mappings.
 
 # specify the storage type (e.g. the source of the data)
 storage-type: WS
@@ -19,7 +20,14 @@ types:
     # A simple mapping that is a map from the storage object type to the search type(s).
     KBaseGenomeAnnotations.Assembly:
         # if types is present any other fields are ignored.
-        types: [Assembly]
+        types:
+            -
+                type: Assembly
+                version: 1
+            -
+                type: AssemblyContig
+                version: 2
+
     # A more complex mapping that takes versions of the storage object type into account.
     KBaseGenome.Genome:
         # Specify the default search type(s) to use if a specific version of the storage object
@@ -27,10 +35,38 @@ types:
         # specified, the object will not be indexed. Even with a default type, objects may fail
         # to index if the new object type version is not backwards compatible with the default 
         # version.
-        default: [Genome3, GenomeFeature2]
+        default:
+           -
+               type: Genome
+               version: 3
+           -
+               type: GenomeFeature
+               version: 2
+
         # specify versions of the storage type and how they map to the search types.
         versions:
-            1: [Genome1, GenomeFeature1]
-            2: Genome1
-            3: [Genome2, GenomeFeature2]
-            4: [Genome3, GenomeFeature2]
+            1:
+                -
+                    type: Genome
+                    version: 1
+                -
+                    type: GenomeFeature
+                    version: 1
+            2:
+                -
+                    type: Genome
+                    version: 1
+            3:
+                -
+                    type: Genome
+                    version: 2
+                -
+                    type: GenomeFeature
+                    version: 2
+            4:
+                -
+                    type: Genome
+                    version: 3
+                -
+                    type: GenomeFeature
+                    version: 2

--- a/resources/types/Genome.yaml
+++ b/resources/types/Genome.yaml
@@ -8,7 +8,11 @@ storage-type: WS
 # The name of the type in the data source.
 storage-object-type: KBaseGenomes.Genome
 
-# This list contains the versions of the specification, ordered by version.
+# This list contains different versions of the parsing rules used to parse the specified
+# storage-object-type. The list is ordered by version number. Each parsing rule version results
+# in a corresponding search type version. The mapping between the source storage-object-type
+# version and the target search type version is specified by the type mappings.
+# If no type mapping is specified for this type, the latest version is used.
 versions:
     -
         # The following rules describe which fields are extracted from the source object and

--- a/test/src/kbasesearchengine/test/data/EmptyAType.json
+++ b/test/src/kbasesearchengine/test/data/EmptyAType.json
@@ -1,4 +1,5 @@
 {
+    # a test spec.
     "global-object-type": "EmptyAType",
     "ui-type-name": "A Type",
     "storage-type": "WS",

--- a/test/src/kbasesearchengine/test/system/TypeMappingTest.java
+++ b/test/src/kbasesearchengine/test/system/TypeMappingTest.java
@@ -9,7 +9,9 @@ import org.junit.Test;
 
 import com.google.common.base.Optional;
 
+import kbasesearchengine.system.SearchObjectType;
 import kbasesearchengine.system.TypeMapping;
+import kbasesearchengine.system.TypeMapping.Builder;
 import kbasesearchengine.test.common.TestCommon;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -26,7 +28,7 @@ public class TypeMappingTest {
         
         assertThat("incorrect buildReady", b.isBuildReady(), is(false));
         
-        b.withNullableDefaultSearchType("bar");
+        b.withDefaultSearchType(new SearchObjectType("bar", 2));
         
         assertThat("incorrect buildReady", b.isBuildReady(), is(true));
         
@@ -34,15 +36,13 @@ public class TypeMappingTest {
         
         assertThat("incorrect storage code", tm.getStorageCode(), is("WS"));
         assertThat("incorrect storage type", tm.getStorageType(), is("foo"));
-        assertThat("incorrect search types", tm.getSearchTypes(), is(set("bar")));
+        assertThat("incorrect search types", tm.getSearchTypes(),
+                is(set(new SearchObjectType("bar", 2))));
         assertThat("incorrect search types without version", tm.getSearchTypes(Optional.absent()),
-                is(set("bar")));
+                is(set(new SearchObjectType("bar", 2))));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(1)),
-                is(set("bar")));
+                is(set(new SearchObjectType("bar", 2))));
         assertThat("incorrect source info", tm.getSourceInfo(), is(Optional.absent()));
-        assertThat("incorrect toString", tm.toString(),
-                is("TypeMapping [storageCode=WS, storageType=foo, sourceInfo=Optional.absent(), " +
-                        "defaultSearchTypes=[bar], versions={}]"));
     }
     
     @Test
@@ -51,7 +51,7 @@ public class TypeMappingTest {
         
         assertThat("incorrect buildReady", b.isBuildReady(), is(false));
         
-        b.withVersion(3, "baz");
+        b.withVersion(3, new SearchObjectType("baz", 1));
         
         assertThat("incorrect buildReady", b.isBuildReady(), is(true));
         
@@ -59,61 +59,54 @@ public class TypeMappingTest {
         
         assertThat("incorrect storage code", tm.getStorageCode(), is("WS1"));
         assertThat("incorrect storage type", tm.getStorageType(), is("foo1"));
-        assertThat("incorrect search types", tm.getSearchTypes(), is(set("baz")));
+        assertThat("incorrect search types", tm.getSearchTypes(),
+                is(set(new SearchObjectType("baz", 1))));
         assertThat("incorrect search types without version", tm.getSearchTypes(Optional.absent()),
                 is(set()));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(1)),
                 is(set()));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(3)),
-                is(set("baz")));
+                is(set(new SearchObjectType("baz", 1))));
         assertThat("incorrect source info", tm.getSourceInfo(), is(Optional.absent()));
-        assertThat("incorrect toString", tm.toString(),
-                is("TypeMapping [storageCode=WS1, storageType=foo1, " +
-                        "sourceInfo=Optional.absent(), defaultSearchTypes=[], " +
-                        "versions={3=[baz]}]"));
     }
     
     @Test
     public void maximalBuild() {
         final TypeMapping tm = TypeMapping.getBuilder("WS2", "foo2")
-                .withNullableDefaultSearchType("foo")
-                .withNullableDefaultSearchType("bar")
-                .withNullableDefaultSearchType("foo")
-                .withVersion(0, "0")
-                .withVersion(3, "baz")
-                .withVersion(4, "bat")
-                .withVersion(3, "bag")
-                .withVersion(3, "baz")
+                .withDefaultSearchType(new SearchObjectType("foo", 16))
+                .withDefaultSearchType(new SearchObjectType("bar", 3))
+                .withDefaultSearchType(new SearchObjectType("foo", 26))
+                .withVersion(0, new SearchObjectType("a0", 1))
+                .withVersion(3, new SearchObjectType("baz", 6))
+                .withVersion(4, new SearchObjectType("bat", 8))
+                .withVersion(3, new SearchObjectType("bar", 10))
+                .withVersion(3, new SearchObjectType("baz", 4))
                 .withNullableSourceInfo("whee")
                 .build();
         
         assertThat("incorrect storage code", tm.getStorageCode(), is("WS2"));
         assertThat("incorrect storage type", tm.getStorageType(), is("foo2"));
         assertThat("incorrect search types", tm.getSearchTypes(),
-                is(set("0", "foo", "bar", "baz", "bat", "bag")));
+                is(set(new SearchObjectType("a0", 1), new SearchObjectType("foo", 26),
+                        new SearchObjectType("bar", 3), new SearchObjectType("bar", 10),
+                        new SearchObjectType("baz", 4), new SearchObjectType("bat", 8))));
         assertThat("incorrect search types without version", tm.getSearchTypes(Optional.absent()),
-                is(set("foo", "bar")));
+                is(set(new SearchObjectType("foo", 26), new SearchObjectType("bar", 3))));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(0)),
-                is(set("0")));
+                is(set(new SearchObjectType("a0", 1))));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(1)),
-                is(set("foo", "bar")));
+                is(set(new SearchObjectType("foo", 26), new SearchObjectType("bar", 3))));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(3)),
-                is(set("baz", "bag")));
+                is(set(new SearchObjectType("baz", 4), new SearchObjectType("bar", 10))));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(4)),
-                is(set("bat")));
+                is(set(new SearchObjectType("bat", 8))));
         assertThat("incorrect source info", tm.getSourceInfo(), is(Optional.of("whee")));
-        assertThat("incorrect toString", tm.toString(),
-                is("TypeMapping [storageCode=WS2, storageType=foo2, " +
-                        "sourceInfo=Optional.of(whee), defaultSearchTypes=[bar, foo], " +
-                        "versions={0=[0], 3=[bag, baz], 4=[bat]}]"));
     }
     
     @Test
     public void nullableAndWhitespaceBuild() {
         final TypeMapping tm = TypeMapping.getBuilder("WS3", "foo3")
-                .withNullableDefaultSearchType("foo")
-                .withNullableDefaultSearchType(null)
-                .withNullableDefaultSearchType("   \t  \n ")
+                .withDefaultSearchType(new SearchObjectType("bar", 10))
                 .withNullableSourceInfo("whee")
                 .withNullableSourceInfo(null)
                 .withNullableSourceInfo("  \n  \t   ")
@@ -122,34 +115,31 @@ public class TypeMappingTest {
         assertThat("incorrect storage code", tm.getStorageCode(), is("WS3"));
         assertThat("incorrect storage type", tm.getStorageType(), is("foo3"));
         assertThat("incorrect search types", tm.getSearchTypes(),
-                is(set("foo")));
+                is(set(new SearchObjectType("bar", 10))));
         assertThat("incorrect search types without version", tm.getSearchTypes(Optional.absent()),
-                is(set("foo")));
+                is(set(new SearchObjectType("bar", 10))));
         assertThat("incorrect search types with version", tm.getSearchTypes(Optional.of(1)),
-                is(set("foo")));
+                is(set(new SearchObjectType("bar", 10))));
         assertThat("incorrect source info", tm.getSourceInfo(), is(Optional.absent()));
-        assertThat("incorrect toString", tm.toString(),
-                is("TypeMapping [storageCode=WS3, storageType=foo3, " +
-                        "sourceInfo=Optional.absent(), defaultSearchTypes=[foo], versions={}]"));
     }
     
     @Test
     public void immutable() {
         //test that returned sets are immutable.
         final TypeMapping tm = TypeMapping.getBuilder("a", "b")
-                .withNullableDefaultSearchType("whee")
-                .withVersion(1, "whoo")
+                .withDefaultSearchType(new SearchObjectType("bar", 10))
+                .withVersion(1, new SearchObjectType("whee", 1))
                 .build();
         try {
             // test default types
-            tm.getSearchTypes(Optional.of(2)).add("baz");
+            tm.getSearchTypes(Optional.of(2)).add(new SearchObjectType("bat", 10));
             fail("expected exception");
         } catch (UnsupportedOperationException e) {
             // test passed
         }
         try {
             // test versioned types
-            tm.getSearchTypes(Optional.of(1)).add("baz");
+            tm.getSearchTypes(Optional.of(1)).add(new SearchObjectType("bat", 10));
             fail("expected exception");
         } catch (UnsupportedOperationException e) {
             // test passed
@@ -181,17 +171,26 @@ public class TypeMappingTest {
     }
     
     @Test
+    public void withDefaultFail() {
+        final Builder tm = TypeMapping.getBuilder("a", "b");
+        try {
+            tm.withDefaultSearchType(null);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, new NullPointerException("searchType"));
+        }
+    }
+    
+    @Test
     public void withVersionFail() {
-        failWithVersion(-1, "foo", new IllegalArgumentException("version must be at least 0"));
-        failWithVersion(0, null,
-                new IllegalArgumentException("searchType cannot be null or the empty string"));
-        failWithVersion(0, "   \t ",
-                new IllegalArgumentException("searchType cannot be null or the empty string"));
+        failWithVersion(-1, new SearchObjectType("t", 1),
+                new IllegalArgumentException("version must be at least 0"));
+        failWithVersion(0, null, new NullPointerException("searchType"));
     }
     
     private void failWithVersion(
             final int ver,
-            final String type,
+            final SearchObjectType type,
             final Exception expected) {
         try {
             TypeMapping.getBuilder("a", "b").withVersion(ver, type);
@@ -221,8 +220,9 @@ public class TypeMappingTest {
     
     private void failGetSearchTypes(final Optional<Integer> version, final Exception expected) {
         try {
-            TypeMapping.getBuilder("a", "b").withNullableDefaultSearchType("c").build()
-                .getSearchTypes(version);
+            TypeMapping.getBuilder("a", "b")
+                    .withDefaultSearchType(new SearchObjectType("bar", 10)).build()
+                    .getSearchTypes(version);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);


### PR DESCRIPTION
Tested the type mapping parser manually against the one mapping
available.

TODO:

* Write tests for TypeFileStorage. It's too complicated at this point to
not have tests.
* Write a test for elastic indexing storage with a type with versions
with incompatible fields.