### PR TITLE
SCT-328 Allow search specs without indexing rules

### DIFF
--- a/lib/src/kbasesearchengine/parse/SubObjectExtractor.java
+++ b/lib/src/kbasesearchengine/parse/SubObjectExtractor.java
@@ -18,58 +18,58 @@ import kbasesearchengine.common.ObjectJsonPath;
  */
 public class SubObjectExtractor {
 
-	/**
-	 * Extract the fields listed in selection from the element and add them to the subset.
-	 * 
-	 * selection must either be an object containing structure field names to extract, '*' in the case of
-	 * extracting a mapping, or '[*]' for extracting a list.  if the selection is empty, nothing is added.
-	 * If extractKeysOf is set, and the element is an Object (ie a kidl mapping), then an array of the keys
-	 * is added instead of the entire mapping.
-	 * 
-	 * we assume here that selection has already been validated against the structure of the document, so that
-	 * if we get true on extractKeysOf, it really is a mapping, and if we get a '*' or '[*]', it really is
-	 * a mapping or array.
-	 * @throws ObjectParseException 
-	 */
-	public static void extract(ObjectJsonPath pathToSub, List<ObjectJsonPath> objpaths, 
-	        JsonParser jts, SubObjectConsumer consumer) throws IOException, ObjectParseException {
-		//if the selection is empty, we return without adding anything
-		SubObjectExtractionNode root = new SubObjectExtractionNode();
-		SubObjectExtractionNode sub = root.addPath(pathToSub, true, false);
-		for (ObjectJsonPath path: objpaths) {
-		    sub.addPath(JsonTokenUtil.trimPath(path), false, true);
-		}
-		extract(root, jts, consumer);
-	}
-	
-	public static void extract(SubObjectExtractionNode tree, JsonParser jts, 
-	        SubObjectConsumer consumer) throws IOException, ObjectParseException {
-		JsonToken t = jts.nextToken();
-		extractFieldsWithOpenToken(jts, t, tree, consumer, new ArrayList<String>(), 
-		        false, false, true);
-		consumer.flush();
-	}
-	
-	/*
-	 * This is main recursive method for tracking current token place in subset schema tree
-	 * and making decisions whether or not we need to process this token or block of tokens or
-	 * just skip it.
-	 */
-	private static void extractFieldsWithOpenToken(JsonParser jts, JsonToken current, 
-			SubObjectExtractionNode selection, SubObjectConsumer consumer, 
-			List<String> path, boolean strictMaps, boolean strictArrays,
-			boolean fromSkippedLevel) throws IOException, ObjectParseException {
-	    if (fromSkippedLevel && !selection.isSkipLevel()) {
-	        // It means we're starting sub-object (or whole object is needed)
-	        consumer.nextObject(ObjectJsonPath.getPathText(path));
-	    }
-		JsonToken t = current;
-		boolean skipLvl = selection.isSkipLevel();
-		if (t == JsonToken.START_OBJECT) {	// we observe open of mapping/object in real json data
-			if (selection.hasChildren()) {	// we have some restrictions for this object in selection
-				// we will remove visited keys from selectedFields and check emptiness at object end
-				Set<String> selectedFields = new LinkedHashSet<String>(
-				        selection.getChildren().keySet());
+    /**
+     * Extract the fields listed in selection from the element and add them to the subset.
+     *
+     * selection must either be an object containing structure field names to extract, '*' in the case of
+     * extracting a mapping, or '[*]' for extracting a list.  if the selection is empty, nothing is added.
+     * If extractKeysOf is set, and the element is an Object (ie a kidl mapping), then an array of the keys
+     * is added instead of the entire mapping.
+     *
+     * we assume here that selection has already been validated against the structure of the document, so that
+     * if we get true on extractKeysOf, it really is a mapping, and if we get a '*' or '[*]', it really is
+     * a mapping or array.
+     * @throws ObjectParseException
+     */
+    public static void extract(ObjectJsonPath pathToSub, List<ObjectJsonPath> objpaths,
+            JsonParser jts, SubObjectConsumer consumer) throws IOException, ObjectParseException {
+        //if the selection is empty, we return without adding anything
+        SubObjectExtractionNode root = new SubObjectExtractionNode();
+        SubObjectExtractionNode sub = root.addPath(pathToSub, true, false);
+        for (ObjectJsonPath path: objpaths) {
+            sub.addPath(JsonTokenUtil.trimPath(path), false, true);
+        }
+        extract(root, jts, consumer);
+    }
+    
+    public static void extract(SubObjectExtractionNode tree, JsonParser jts,
+            SubObjectConsumer consumer) throws IOException, ObjectParseException {
+        JsonToken t = jts.nextToken();
+        extractFieldsWithOpenToken(jts, t, tree, consumer, new ArrayList<String>(),
+                false, false, true);
+        consumer.flush();
+    }
+    
+    /*
+     * This is main recursive method for tracking current token place in subset schema tree
+     * and making decisions whether or not we need to process this token or block of tokens or
+     * just skip it.
+     */
+    private static void extractFieldsWithOpenToken(JsonParser jts, JsonToken current,
+            SubObjectExtractionNode selection, SubObjectConsumer consumer,
+            List<String> path, boolean strictMaps, boolean strictArrays,
+            boolean fromSkippedLevel) throws IOException, ObjectParseException {
+        if (fromSkippedLevel && !selection.isSkipLevel()) {
+            // It means we're starting sub-object (or whole object is needed)
+            consumer.nextObject(ObjectJsonPath.getPathText(path));
+        }
+        JsonToken t = current;
+        boolean skipLvl = selection.isSkipLevel();
+        if (t == JsonToken.START_OBJECT) {    // we observe open of mapping/object in real json data
+            if (selection.hasChildren()) {    // we have some restrictions for this object in selection
+                // we will remove visited keys from selectedFields and check emptiness at object end
+                Set<String> selectedFields = new LinkedHashSet<String>(
+                        selection.getChildren().keySet());
                 if (selectedFields.size() == 1 && selectedFields.contains("{size}")) {
                     int size = 0;
                     while (true) {
@@ -148,118 +148,118 @@ public class SubObjectExtractor {
                                 getPathText(path, notFound));
                     }
                 }
-			} else {  // need all fields and values
-			    if (selection.isNeedAll()) {
-			        JsonTokenUtil.writeTokensFromCurrent(jts, t, consumer.getOutput());
-			    } else {
-			        JsonTokenUtil.skipChildren(jts, t);
-			    }
-			}
-		} else if (t == JsonToken.START_ARRAY) {	// we observe open of array/list in real json data
-		    if (selection.hasChildren()) {  // we have some restrictions for array item positions in selection
-		        Set<String> selectedFields = new LinkedHashSet<String>(
-		                selection.getChildren().keySet());
-		        if (selectedFields.size() == 1 && selectedFields.contains("{size}")) {
-		            int size = 0;
-		            while (true) {
-		                t = jts.nextToken();
-		                if (t == JsonToken.END_ARRAY) {
-		                    break;
-		                }
-		                JsonTokenUtil.skipChildren(jts, t);
-		                size++;
-		            }
-		            consumer.getOutput().writeNumber(size);
-		        } else {
-		            SubObjectExtractionNode allChild = null;
-		            // now we support only '[*]' which means all elements and set of numbers in case of 
-		            // certain item positions are selected in array
-		            if (!selectedFields.contains("[*]")) {
-		                for (String item : selectedFields) {
-		                    try {
-		                        Integer.parseInt(item);
-		                    } catch (NumberFormatException ex) {
-		                        throw new ObjectParseException("Invalid selection: data at '" + 
-		                                ObjectJsonPath.getPathText(path) + "' is an array, so " +
-		                                "element selection must be an integer. You requested element" +
-		                                " '" + item + "', at: " + ObjectJsonPath.getPathText(path));
-		                    }
-		                }
-		            }
-		            if (selectedFields.contains("[*]")) {
-		                selectedFields.remove("[*]");
-		                allChild = selection.getChildren().get("[*]");
-		                // if there is [*] keyword selected there shouldn't be anything else in selection
-		                if (selectedFields.size() > 0)
-		                    throw new ObjectParseException("Invalid selection: the selection path " +
-		                            "contains both '[*]' to select all elements and selection of " +
-		                            "specific elements (" + selectedFields + "), at: " + 
-		                            ObjectJsonPath.getPathText(path));
-		            }
-		            if (!skipLvl) {
-		                JsonTokenUtil.writeCurrentToken(jts, t, consumer.getOutput());  // write start of array into output
-		            }
-		            for (int pos = 0; ; pos++) {
-		                t = jts.nextToken();
-		                if (t == JsonToken.END_ARRAY) {
-		                    if (!skipLvl) {
-		                        JsonTokenUtil.writeCurrentToken(jts, t, consumer.getOutput());
-		                    }
-		                    break;
-		                }
-		                SubObjectExtractionNode child = null;
-		                if (allChild != null) {
-		                    child = allChild; 
-		                } else {
-		                    String key = "" + pos;
-		                    if (selection.getChildren().containsKey(key)) {
-		                        child = selection.getChildren().get(key);
-		                        selectedFields.remove(key);
-		                    }
-		                }
-		                if (child == null) {
-		                    // this element of array is not selected, skip it
-		                    JsonTokenUtil.skipChildren(jts, t);
-		                } else {
-		                    // add element position to the tail of path branch
-		                    path.add("" + pos);
-		                    // process value of this element recursively
-		                    extractFieldsWithOpenToken(jts, t, child, consumer, path, strictMaps, 
-		                            strictArrays, selection.isSkipLevel());
-		                    // remove field from tail of path branch
-		                    path.remove(path.size() - 1);
-		                }
-		            }
-		            // let's check have we visited all selected items in this array
-		            if (strictArrays && !selectedFields.isEmpty()) {
-		                String notFound = selectedFields.iterator().next();
-		                throw new ObjectParseException("Invalid selection: no array element exists " +
-		                        "at position '" + notFound + "', at: " + getPathText(path, notFound));
-		            }
-		        }
-			} else {
-			    if (selection.isNeedAll()) {
-			        // need all elements
-			        JsonTokenUtil.writeTokensFromCurrent(jts, t, consumer.getOutput());
-			    } else {
-			        JsonTokenUtil.skipChildren(jts, t);
-			    }
-			}
-		} else {	// we observe scalar value (text, integer, double, boolean, null) in real json data
-			if (selection.hasChildren())
-				throw new ObjectParseException("Invalid selection: the path given specifies " +
-						"fields or elements that do not exist because data at this location is " +
-						"a scalar value (i.e. string, integer, float), at: " + 
-						ObjectJsonPath.getPathText(path));
-			JsonTokenUtil.writeCurrentToken(jts, t, consumer.getOutput());
-		}
-	}
+            } else {  // need all fields and values
+                if (selection.isNeedAll()) {
+                    JsonTokenUtil.writeTokensFromCurrent(jts, t, consumer.getOutput());
+                } else {
+                    JsonTokenUtil.skipChildren(jts, t);
+                }
+            }
+        } else if (t == JsonToken.START_ARRAY) {    // we observe open of array/list in real json data
+            if (selection.hasChildren()) {  // we have some restrictions for array item positions in selection
+                Set<String> selectedFields = new LinkedHashSet<String>(
+                        selection.getChildren().keySet());
+                if (selectedFields.size() == 1 && selectedFields.contains("{size}")) {
+                    int size = 0;
+                    while (true) {
+                        t = jts.nextToken();
+                        if (t == JsonToken.END_ARRAY) {
+                            break;
+                        }
+                        JsonTokenUtil.skipChildren(jts, t);
+                        size++;
+                    }
+                    consumer.getOutput().writeNumber(size);
+                } else {
+                    SubObjectExtractionNode allChild = null;
+                    // now we support only '[*]' which means all elements and set of numbers in case of 
+                    // certain item positions are selected in array
+                    if (!selectedFields.contains("[*]")) {
+                        for (String item : selectedFields) {
+                            try {
+                                Integer.parseInt(item);
+                            } catch (NumberFormatException ex) {
+                                throw new ObjectParseException("Invalid selection: data at '" +
+                                        ObjectJsonPath.getPathText(path) + "' is an array, so " +
+                                        "element selection must be an integer. You requested element" +
+                                        " '" + item + "', at: " + ObjectJsonPath.getPathText(path));
+                            }
+                        }
+                    }
+                    if (selectedFields.contains("[*]")) {
+                        selectedFields.remove("[*]");
+                        allChild = selection.getChildren().get("[*]");
+                        // if there is [*] keyword selected there shouldn't be anything else in selection
+                        if (selectedFields.size() > 0)
+                            throw new ObjectParseException("Invalid selection: the selection path " +
+                                    "contains both '[*]' to select all elements and selection of " +
+                                    "specific elements (" + selectedFields + "), at: " +
+                                    ObjectJsonPath.getPathText(path));
+                    }
+                    if (!skipLvl) {
+                        JsonTokenUtil.writeCurrentToken(jts, t, consumer.getOutput());  // write start of array into output
+                    }
+                    for (int pos = 0; ; pos++) {
+                        t = jts.nextToken();
+                        if (t == JsonToken.END_ARRAY) {
+                            if (!skipLvl) {
+                                JsonTokenUtil.writeCurrentToken(jts, t, consumer.getOutput());
+                            }
+                            break;
+                        }
+                        SubObjectExtractionNode child = null;
+                        if (allChild != null) {
+                            child = allChild;
+                        } else {
+                            String key = "" + pos;
+                            if (selection.getChildren().containsKey(key)) {
+                                child = selection.getChildren().get(key);
+                                selectedFields.remove(key);
+                            }
+                        }
+                        if (child == null) {
+                            // this element of array is not selected, skip it
+                            JsonTokenUtil.skipChildren(jts, t);
+                        } else {
+                            // add element position to the tail of path branch
+                            path.add("" + pos);
+                            // process value of this element recursively
+                            extractFieldsWithOpenToken(jts, t, child, consumer, path, strictMaps,
+                                    strictArrays, selection.isSkipLevel());
+                            // remove field from tail of path branch
+                            path.remove(path.size() - 1);
+                        }
+                    }
+                    // let's check have we visited all selected items in this array
+                    if (strictArrays && !selectedFields.isEmpty()) {
+                        String notFound = selectedFields.iterator().next();
+                        throw new ObjectParseException("Invalid selection: no array element exists " +
+                                "at position '" + notFound + "', at: " + getPathText(path, notFound));
+                    }
+                }
+            } else {
+                if (selection.isNeedAll()) {
+                    // need all elements
+                    JsonTokenUtil.writeTokensFromCurrent(jts, t, consumer.getOutput());
+                } else {
+                    JsonTokenUtil.skipChildren(jts, t);
+                }
+            }
+        } else {    // we observe scalar value (text, integer, double, boolean, null) in real json data
+            if (selection.hasChildren())
+                throw new ObjectParseException("Invalid selection: the path given specifies " +
+                        "fields or elements that do not exist because data at this location is " +
+                        "a scalar value (i.e. string, integer, float), at: " +
+                        ObjectJsonPath.getPathText(path));
+            JsonTokenUtil.writeCurrentToken(jts, t, consumer.getOutput());
+        }
+    }
 
-	public static String getPathText(List<String> path, String add) {
-		path.add(add);
-		String ret = ObjectJsonPath.getPathText(path);
-		path.remove(path.size() - 1);
-		return ret;
-	}
-	
+    public static String getPathText(List<String> path, String add) {
+        path.add(add);
+        String ret = ObjectJsonPath.getPathText(path);
+        path.remove(path.size() - 1);
+        return ret;
+    }
+    
 }

--- a/lib/src/kbasesearchengine/parse/SubObjectExtractor.java
+++ b/lib/src/kbasesearchengine/parse/SubObjectExtractor.java
@@ -31,8 +31,12 @@ public class SubObjectExtractor {
      * a mapping or array.
      * @throws ObjectParseException
      */
-    public static void extract(ObjectJsonPath pathToSub, List<ObjectJsonPath> objpaths,
-            JsonParser jts, SubObjectConsumer consumer) throws IOException, ObjectParseException {
+    public static void extract(
+            final ObjectJsonPath pathToSub,
+            final List<ObjectJsonPath> objpaths,
+            final JsonParser jts,
+            final SubObjectConsumer consumer)
+            throws IOException, ObjectParseException {
         //if the selection is empty, we return without adding anything
         SubObjectExtractionNode root = new SubObjectExtractionNode();
         SubObjectExtractionNode sub = root.addPath(pathToSub, true, false);
@@ -42,8 +46,11 @@ public class SubObjectExtractor {
         extract(root, jts, consumer);
     }
     
-    public static void extract(SubObjectExtractionNode tree, JsonParser jts,
-            SubObjectConsumer consumer) throws IOException, ObjectParseException {
+    public static void extract(
+            final SubObjectExtractionNode tree,
+            final JsonParser jts,
+            final SubObjectConsumer consumer)
+            throws IOException, ObjectParseException {
         JsonToken t = jts.nextToken();
         extractFieldsWithOpenToken(jts, t, tree, consumer, new ArrayList<String>(),
                 false, false, true);
@@ -55,10 +62,16 @@ public class SubObjectExtractor {
      * and making decisions whether or not we need to process this token or block of tokens or
      * just skip it.
      */
-    private static void extractFieldsWithOpenToken(JsonParser jts, JsonToken current,
-            SubObjectExtractionNode selection, SubObjectConsumer consumer,
-            List<String> path, boolean strictMaps, boolean strictArrays,
-            boolean fromSkippedLevel) throws IOException, ObjectParseException {
+    private static void extractFieldsWithOpenToken(
+            final JsonParser jts,
+            final JsonToken current,
+            final SubObjectExtractionNode selection,
+            final SubObjectConsumer consumer,
+            final List<String> path,
+            final boolean strictMaps,
+            final boolean strictArrays,
+            final boolean fromSkippedLevel)
+            throws IOException, ObjectParseException {
         if (fromSkippedLevel && !selection.isSkipLevel()) {
             // It means we're starting sub-object (or whole object is needed)
             consumer.nextObject(ObjectJsonPath.getPathText(path));

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -73,7 +73,6 @@ public class ElasticIndexingStorage implements IndexingStorage {
     private String esUser;
     private String esPassword;
     private String indexNamePrefix;
-    private boolean skipFullJson = false;
     private Map<SearchObjectType, String> typeVerToIndex = new LinkedHashMap<>();
     private Map<String, String> typeToIndex = new LinkedHashMap<>();
     private RestClient restClient = null;
@@ -116,14 +115,6 @@ public class ElasticIndexingStorage implements IndexingStorage {
         this.indexNamePrefix = indexNamePrefix;
     }
 
-    public boolean isSkipFullJson() {
-        return skipFullJson;
-    }
-    
-    public void setSkipFullJson(boolean skipFullJson) {
-        this.skipFullJson = skipFullJson;
-    }
-    
     private String getAnyIndexPattern() {
         return indexNamePrefix + "*";
     }
@@ -221,12 +212,11 @@ public class ElasticIndexingStorage implements IndexingStorage {
         try {
             PrintWriter pw = new PrintWriter(tempFile);
             int lastVersion = loadLastVersion(indexName, pguid, pguid.getVersion());
-            Map<GUID, String> parentGuidToEsId = checkParentDoc(indexName, new LinkedHashSet<>(
-                    Arrays.asList(pguid)), isPublic, lastVersion);
+            final String esParentId = checkParentDoc(indexName, new LinkedHashSet<>(
+                    Arrays.asList(pguid)), isPublic, lastVersion).get(pguid);
             if (idToObj.size() > 0) {
                 Map<GUID, String> esIds = lookupDocIds(indexName, idToObj.keySet());
                 for (GUID id : idToObj.keySet()) {
-                    String esParentId = parentGuidToEsId.get(pguid);
                     ParsedObject obj = idToObj.get(id);
                     Map<String, Object> doc = convertObject(id, objectType, obj, data, 
                             timestamp, parentJsonValue, isPublic, lastVersion);
@@ -241,10 +231,23 @@ public class ElasticIndexingStorage implements IndexingStorage {
                     pw.println(UObject.transformObjectToString(header));
                     pw.println(UObject.transformObjectToString(doc));
                 }
-                pw.close();
-                makeBulkRequest("POST", indexName, tempFile);
-                updateLastVersionsInData(indexName, pguid, lastVersion);
+            } else {
+                // there were no search objects parsed from the source object, so just index
+                // the general object information
+                final Map<String, Object> doc = convertObject(pguid, objectType, null, data,
+                        timestamp, parentJsonValue, isPublic, lastVersion);
+                final Map<String, Object> index = new HashMap<>();
+                index.put("_index", indexName);
+                index.put("_type", getDataTableName());
+                index.put("parent", esParentId);
+                index.put("_id", esParentId);
+                final Map<String, Object> header = ImmutableMap.of("index", index);
+                pw.println(UObject.transformObjectToString(header));
+                pw.println(UObject.transformObjectToString(doc));
             }
+            pw.close();
+            makeBulkRequest("POST", indexName, tempFile);
+            updateLastVersionsInData(indexName, pguid, lastVersion);
         } finally {
             tempFile.delete();
         }
@@ -261,8 +264,10 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final boolean isPublic,
             final int lastVersion) {
         Map<String, List<Object>> indexPart = new LinkedHashMap<>();
-        for (String key : obj.keywords.keySet()) {
-            indexPart.put(getKeyProperty(key), obj.keywords.get(key));
+        if (obj != null) {
+            for (String key : obj.keywords.keySet()) {
+                indexPart.put(getKeyProperty(key), obj.keywords.get(key));
+            }
         }
         Map<String, Object> doc = new LinkedHashMap<>();
         doc.putAll(indexPart);
@@ -287,7 +292,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         doc.put("islast", lastVersion == id.getVersion());
         doc.put("public", isPublic);
         doc.put("shared", false);
-        if (!skipFullJson) {
+        if (obj != null) {
             doc.put("ojson", obj.json);
             doc.put("pjson", parentJson);
         }
@@ -1077,8 +1082,11 @@ public class ElasticIndexingStorage implements IndexingStorage {
             b.withNullableTimestamp(Instant.ofEpochMilli((long) obj.get(OBJ_TIMESTAMP)));
         }
         if (json) {
-            b.withNullableData(UObject.transformStringToObject(
-                    (String) obj.get("ojson"), Object.class));
+            final String ojson = (String) obj.get("ojson");
+            if (ojson != null) {
+                b.withNullableData(UObject.transformStringToObject(
+                        ojson, Object.class));
+            }
             final String pjson = (String) obj.get("pjson");
             if (pjson != null) {
                 b.withNullableParentData(UObject.transformStringToObject(pjson, Object.class));
@@ -1592,14 +1600,15 @@ public class ElasticIndexingStorage implements IndexingStorage {
 
         Map<String, Object> props = new LinkedHashMap<>();
         final Map<String, Object> keyword = ImmutableMap.of("type", "keyword");
-        Map<String, Object> tmp;
+        final ImmutableMap<String, String> integer = ImmutableMap.of("type", "integer");
+        final ImmutableMap<String, Object> bool = ImmutableMap.of("type", "boolean");
+
         props.put("guid", keyword);
 
         props.put(SEARCH_OBJ_TYPE, keyword);
-        props.put(SEARCH_OBJ_TYPE_VER, ImmutableMap.of("type", "integer"));
+        props.put(SEARCH_OBJ_TYPE_VER, integer);
 
-        tmp = ImmutableMap.of("type", "text");
-        props.put(OBJ_NAME, tmp);
+        props.put(OBJ_NAME, ImmutableMap.of("type", "text"));
 
         props.put(OBJ_CREATOR, keyword);
         props.put(OBJ_COPIER, keyword);
@@ -1609,45 +1618,32 @@ public class ElasticIndexingStorage implements IndexingStorage {
         props.put(OBJ_PROV_COMMIT_HASH, keyword);
         props.put(OBJ_MD5, keyword);
 
-        tmp = ImmutableMap.of("type", "date");
-        props.put(OBJ_TIMESTAMP, tmp);
-
+        props.put(OBJ_TIMESTAMP, ImmutableMap.of("type", "date"));
+        
         props.put("prefix", keyword);
-
         props.put("str_cde", keyword);
+        props.put("accgrp", integer);
+        props.put("version", integer);
 
-        tmp = ImmutableMap.of("type", "integer");
-        props.put("accgrp", tmp);
+        props.put("islast", bool);
+        props.put("public", bool);
+        props.put("shared", bool);
 
-        tmp = ImmutableMap.of("type", "integer");
-        props.put("version", tmp);
+        props.put("ojson", ImmutableMap.of(
+                "type", "keyword",
+                "index", false,
+                "doc_values", false));
 
-        tmp = ImmutableMap.of("type", "boolean");
-        props.put("islast", tmp);
-
-        tmp = ImmutableMap.of("type", "boolean");
-        props.put("public", tmp);
-
-        tmp = ImmutableMap.of("type", "boolean");
-        props.put("shared", tmp);
-
-        if (!skipFullJson) {
-            tmp = ImmutableMap.of("type", "keyword",
-                                  "index", false,
-                                  "doc_values", false);
-            props.put("ojson", tmp);
-
-            tmp = ImmutableMap.of("type", "keyword",
-                                  "index", false,
-                                  "doc_values", false);
-            props.put("pjson", tmp);
-        }
+        props.put("pjson", ImmutableMap.of(
+                "type", "keyword",
+                "index", false,
+                "doc_values", false));
+        
+        
         for (IndexingRules rules : indexingRules) {
             String propName = getKeyProperty(rules.getKeyName());
             String propType = getEsType(rules.isFullText(), rules.getKeywordType());
-
-            tmp = ImmutableMap.of("type", propType);
-            props.put(propName, tmp);
+            props.put(propName, ImmutableMap.of("type", propType));
         }
 
         // table = {"data": {},
@@ -1661,8 +1657,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         Map<String, Object> table = new LinkedHashMap<>();
 
 
-        tmp = ImmutableMap.of("type", getAccessTableName());
-        table.put("_parent", tmp);
+        table.put("_parent", ImmutableMap.of("type", getAccessTableName()));
         table.put("properties", ImmutableMap.copyOf(props));
 
         // Access (parent)

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1074,7 +1074,9 @@ public class ElasticIndexingStorage implements IndexingStorage {
             b.withNullableType(new SearchObjectType(
                     (String) obj.get(SEARCH_OBJ_TYPE),
                     (Integer) obj.get(SEARCH_OBJ_TYPE_VER)));
-            b.withNullableTimestamp(Instant.ofEpochMilli((long) obj.get(OBJ_TIMESTAMP)));
+            // sometimes this is a long, sometimes it's an int
+            b.withNullableTimestamp(Instant.ofEpochMilli(
+                    ((Number) obj.get(OBJ_TIMESTAMP)).longValue()));
         }
         if (json) {
             final String ojson = (String) obj.get("ojson");

--- a/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
+++ b/lib/src/kbasesearchengine/system/ObjectTypeParsingRules.java
@@ -204,6 +204,10 @@ public class ObjectTypeParsingRules {
         return new Builder(globalObjectType, storageType);
     }
     
+    /** A builder for an {@link ObjectTypeParsingRules}.
+     * @author gaprice@lbl.gov
+     *
+     */
     public static class Builder {
         
         private final SearchObjectType globalObjectType;
@@ -236,8 +240,7 @@ public class ObjectTypeParsingRules {
             return this;
         }
         
-        /** Add an indexing rule to this builder. At least one rule must be added before the
-         * build can complete.
+        /** Add an indexing rule to this builder.
          * @param rules the indexing rule.
          * @return this builder.
          */
@@ -286,10 +289,6 @@ public class ObjectTypeParsingRules {
          * @return the rule set.
          */
         public ObjectTypeParsingRules build() {
-            if (indexingRules.isEmpty()) {
-                throw new IllegalStateException("Must supply at least one indexing rule");
-            }
-            
             return new ObjectTypeParsingRules(globalObjectType, uiTypeName, storageObjectType,
                     indexingRules, subObjectType, subObjectPath, subObjectIDPath);
         }

--- a/test/src/kbasesearchengine/test/data/NoIndexingRules.spec
+++ b/test/src/kbasesearchengine/test/data/NoIndexingRules.spec
@@ -1,0 +1,7 @@
+module NoIndexingRules {
+
+	/* @optional foo */
+	typedef structure {
+		int foo;
+	} Type;
+};

--- a/test/src/kbasesearchengine/test/data/NoIndexingRules.yaml
+++ b/test/src/kbasesearchengine/test/data/NoIndexingRules.yaml
@@ -1,0 +1,8 @@
+# a test spec.
+
+global-object-type: NoIndexRules
+storage-type: WS
+storage-object-type: NoIndexingRules.Type
+versions:
+    -
+        indexing-rules: []

--- a/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
+++ b/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
@@ -177,7 +177,7 @@ public class IndexerWorkerIntegrationTest {
         storage = esStorage;
         
         worker = new IndexerWorker("test", Arrays.asList(weh), eventStorage, esStorage,
-                ss, tempDirPath.resolve("MainObjectProcessor").toFile(), logger);
+                ss, tempDirPath.resolve("WorkerTemp").toFile(), logger);
         loadTypes(wsUrl, wsadmintoken);
         wsid = (int) loadTestData(wsUrl, userToken);
     }

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -10,6 +10,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -340,7 +342,7 @@ public class ElasticIndexingStorageTest {
     
     @Test
     public void testSharing() throws Exception {
-        SearchObjectType objType = new SearchObjectType("Sharable",1 );
+        SearchObjectType objType = new SearchObjectType("Sharable", 1);
         IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop2"))
                 .withKeywordType("integer").build();
         List<IndexingRules> indexingRules= Arrays.asList(ir);
@@ -610,6 +612,44 @@ public class ElasticIndexingStorageTest {
 
         assertThat("incorrect indexed object", indexedObj2, is(expected2));
         
+    }
+    
+    @Test
+    public void noIndexingRules() throws Exception {
+        indexStorage.indexObjects(
+                new SearchObjectType("NoIndexingRules", 1),
+                SourceData.getBuilder(new UObject(new HashMap<>()), "objname", "creator")
+                        .withNullableCommitHash("commit")
+                        .withNullableCopier("cop")
+                        .withNullableMD5("emmdeefive")
+                        .withNullableMethod("meth")
+                        .withNullableModule("mod")
+                        .withNullableVersion("ver")
+                        .build(),
+                Instant.ofEpochMilli(10000),
+                null,
+                new GUID("WS:1000/1/1"),
+                Collections.emptyMap(),
+                false,
+                Collections.emptyList());
+        
+        final ObjectData indexedObj =
+                indexStorage.getObjectsByIds(TestCommon.set(new GUID("WS:1000/1/1"))).get(0);
+        
+        final ObjectData expected = ObjectData.getBuilder(new GUID("WS:1000/1/1"))
+                .withNullableObjectName("objname")
+                .withNullableType(new SearchObjectType("NoIndexingRules", 1))
+                .withNullableCreator("creator")
+                .withNullableCommitHash("commit")
+                .withNullableCopier("cop")
+                .withNullableMD5("emmdeefive")
+                .withNullableMethod("meth")
+                .withNullableModule("mod")
+                .withNullableModuleVersion("ver")
+                .withNullableTimestamp(Instant.ofEpochMilli(10000))
+                .build();
+        
+        assertThat("incorrect indexed object", indexedObj, is(expected));
     }
 
 }

--- a/test/src/kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java
+++ b/test/src/kbasesearchengine/test/system/ObjectTypeParsingRulesTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -23,6 +24,23 @@ public class ObjectTypeParsingRulesTest {
     @Test
     public void equals() {
         EqualsVerifier.forClass(ObjectTypeParsingRules.class).usingGetClass().verify();
+    }
+    
+    @Test
+    public void buildWithoutIndexingRule() {
+        final ObjectTypeParsingRules r = ObjectTypeParsingRules.getBuilder(
+                new SearchObjectType("foo", 1), new StorageObjectType("bar", "baz"))
+                .build();
+        
+        assertThat("incorrect global type", r.getGlobalObjectType(),
+                is(new SearchObjectType("foo", 1)));
+        assertThat("incorrect UI name", r.getUiTypeName(), is("Foo"));
+        assertThat("incorrect storage type", r.getStorageObjectType(),
+                is(new StorageObjectType("bar", "baz")));
+        assertThat("incorrect index rules", r.getIndexingRules(), is(Collections.emptyList()));
+        assertThat("incorrect subobj type", r.getSubObjectType(), is(Optional.absent()));
+        assertThat("incorrect subobj path", r.getSubObjectPath(), is(Optional.absent()));
+        assertThat("incorrect subobj id path", r.getSubObjectIDPath(), is(Optional.absent()));
     }
     
     @Test
@@ -200,19 +218,6 @@ public class ObjectTypeParsingRulesTest {
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);
-        }
-    }
-    
-    @Test
-    public void buildFail() {
-        try {
-            ObjectTypeParsingRules.getBuilder(
-                    new SearchObjectType("t", 1),
-                    new StorageObjectType("c", "t")).build();
-            fail("expected exception");
-        } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new IllegalStateException(
-                    "Must supply at least one indexing rule"));
         }
     }
     


### PR DESCRIPTION
Allows for easily setting up minimal indexes for types where we don't want to take the time to develop a spec but do want to index the general object properties like name, etc.

Note most of the SubObjectExtractor changes are whitespace.

ElasticIndexingStorage would silently drop objects with no indexing
rules, while the logger made it appear as though everything worked.

also removed the EIS.skipFullJson field, which was unused and always
false.

also also some minor cleanup.