### PR TITLE
Use embedded auth server for tests

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -36,5 +36,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/mongo/mongo-java-driver-3.4.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/equalsverifier/equalsverifier-2.2.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mustache/compiler-0.9.3.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth2/kbase-auth2test-0.2.2.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -12,6 +12,7 @@
   <property name="dist" location="dist"/>
   <property name="classes" location="classes"/>
   <property name="bin" location="bin"/>
+  <property name="test.cfg" location="/kb/module/work/test.cfg"/>
   <property name="jar.file" value="KBaseSearchEngine.jar"/>
   <condition property="jars.dir" value="${env.JARS_DIR}" else="/kb/deployment/lib/jars">
     <isset property="env.JARS_DIR" />
@@ -150,6 +151,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
           <path refid="compile.classpath"/>
         </classpath>
         <formatter type="plain" usefile="false" />
+        <sysproperty key="test.cfg" value="${test.cfg}"/>
         <batchtest>
           <fileset dir="${test.src}">
             <include name="kbasesearchengine/test/parse/**Test.java"/>

--- a/build.xml
+++ b/build.xml
@@ -141,7 +141,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
     <chmod file="${bin}/${exec.cmd.search_tools}" perm="a+x"/>
   </target>
 	
-  <target name="test" depends="compile" description="run all tests">
+  <target name="test" description="run all tests">
     <delete dir="${test.reports.dir}"/>
     <mkdir dir="${test.reports.dir}"/>
     <jacoco:coverage destfile="${test.reports.dir}/jacoco.exec"

--- a/build.xml
+++ b/build.xml
@@ -58,6 +58,7 @@
     <include name="jcommander/jcommander-1.48.jar"/>
     <include name="snakeyaml/snakeyaml-1.18.jar"/>
     <include name="equalsverifier/equalsverifier-2.2.2.jar"/>
+    <include name="kbase/auth2/kbase-auth2test-0.2.2.jar"/>
     <!-- mockito and dependencies -->
     <include name="mockito/mockito-core-2.7.10.jar"/>
     <include name="bytebuddy/byte-buddy-1.6.8.jar"/>
@@ -140,7 +141,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
     <chmod file="${bin}/${exec.cmd.search_tools}" perm="a+x"/>
   </target>
 	
-  <target name="test" description="run all tests">
+  <target name="test" depends="compile" description="run all tests">
     <delete dir="${test.reports.dir}"/>
     <mkdir dir="${test.reports.dir}"/>
     <jacoco:coverage destfile="${test.reports.dir}/jacoco.exec"

--- a/test/src/kbasesearchengine/test/events/handler/CloneableWorkspaceClientImplTest.java
+++ b/test/src/kbasesearchengine/test/events/handler/CloneableWorkspaceClientImplTest.java
@@ -12,10 +12,7 @@ import org.junit.Test;
 
 import kbasesearchengine.events.handler.CloneableWorkspaceClient;
 import kbasesearchengine.events.handler.CloneableWorkspaceClientImpl;
-import kbasesearchengine.test.common.TestCommon;
-import us.kbase.auth.AuthConfig;
 import us.kbase.auth.AuthToken;
-import us.kbase.auth.ConfigurableAuthService;
 import workspace.WorkspaceClient;
 
 public class CloneableWorkspaceClientImplTest {
@@ -24,10 +21,7 @@ public class CloneableWorkspaceClientImplTest {
     
     @BeforeClass
     public static void getToken() throws Exception {
-        final URL authURL = TestCommon.getAuthUrl();
-        final ConfigurableAuthService authSrv = new ConfigurableAuthService(
-                new AuthConfig().withKBaseAuthServerURL(authURL));
-        userToken = TestCommon.getToken(authSrv);
+        userToken = new AuthToken("fake", "fake");
     }
     
     @Test


### PR DESCRIPTION
No longer any need for tokens in the test config when running ant test directly.
`ant test -Djars.dir=/home/crusherofheads/localgit/jars/lib/jars -Dtest.cfg=test_local/test.cfg`

Running kb-sdk test still requires a token.