### PR TITLE
SCT-427 Add builder for StoredStatusEvent with worker codes

### DIFF
--- a/lib/src/kbasesearchengine/events/StoredStatusEvent.java
+++ b/lib/src/kbasesearchengine/events/StoredStatusEvent.java
@@ -21,7 +21,7 @@ public class StoredStatusEvent implements StatusEventWithId {
     private final StatusEventProcessingState state;
     private final Optional<Instant> updateTime;
     private final Optional<String> updater;
-    private final Set<String> tags;
+    private final Set<String> workerCodes;
     
     private StoredStatusEvent(
             final StatusEvent event,
@@ -29,13 +29,13 @@ public class StoredStatusEvent implements StatusEventWithId {
             final StatusEventProcessingState state,
             final Optional<Instant> updateTime,
             final Optional<String> updater,
-            final Set<String> tags) {
+            final Set<String> workerCodes) {
         this.event = event;
         this.id = id;
         this.state = state;
         this.updateTime = updateTime;
         this.updater = updater;
-        this.tags = Collections.unmodifiableSet(tags);
+        this.workerCodes = Collections.unmodifiableSet(workerCodes);
     }
 
     @Override
@@ -74,11 +74,11 @@ public class StoredStatusEvent implements StatusEventWithId {
         return updater;
     }
     
-    /** Return the tags that specify which workers can process the event.
-     * @return the tags.
+    /** Return the codes that specify which workers can process the event.
+     * @return the codes.
      */
-    public Set<String> getTags() {
-        return tags;
+    public Set<String> getWorkerCodes() {
+        return workerCodes;
     }
     
     @Override
@@ -88,7 +88,7 @@ public class StoredStatusEvent implements StatusEventWithId {
         result = prime * result + ((event == null) ? 0 : event.hashCode());
         result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + ((state == null) ? 0 : state.hashCode());
-        result = prime * result + ((tags == null) ? 0 : tags.hashCode());
+        result = prime * result + ((workerCodes == null) ? 0 : workerCodes.hashCode());
         result = prime * result
                 + ((updateTime == null) ? 0 : updateTime.hashCode());
         result = prime * result + ((updater == null) ? 0 : updater.hashCode());
@@ -124,11 +124,11 @@ public class StoredStatusEvent implements StatusEventWithId {
         if (state != other.state) {
             return false;
         }
-        if (tags == null) {
-            if (other.tags != null) {
+        if (workerCodes == null) {
+            if (other.workerCodes != null) {
                 return false;
             }
-        } else if (!tags.equals(other.tags)) {
+        } else if (!workerCodes.equals(other.workerCodes)) {
             return false;
         }
         if (updateTime == null) {
@@ -172,7 +172,7 @@ public class StoredStatusEvent implements StatusEventWithId {
         private final StatusEventProcessingState state;
         private Optional<Instant> updateTime = Optional.absent();
         private Optional<String> updater = Optional.absent();
-        private Set<String> tags = new HashSet<>();
+        private Set<String> workerCodes = new HashSet<>();
         
         private Builder(
                 final StatusEvent event,
@@ -186,13 +186,13 @@ public class StoredStatusEvent implements StatusEventWithId {
             this.state = state;
         }
         
-        /** Add a tag that specifies which workers can process this event to the builder.
-         * @param tag the tag.
+        /** Add a code that specifies which workers can process this event to the builder.
+         * @param workerCode the worker code.
          * @return this builder.
          */
-        public Builder withTag(final String tag) {
-            Utils.notNullOrEmpty(tag, "tag cannot be null or whitespace");
-            tags.add(tag);
+        public Builder withWorkerCode(final String workerCode) {
+            Utils.notNullOrEmpty(workerCode, "workerCode cannot be null or whitespace");
+            workerCodes.add(workerCode);
             return this;
         }
         
@@ -218,7 +218,7 @@ public class StoredStatusEvent implements StatusEventWithId {
          * @return the event.
          */
         public StoredStatusEvent build() {
-            return new StoredStatusEvent(event, id, state, updateTime, updater, tags);
+            return new StoredStatusEvent(event, id, state, updateTime, updater, workerCodes);
         }
     }
 }

--- a/lib/src/kbasesearchengine/events/StoredStatusEvent.java
+++ b/lib/src/kbasesearchengine/events/StoredStatusEvent.java
@@ -1,6 +1,9 @@
 package kbasesearchengine.events;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.google.common.base.Optional;
 
@@ -18,36 +21,21 @@ public class StoredStatusEvent implements StatusEventWithId {
     private final StatusEventProcessingState state;
     private final Optional<Instant> updateTime;
     private final Optional<String> updater;
+    private final Set<String> tags;
     
-    // right on the edge of needing to convert to a builder...
-    
-    /** Create a stored event.
-     * @param event the event.
-     * @param id the event ID.
-     * @param state the processing state of the event.
-     * @param updateTime the time of the last update to the processing state. Optional and
-     * nullable.
-     * @param updater the id of the operator that last updated the processing state. Optional and
-     * nullable.
-     */
-    public StoredStatusEvent(
+    private StoredStatusEvent(
             final StatusEvent event,
             final StatusEventID id,
             final StatusEventProcessingState state,
-            final Instant updateTime,
-            final String updater) {
-        Utils.nonNull(event, "event");
-        Utils.nonNull(id, "id");
-        Utils.nonNull(state, "state");
+            final Optional<Instant> updateTime,
+            final Optional<String> updater,
+            final Set<String> tags) {
         this.event = event;
         this.id = id;
         this.state = state;
-        this.updateTime = Optional.fromNullable(updateTime);
-        if (Utils.isNullOrEmpty(updater)) {
-            this.updater = Optional.absent();
-        } else {
-            this.updater = Optional.of(updater);
-        }
+        this.updateTime = updateTime;
+        this.updater = updater;
+        this.tags = Collections.unmodifiableSet(tags);
     }
 
     @Override
@@ -85,7 +73,152 @@ public class StoredStatusEvent implements StatusEventWithId {
     public Optional<String> getUpdater() {
         return updater;
     }
-
-    // will add equals & hashcode if needed.
     
+    /** Return the tags that specify which workers can process the event.
+     * @return the tags.
+     */
+    public Set<String> getTags() {
+        return tags;
+    }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((event == null) ? 0 : event.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        result = prime * result + ((tags == null) ? 0 : tags.hashCode());
+        result = prime * result
+                + ((updateTime == null) ? 0 : updateTime.hashCode());
+        result = prime * result + ((updater == null) ? 0 : updater.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        StoredStatusEvent other = (StoredStatusEvent) obj;
+        if (event == null) {
+            if (other.event != null) {
+                return false;
+            }
+        } else if (!event.equals(other.event)) {
+            return false;
+        }
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        if (state != other.state) {
+            return false;
+        }
+        if (tags == null) {
+            if (other.tags != null) {
+                return false;
+            }
+        } else if (!tags.equals(other.tags)) {
+            return false;
+        }
+        if (updateTime == null) {
+            if (other.updateTime != null) {
+                return false;
+            }
+        } else if (!updateTime.equals(other.updateTime)) {
+            return false;
+        }
+        if (updater == null) {
+            if (other.updater != null) {
+                return false;
+            }
+        } else if (!updater.equals(other.updater)) {
+            return false;
+        }
+        return true;
+    }
+
+    /** Get a builder for a {@link StoredStatusEvent}.
+     * @param event the stored event.
+     * @param id the ID of the event.
+     * @param state the state of the event.
+     * @return a new builder.
+     */
+    public static Builder getBuilder(
+            final StatusEvent event,
+            final StatusEventID id,
+            final StatusEventProcessingState state) {
+        return new Builder(event, id, state);
+    }
+    
+    /** A builder for {@link StoredStatusEvent}s.
+     * @author gaprice@lbl.gov
+     *
+     */
+    public static class Builder {
+
+        private final StatusEvent event;
+        private final StatusEventID id;
+        private final StatusEventProcessingState state;
+        private Optional<Instant> updateTime = Optional.absent();
+        private Optional<String> updater = Optional.absent();
+        private Set<String> tags = new HashSet<>();
+        
+        private Builder(
+                final StatusEvent event,
+                final StatusEventID id,
+                final StatusEventProcessingState state) {
+            Utils.nonNull(event, "event");
+            Utils.nonNull(id, "id");
+            Utils.nonNull(state, "state");
+            this.event = event;
+            this.id = id;
+            this.state = state;
+        }
+        
+        /** Add a tag that specifies which workers can process this event to the builder.
+         * @param tag the tag.
+         * @return this builder.
+         */
+        public Builder withTag(final String tag) {
+            Utils.notNullOrEmpty(tag, "tag cannot be null or whitespace");
+            tags.add(tag);
+            return this;
+        }
+        
+        /** Add an update time and optional updater id to the event.
+         * @param updateTime the update time. If null, the update is wholly ignored.
+         * @param updater the id of the updater. If null or whitespace the id is ignored.
+         * @return this builder.
+         */
+        public Builder withNullableUpdate(final Instant updateTime, final String updater) {
+            if (updateTime == null) {
+                return this;
+            }
+            this.updateTime = Optional.of(updateTime);
+            if (!Utils.isNullOrEmpty(updater)) {
+                this.updater = Optional.of(updater);
+            } else {
+                this.updater = Optional.absent();
+            }
+            return this;
+        }
+        
+        /** Build the {@link StoredStatusEvent}.
+         * @return the event.
+         */
+        public StoredStatusEvent build() {
+            return new StoredStatusEvent(event, id, state, updateTime, updater, tags);
+        }
+    }
 }

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -182,11 +182,11 @@ public class IndexerWorker implements Stoppable {
         Utils.nonNull(errtype, "errtype");
         final String msg;
         if (ErrorType.FATAL.equals(errtype)) {
-            msg = "Fatal error in indexer, shutting down: ";
+            msg = "Fatal error in indexer, shutting down";
         } else if (ErrorType.STD.equals(errtype)) {
-            msg = "Error in indexer: ";
+            msg = "Error in indexer";
         } else if (ErrorType.UNEXPECTED.equals(errtype)) {
-            msg = "Unexpected error in indexer: ";
+            msg = "Unexpected error in indexer";
         } else {
             throw new RuntimeException("Unknown error type: " + errtype);
         }
@@ -205,13 +205,13 @@ public class IndexerWorker implements Stoppable {
             final RetriableIndexingException e) {
         final String msg;
         if (event.isPresent()) {
-            msg = String.format("Retriable error in indexer for event %s %s%s, retry %s: ",
+            msg = String.format("Retriable error in indexer for event %s %s%s, retry %s",
                     event.get().getEvent().getEventType(),
                     event.get().isParentId() ? "with parent ID " : "",
                     event.get().getId().getId(),
                     retrycount);
         } else {
-            msg = String.format("Retriable error in indexer, retry %s: ", retrycount);
+            msg = String.format("Retriable error in indexer, retry %s", retrycount);
         }
         logError(msg, e);
     }
@@ -358,7 +358,7 @@ public class IndexerWorker implements Stoppable {
         if (exception instanceof FatalIndexingException) {
             throw (FatalIndexingException) exception;
         } else {
-            final String msg = error + String.format(" for event %s %s%s: ",
+            final String msg = error + String.format(" for event %s %s%s",
                     event.getEvent().getEventType(),
                     event.isParentId() ? "with parent ID " : "",
                     event.getId().getId());

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -316,11 +316,13 @@ public class ElasticIndexingStorage implements IndexingStorage {
     private Map<GUID, String> lookupDocIds(String indexName, Set<GUID> guids) throws IOException {
 
         // doc = {"query": {"bool": {"filter": [{"terms": {"guid": [guids]}}]}}}
-        Map<String, Object> doc = ImmutableMap.of("query", ImmutableMap.of(
-                                                    "bool", ImmutableMap.of(
-                                                      "filter", Arrays.asList(ImmutableMap.of("terms",
-                                                         ImmutableMap.of("guid",
-                                     guids.stream().map(u -> u.toString()).collect(Collectors.toList())))))));
+        Map<String, Object> doc = ImmutableMap.of(
+                "query", ImmutableMap.of(
+                        "bool", ImmutableMap.of(
+                                "filter", Arrays.asList(ImmutableMap.of(
+                                        "terms", ImmutableMap.of(
+                                                "guid", guids.stream().map(u -> u.toString())
+                                                        .collect(Collectors.toList())))))));
 
         String urlPath = "/" + indexName + "/" + getDataTableName() + "/_search";
         Response resp = makeRequest("GET", urlPath, doc);
@@ -516,9 +518,9 @@ public class ElasticIndexingStorage implements IndexingStorage {
 
         // script = {"inline": "ctx._source.islast = (ctx._source.version == params.lastver)",
         //           "params": {"lastver": lastVersion}}
-        Map<String, Object> script =
-                ImmutableMap.of("inline", "ctx._source.islast = (ctx._source.version == params.lastver);",
-                                "params", params);
+        Map<String, Object> script = ImmutableMap.of(
+                "inline", "ctx._source.islast = (ctx._source.version == params.lastver);",
+                "params", params);
 
         // doc = {"query": {"bool": {"filter": [{"term": {"prefix": prefix}}]}},
         //        "script": {"inline": "ctx._source.islast = (ctx._source.version == params.lastver)",

--- a/test/src/kbasesearchengine/test/events/EventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/EventQueueTest.java
@@ -64,12 +64,12 @@ public class EventQueueTest {
             final StatusEventType type,
             final StatusEventProcessingState state,
             final String objectID) {
-        return new StoredStatusEvent(StatusEvent.getBuilder(
+        return StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "storagecode", time, type)
                 .withNullableObjectID(objectID)
                 .withNullableAccessGroupID(accgrpID)
                 .build(),
-                new StatusEventID(eventid), state, null, null);
+                new StatusEventID(eventid), state).build();
     }
     
     private StoredStatusEvent unproc(
@@ -195,7 +195,7 @@ public class EventQueueTest {
                 StatusEventProcessingState.FAIL, StatusEventProcessingState.INDX,
                 StatusEventProcessingState.UNINDX, StatusEventProcessingState.READY,
                 StatusEventProcessingState.PROC)) {
-            failLoad(new StoredStatusEvent(se, id, state, null, null),
+            failLoad(StoredStatusEvent.getBuilder(se, id, state).build(),
                     new IllegalArgumentException("Illegal state for loading event: " + state));
         }
     }
@@ -212,12 +212,12 @@ public class EventQueueTest {
     @Test
     public void setProcessingCompleteFail() {
         final EventQueue q = new EventQueue();
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .withNullableAccessGroupID(1)
                 .withNullableObjectID("id")
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
         
         //nulls
         failSetProcessingComplete(q, null, new NullPointerException("event"));
@@ -227,21 +227,21 @@ public class EventQueueTest {
         
         // with group level event in processed state with different event id
         final EventQueue q2 = new EventQueue(Arrays.asList(
-                new StoredStatusEvent(StatusEvent.getBuilder(
+                StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                         "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ACCESS_GROUP)
                         .withNullableAccessGroupID(1)
                         .build(),
-                        new StatusEventID("foo2"), StatusEventProcessingState.PROC, null, null)));
+                        new StatusEventID("foo2"), StatusEventProcessingState.PROC).build()));
         failSetProcessingComplete(q2, sse, new NoSuchEventException(sse));
         
         // with group level event with different group id
         final EventQueue q3 = new EventQueue(Arrays.asList(
-                new StoredStatusEvent(StatusEvent.getBuilder(
+                StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                         "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                         .withNullableAccessGroupID(2)
                         .withNullableObjectID("id")
                         .build(),
-                        new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null)));
+                        new StatusEventID("foo"), StatusEventProcessingState.PROC).build()));
         failSetProcessingComplete(q3, sse, new NoSuchEventException(sse));
         
     }

--- a/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
@@ -44,10 +44,10 @@ public class ObjectEventQueueTest {
     }
 
     private void isVersionLevelEvent(final StatusEventType type, final boolean expected) {
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), type)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
         assertThat("incorrect isVersion", ObjectEventQueue.isVersionLevelEvent(sse),
                 is(expected));
@@ -108,10 +108,10 @@ public class ObjectEventQueueTest {
     @Test
     public void loadOneObjectLevelEventAndProcess() {
         final ObjectEventQueue q = new ObjectEventQueue();
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -130,18 +130,18 @@ public class ObjectEventQueueTest {
     public void loadMultipleObjectLevelEventsAndProcess() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.RENAME_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -188,10 +188,10 @@ public class ObjectEventQueueTest {
     public void loadOneVersionLevelEventAndProcess() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -210,18 +210,18 @@ public class ObjectEventQueueTest {
     public void loadMultipleVersionLevelEventsAndProcess() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -254,27 +254,27 @@ public class ObjectEventQueueTest {
     public void blockVersionEventsWithObjectLevelEvent() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse3 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse3 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar3", Instant.ofEpochMilli(40000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo4"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo4"), StatusEventProcessingState.UNPROC).build();
         
-        final StoredStatusEvent blocking = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent blocking = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "blocker", Instant.ofEpochMilli(25000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("blk"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("blk"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -335,10 +335,10 @@ public class ObjectEventQueueTest {
     }
 
     private void assertSingleObjectLevelReadyEvent(final StatusEventType type) {
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), type)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
         final ObjectEventQueue q = new ObjectEventQueue(sse);
         assertQueueState(q, set(sse), set(), 1);
     }
@@ -354,32 +354,32 @@ public class ObjectEventQueueTest {
     }
     
     private void assertSingleObjectLevelProcessingEvent(final StatusEventType type) {
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), type)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.PROC).build();
         final ObjectEventQueue q = new ObjectEventQueue(sse);
         assertQueueState(q, set(), set(sse), 1);
     }
     
     @Test
     public void constructWithVersionLevelEvents() {
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.READY, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.READY).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.PROC, null, null);
-        final StoredStatusEvent sse3 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo2"), StatusEventProcessingState.PROC).build();
+        final StoredStatusEvent sse3 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar3", Instant.ofEpochMilli(40000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo4"), StatusEventProcessingState.PROC, null, null);
+                new StatusEventID("foo4"), StatusEventProcessingState.PROC).build();
         
         assertEmpty(new ObjectEventQueue(new LinkedList<>(), new LinkedList<>()));
         
@@ -414,10 +414,10 @@ public class ObjectEventQueueTest {
         // from the original load()ed event, so check that works.
         // the status event itself and the id should not mutate, but other fields are fair game.
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
         final ObjectEventQueue q = new ObjectEventQueue();
         q.load(sse);
@@ -425,11 +425,12 @@ public class ObjectEventQueueTest {
         q.moveReadyToProcessing();
         assertQueueState(q, set(), set(sse), 1);
         
-        final StoredStatusEvent hideousmutant = new StoredStatusEvent(StatusEvent.getBuilder(
-                "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
-                .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.INDX,
-                Instant.ofEpochMilli(10000), "whee");
+        final StoredStatusEvent hideousmutant = StoredStatusEvent.getBuilder(
+                StatusEvent.getBuilder("bar", Instant.ofEpochMilli(10000),
+                        StatusEventType.NEW_VERSION).build(),
+                new StatusEventID("foo"), StatusEventProcessingState.INDX)
+                .withNullableUpdate(Instant.ofEpochMilli(10000), "whee")
+                .build();
         
         q.setProcessingComplete(hideousmutant);
         assertEmpty(q);
@@ -438,14 +439,14 @@ public class ObjectEventQueueTest {
     @Test
     public void immutableGetReady() {
         // test both getReady paths
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
         
         final ObjectEventQueue q = new ObjectEventQueue(sse);
         assertGetReadyReturnIsImmutable(sse2, q);
@@ -468,14 +469,14 @@ public class ObjectEventQueueTest {
     @Test
     public void immutableGetProcessing() {
         // test both getProcessing paths
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.PROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.PROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.PROC).build();
         
         final ObjectEventQueue q = new ObjectEventQueue(sse);
         assertGetProcessingReturnIsImmutable(sse2, q);
@@ -498,14 +499,14 @@ public class ObjectEventQueueTest {
     @Test
     public void immutableMoveReady() {
         // test both moveReady paths
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
         final ObjectEventQueue q = new ObjectEventQueue();
         q.load(sse);
@@ -535,14 +536,14 @@ public class ObjectEventQueueTest {
     @Test
     public void immutableMoveProcessing() {
         // test both moveProcessing paths
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
         
         final ObjectEventQueue q = new ObjectEventQueue(sse);
         assertMoveProcessingReturnIsImmutable(sse2, q);
@@ -579,22 +580,22 @@ public class ObjectEventQueueTest {
                 StatusEventProcessingState.FAIL, StatusEventProcessingState.INDX,
                 StatusEventProcessingState.UNINDX, StatusEventProcessingState.UNPROC)) {
             failConstructWithVersionLevelEvents(
-                    Arrays.asList(new StoredStatusEvent(se, id, state, null, null)),
+                    Arrays.asList(StoredStatusEvent.getBuilder(se, id, state).build()),
                     new LinkedList<>(),
                     new IllegalArgumentException("Illegal initial event state: " + state));
             failConstructWithVersionLevelEvents(new LinkedList<>(),
-                    Arrays.asList(new StoredStatusEvent(se, id, state, null, null)),
+                    Arrays.asList(StoredStatusEvent.getBuilder(se, id, state).build()),
                     new IllegalArgumentException("Illegal initial event state: " + state));
         }
         
         failConstructWithVersionLevelEvents(
-                Arrays.asList(new StoredStatusEvent(
-                        se, id, StatusEventProcessingState.PROC, null, null)),
+                Arrays.asList(StoredStatusEvent.getBuilder(
+                        se, id, StatusEventProcessingState.PROC).build()),
                 new LinkedList<>(),
                 new IllegalArgumentException("Illegal initial event state: PROC"));
         failConstructWithVersionLevelEvents(new LinkedList<>(),
-                Arrays.asList(new StoredStatusEvent(
-                        se, id, StatusEventProcessingState.READY, null, null)),
+                Arrays.asList(StoredStatusEvent.getBuilder(
+                        se, id, StatusEventProcessingState.READY).build()),
                 new IllegalArgumentException("Illegal initial event state: READY"));
         
         // bad event types
@@ -604,14 +605,14 @@ public class ObjectEventQueueTest {
                 StatusEventType.PUBLISH_ACCESS_GROUP, StatusEventType.PUBLISH_ALL_VERSIONS,
                 StatusEventType.RENAME_ALL_VERSIONS, StatusEventType.UNDELETE_ALL_VERSIONS,
                 StatusEventType.UNPUBLISH_ACCESS_GROUP, StatusEventType.UNPUBLISH_ALL_VERSIONS)) {
-            final StoredStatusEvent setype = new StoredStatusEvent(StatusEvent.getBuilder(
+            final StoredStatusEvent setype = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                     "foo", Instant.ofEpochMilli(10000), type).build(),
-                    id, StatusEventProcessingState.READY, null, null);
+                    id, StatusEventProcessingState.READY).build();
             failConstructWithVersionLevelEvents(Arrays.asList(setype), new LinkedList<>(),
                     new IllegalArgumentException("Illegal initial event type: " + type));
-            final StoredStatusEvent setype2 = new StoredStatusEvent(StatusEvent.getBuilder(
+            final StoredStatusEvent setype2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                     "foo", Instant.ofEpochMilli(10000), type).build(),
-                    id, StatusEventProcessingState.PROC, null, null);
+                    id, StatusEventProcessingState.PROC).build();
             failConstructWithVersionLevelEvents(new LinkedList<>(), Arrays.asList(setype2),
                     new IllegalArgumentException("Illegal initial event type: " + type));
         }
@@ -641,7 +642,7 @@ public class ObjectEventQueueTest {
         for (final StatusEventProcessingState state: Arrays.asList(
                 StatusEventProcessingState.FAIL, StatusEventProcessingState.INDX,
                 StatusEventProcessingState.UNINDX, StatusEventProcessingState.UNPROC)) {
-            failConstructWithObjectLevelEvent(new StoredStatusEvent(se, id, state, null, null),
+            failConstructWithObjectLevelEvent(StoredStatusEvent.getBuilder(se, id, state).build(),
                     new IllegalArgumentException("Illegal initial event state: " + state));
         }
         
@@ -649,9 +650,9 @@ public class ObjectEventQueueTest {
         for (final StatusEventType type: Arrays.asList(
                 StatusEventType.COPY_ACCESS_GROUP, StatusEventType.DELETE_ACCESS_GROUP,
                 StatusEventType.NEW_VERSION, StatusEventType.PUBLISH_ACCESS_GROUP)) {
-            final StoredStatusEvent setype = new StoredStatusEvent(StatusEvent.getBuilder(
+            final StoredStatusEvent setype = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                     "foo", Instant.ofEpochMilli(10000), type).build(),
-                    id, StatusEventProcessingState.READY, null, null);
+                    id, StatusEventProcessingState.READY).build();
             failConstructWithObjectLevelEvent(setype,
                     new IllegalArgumentException("Illegal initial event type: " + type));
         }
@@ -683,7 +684,7 @@ public class ObjectEventQueueTest {
                 StatusEventProcessingState.FAIL, StatusEventProcessingState.INDX,
                 StatusEventProcessingState.UNINDX, StatusEventProcessingState.READY,
                 StatusEventProcessingState.PROC)) {
-            failLoad(new StoredStatusEvent(se, id, state, null, null),
+            failLoad(StoredStatusEvent.getBuilder(se, id, state).build(),
                     new IllegalArgumentException("Illegal state for loading event: " + state));
         }
         
@@ -691,9 +692,9 @@ public class ObjectEventQueueTest {
         for (final StatusEventType type: Arrays.asList(
                 StatusEventType.COPY_ACCESS_GROUP, StatusEventType.DELETE_ACCESS_GROUP,
                 StatusEventType.PUBLISH_ACCESS_GROUP)) {
-            final StoredStatusEvent setype = new StoredStatusEvent(StatusEvent.getBuilder(
+            final StoredStatusEvent setype = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                     "foo", Instant.ofEpochMilli(10000), type).build(),
-                    id, StatusEventProcessingState.UNPROC, null, null);
+                    id, StatusEventProcessingState.UNPROC).build();
             failLoad(setype,
                     new IllegalArgumentException("Illegal type for loading event: " + type));
         }
@@ -711,10 +712,10 @@ public class ObjectEventQueueTest {
     @Test
     public void setProcessingCompleteFail() {
         final ObjectEventQueue q = new ObjectEventQueue();
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
         
         //nulls
         failSetProcessingComplete(q, null, new NullPointerException("event"));
@@ -723,19 +724,19 @@ public class ObjectEventQueueTest {
         failSetProcessingComplete(q, sse, new NoSuchEventException(sse));
         
         // with object level event in processed state
-        final ObjectEventQueue q2 = new ObjectEventQueue(new StoredStatusEvent(
+        final ObjectEventQueue q2 = new ObjectEventQueue(StoredStatusEvent.getBuilder(
                 StatusEvent.getBuilder(
                         "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                         .build(),
-                        new StatusEventID("foo2"), StatusEventProcessingState.PROC, null, null));
+                        new StatusEventID("foo2"), StatusEventProcessingState.PROC).build());
         failSetProcessingComplete(q2, sse, new NoSuchEventException(sse));
         
         // with version level event in processed state
         final ObjectEventQueue q3 = new ObjectEventQueue(new LinkedList<>(), Arrays.asList(
-                new StoredStatusEvent(StatusEvent.getBuilder(
+                StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                         "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                         .build(),
-                        new StatusEventID("foo2"), StatusEventProcessingState.PROC, null, null)));
+                        new StatusEventID("foo2"), StatusEventProcessingState.PROC).build()));
         failSetProcessingComplete(q3, sse, new NoSuchEventException(sse));
     }
     
@@ -782,18 +783,18 @@ public class ObjectEventQueueTest {
     public void drainAndBlockVersionLevelEventsWithEventInReadyAndNoDrain() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -821,18 +822,18 @@ public class ObjectEventQueueTest {
     public void drainAndBlockVersionLevelEventsWithDrain() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.NEW_VERSION)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         
@@ -853,18 +854,18 @@ public class ObjectEventQueueTest {
     public void drainAndBlockObjectLevelEvents() {
         final ObjectEventQueue q = new ObjectEventQueue();
         
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse1 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse1 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar1", Instant.ofEpochMilli(20000), StatusEventType.NEW_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC, null, null);
-        final StoredStatusEvent sse2 = new StoredStatusEvent(StatusEvent.getBuilder(
+                new StatusEventID("foo1"), StatusEventProcessingState.UNPROC).build();
+        final StoredStatusEvent sse2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "bar2", Instant.ofEpochMilli(30000), StatusEventType.RENAME_ALL_VERSIONS)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC, null, null);
+                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
         
         assertEmpty(q);
         

--- a/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
+++ b/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
@@ -42,7 +42,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
         assertThat("incorrect update time", sei.getUpdateTime(), is(Optional.absent()));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
-        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+        assertThat("incorrect tags", sei.getWorkerCodes(), is(Collections.emptySet()));
     }
 
     
@@ -62,7 +62,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
         assertThat("incorrect update time", sei.getUpdateTime(), is(Optional.absent()));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
-        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+        assertThat("incorrect tags", sei.getWorkerCodes(), is(Collections.emptySet()));
     }
     
     @Test 
@@ -87,7 +87,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect update time", sei.getUpdateTime(),
                 is(Optional.of(Instant.ofEpochMilli(10000))));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
-        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+        assertThat("incorrect tags", sei.getWorkerCodes(), is(Collections.emptySet()));
     }
     
     @Test
@@ -108,7 +108,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect update time", sei.getUpdateTime(),
                 is(Optional.of(Instant.ofEpochMilli(20000))));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
-        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+        assertThat("incorrect tags", sei.getWorkerCodes(), is(Collections.emptySet()));
     }
     
     @Test
@@ -129,7 +129,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect update time", sei.getUpdateTime(),
                 is(Optional.of(Instant.ofEpochMilli(20000))));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
-        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+        assertThat("incorrect tags", sei.getWorkerCodes(), is(Collections.emptySet()));
     }
     
     @Test
@@ -140,8 +140,8 @@ public class StoredStatusEventTest {
         final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
                 StatusEventProcessingState.UNPROC)
                 .withNullableUpdate(Instant.ofEpochMilli(20000), "foo")
-                .withTag("foo")
-                .withTag("bar")
+                .withWorkerCode("foo")
+                .withWorkerCode("bar")
                 .build();
         assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
         assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
@@ -151,7 +151,7 @@ public class StoredStatusEventTest {
         assertThat("incorrect update time", sei.getUpdateTime(),
                 is(Optional.of(Instant.ofEpochMilli(20000))));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
-        assertThat("incorrect tags", sei.getTags(), is(set("foo", "bar")));
+        assertThat("incorrect tags", sei.getWorkerCodes(), is(set("foo", "bar")));
     }
     
     @Test
@@ -162,12 +162,12 @@ public class StoredStatusEventTest {
         final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
                 StatusEventProcessingState.UNPROC)
                 .withNullableUpdate(Instant.ofEpochMilli(20000), "foo")
-                .withTag("foo")
-                .withTag("bar")
+                .withWorkerCode("foo")
+                .withWorkerCode("bar")
                 .build();
         
         try {
-            sei.getTags().add("whee");
+            sei.getWorkerCodes().add("whee");
             fail("expected exception");
         } catch (UnsupportedOperationException e) {
             //pass
@@ -188,9 +188,10 @@ public class StoredStatusEventTest {
     
     @Test
     public void buildFailTag() {
-        failBuildTag(null, new IllegalArgumentException("tag cannot be null or whitespace"));
+        failBuildTag(null,
+                new IllegalArgumentException("workerCode cannot be null or whitespace"));
         failBuildTag("   \t   \n ",
-                new IllegalArgumentException("tag cannot be null or whitespace"));
+                new IllegalArgumentException("workerCode cannot be null or whitespace"));
     }
     
     private void failBuildTag(final String tag, final Exception expected) {
@@ -199,7 +200,7 @@ public class StoredStatusEventTest {
         try {
             StoredStatusEvent.getBuilder(event, new StatusEventID("foo"),
                     StatusEventProcessingState.UNINDX)
-                    .withTag(tag);
+                    .withWorkerCode(tag);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);

--- a/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
+++ b/test/src/kbasesearchengine/test/events/StoredStatusEventTest.java
@@ -1,10 +1,12 @@
 package kbasesearchengine.test.events;
 
+import static kbasesearchengine.test.common.TestCommon.set;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.time.Instant;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -16,21 +18,23 @@ import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StoredStatusEvent;
 import kbasesearchengine.test.common.TestCommon;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class StoredStatusEventTest {
 
     @Test
-    public void constructNoUpdater() {
-        constructNoUpdater(null);
-        constructNoUpdater("   \t   \n   ");
+    public void equals() {
+        EqualsVerifier.forClass(StoredStatusEvent.class).usingGetClass().verify();
     }
-
-    private void constructNoUpdater(final String updater) {
+    
+    @Test 
+    public void buildMinimal() {
         final StatusEvent se = StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
         
-        final StoredStatusEvent sei = new StoredStatusEvent(se, new StatusEventID("foo"),
-                StatusEventProcessingState.UNPROC, null, updater);
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .build();
         assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
         assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
@@ -38,15 +42,107 @@ public class StoredStatusEventTest {
         assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
         assertThat("incorrect update time", sei.getUpdateTime(), is(Optional.absent()));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
+        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
     }
+
     
-    @Test
-    public void constructWithUpdater() {
+    @Test 
+    public void buildMinimalNullUpdate() {
         final StatusEvent se = StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
         
-        final StoredStatusEvent sei = new StoredStatusEvent(se, new StatusEventID("foo"),
-                StatusEventProcessingState.UNPROC, Instant.ofEpochMilli(20000), "foo");
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .withNullableUpdate(null, null)
+                .build();
+        assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
+        assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
+        assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", sei.getUpdateTime(), is(Optional.absent()));
+        assertThat("incorrect is parent", sei.isParentId(), is(false));
+        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+    }
+    
+    @Test 
+    public void buildMinimalNoUpdater() {
+        buildMinimalNoUpdater(null);
+        buildMinimalNoUpdater("   \t  \n  ");
+    }
+
+    private void buildMinimalNoUpdater(final String updater) {
+        final StatusEvent se = StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
+        
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .withNullableUpdate(Instant.ofEpochMilli(10000), updater)
+                .build();
+        assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
+        assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
+        assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", sei.getUpdateTime(),
+                is(Optional.of(Instant.ofEpochMilli(10000))));
+        assertThat("incorrect is parent", sei.isParentId(), is(false));
+        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+    }
+    
+    @Test
+    public void buildMinimalReplaceUpdater() {
+        final StatusEvent se = StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
+        
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .withNullableUpdate(Instant.ofEpochMilli(10000), "foo")
+                .withNullableUpdate(Instant.ofEpochMilli(20000), "bar")
+                .build();
+        assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
+        assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
+        assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", sei.getUpdater(), is(Optional.of("bar")));
+        assertThat("incorrect update time", sei.getUpdateTime(),
+                is(Optional.of(Instant.ofEpochMilli(20000))));
+        assertThat("incorrect is parent", sei.isParentId(), is(false));
+        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+    }
+    
+    @Test
+    public void buildMinimalReplaceUpdaterWithNull() {
+        final StatusEvent se = StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
+        
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .withNullableUpdate(Instant.ofEpochMilli(10000), "foo")
+                .withNullableUpdate(Instant.ofEpochMilli(20000), null)
+                .build();
+        assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
+        assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
+        assertThat("incorrect state", sei.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", sei.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", sei.getUpdateTime(),
+                is(Optional.of(Instant.ofEpochMilli(20000))));
+        assertThat("incorrect is parent", sei.isParentId(), is(false));
+        assertThat("incorrect tags", sei.getTags(), is(Collections.emptySet()));
+    }
+    
+    @Test
+    public void buildMaximal() {
+        final StatusEvent se = StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
+        
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .withNullableUpdate(Instant.ofEpochMilli(20000), "foo")
+                .withTag("foo")
+                .withTag("bar")
+                .build();
         assertThat("incorrect id", sei.getId(), is(new StatusEventID("foo")));
         assertThat("incorrect event", sei.getEvent(), is(StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build()));
@@ -55,33 +151,72 @@ public class StoredStatusEventTest {
         assertThat("incorrect update time", sei.getUpdateTime(),
                 is(Optional.of(Instant.ofEpochMilli(20000))));
         assertThat("incorrect is parent", sei.isParentId(), is(false));
+        assertThat("incorrect tags", sei.getTags(), is(set("foo", "bar")));
     }
     
     @Test
-    public void constructFail() {
+    public void immutable() {
+        final StatusEvent se = StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
+        
+        final StoredStatusEvent sei = StoredStatusEvent.getBuilder(se, new StatusEventID("foo"),
+                StatusEventProcessingState.UNPROC)
+                .withNullableUpdate(Instant.ofEpochMilli(20000), "foo")
+                .withTag("foo")
+                .withTag("bar")
+                .build();
+        
+        try {
+            sei.getTags().add("whee");
+            fail("expected exception");
+        } catch (UnsupportedOperationException e) {
+            //pass
+        }
+    }
+    
+    @Test
+    public void buildFail() {
         final StatusEvent event = StatusEvent.getBuilder(
                 "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
         final StatusEventID id = new StatusEventID("foo");
         final StatusEventProcessingState state = StatusEventProcessingState.UNINDX;
         
-        failConstruct(null, id, state, new NullPointerException("event"));
-        failConstruct(event, null, state, new NullPointerException("id"));
-        failConstruct(event, id, null, new NullPointerException("state"));
-        
+        failBuild(null, id, state, new NullPointerException("event"));
+        failBuild(event, null, state, new NullPointerException("id"));
+        failBuild(event, id, null, new NullPointerException("state"));
     }
     
-    private void failConstruct(
-            final StatusEvent event,
-            final StatusEventID id,
-            final StatusEventProcessingState state,
-            final Exception expected) {
+    @Test
+    public void buildFailTag() {
+        failBuildTag(null, new IllegalArgumentException("tag cannot be null or whitespace"));
+        failBuildTag("   \t   \n ",
+                new IllegalArgumentException("tag cannot be null or whitespace"));
+    }
+    
+    private void failBuildTag(final String tag, final Exception expected) {
+        final StatusEvent event = StatusEvent.getBuilder(
+                "foo", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS).build();
         try {
-            // no exceptions can be triggered by update time or updater
-            new StoredStatusEvent(event, id, state, null, null);
+            StoredStatusEvent.getBuilder(event, new StatusEventID("foo"),
+                    StatusEventProcessingState.UNINDX)
+                    .withTag(tag);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);
         }
     }
     
+    private void failBuild(
+            final StatusEvent event,
+            final StatusEventID id,
+            final StatusEventProcessingState state,
+            final Exception expected) {
+        try {
+            // no exceptions can be triggered by update time or updater
+            StoredStatusEvent.getBuilder(event, id, state).build();
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
 }

--- a/test/src/kbasesearchengine/test/events/exceptions/ExceptionTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/ExceptionTest.java
@@ -21,9 +21,9 @@ public class ExceptionTest {
     
     @Test
     public void noSuchEventException() {
-        final StoredStatusEvent sse = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent sse = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 "sc", Instant.ofEpochMilli(1000), StatusEventType.COPY_ACCESS_GROUP).build(),
-                new StatusEventID("foo"), StatusEventProcessingState.READY, null, null);
+                new StatusEventID("foo"), StatusEventProcessingState.READY).build();
         
         final NoSuchEventException e = new NoSuchEventException(sse);
         assertThat("incorrect message", e.getMessage(), is("Event with ID foo not found"));

--- a/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
@@ -177,16 +177,15 @@ public class RetrierTest {
     public void consumer2RetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 100, Collections.emptyList(), collog);
-        final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent ev = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
                 .build(),
                 new StatusEventID("wugga"),
-                StatusEventProcessingState.UNPROC,
-                null,
-                null);
+                StatusEventProcessingState.UNPROC)
+                .build();
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2), "foo", ev);
         final Instant end = Instant.now();
@@ -255,16 +254,15 @@ public class RetrierTest {
     public void consumer2FatalRetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 100, Arrays.asList(140, 60), collog);
-        final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent ev = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
                 .build(),
                 new StatusEventID("wugga"),
-                StatusEventProcessingState.UNPROC,
-                null,
-                null);
+                StatusEventProcessingState.UNPROC)
+                .build();
         final Instant start = Instant.now();
         ret.retryCons(new TestConsumer<>("foo", 2, true), "foo", ev);
         final Instant end = Instant.now();
@@ -376,16 +374,15 @@ public class RetrierTest {
     public void function2RetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 100, Collections.emptyList(), collog);
-        final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent ev = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
                 .build(),
                 new StatusEventID("wugga"),
-                StatusEventProcessingState.UNPROC,
-                null,
-                null);
+                StatusEventProcessingState.UNPROC)
+                .build();
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 26L, 2), "foo", ev);
         final Instant end = Instant.now();
@@ -456,16 +453,15 @@ public class RetrierTest {
     public void function2FatalRetrySuccessWithEvent() throws Exception {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(2, 100, Arrays.asList(140, 60), collog);
-        final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent ev = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "whee"), Instant.now(), StatusEventType.NEW_VERSION)
                 .withNullableAccessGroupID(23)
                 .withNullableObjectID("bar")
                 .withNullableVersion(6)
                 .build(),
                 new StatusEventID("wugga"),
-                StatusEventProcessingState.UNPROC,
-                null,
-                null);
+                StatusEventProcessingState.UNPROC)
+                .build();
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>("foo", 64L, 2, true), "foo", ev);
         final Instant end = Instant.now();

--- a/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
+++ b/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
@@ -279,7 +279,7 @@ public class IndexerWorkerIntegrationTest {
     
     @Test
     public void testGenomeManually() throws Exception {
-        final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
+        final StoredStatusEvent ev = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                 new StorageObjectType("WS", "KBaseGenomes.Genome"),
                 Instant.now(),
                 StatusEventType.NEW_VERSION)
@@ -289,9 +289,8 @@ public class IndexerWorkerIntegrationTest {
                 .withNullableisPublic(false)
                 .build(),
                 new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC,
-                null,
-                null);
+                StatusEventProcessingState.UNPROC)
+                .build();
         worker.processOneEvent(ev.getEvent());
         PostProcessing pp = new PostProcessing();
         pp.objectInfo = true;
@@ -321,7 +320,7 @@ public class IndexerWorkerIntegrationTest {
     private void indexFewVersions(final StoredStatusEvent evid) throws Exception {
         final StatusEvent ev = evid.getEvent();
         for (int i = Math.max(1, ev.getVersion().get() - 5); i <= ev.getVersion().get(); i++) {
-            final StoredStatusEvent ev2 = new StoredStatusEvent(StatusEvent.getBuilder(
+            final StoredStatusEvent ev2 = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                     ev.getStorageObjectType().get(),
                     ev.getTimestamp(),
                     ev.getEventType())
@@ -331,9 +330,8 @@ public class IndexerWorkerIntegrationTest {
                     .withNullableisPublic(ev.isPublic().get())
                     .build(),
                     evid.getId(),
-                    StatusEventProcessingState.UNPROC,
-                    null,
-                    null);
+                    StatusEventProcessingState.UNPROC)
+                    .build();
             worker.processOneEvent(ev2.getEvent());
         }
     }
@@ -369,8 +367,8 @@ public class IndexerWorkerIntegrationTest {
                 .withNullableVersion(5)
                 .withNullableisPublic(false)
                 .build();
-        indexFewVersions(new StoredStatusEvent(ev, new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC, null, null));
+        indexFewVersions(StoredStatusEvent.getBuilder(ev, new StatusEventID("-1"),
+                StatusEventProcessingState.UNPROC).build());
         checkSearch(1, "Narrative", "tree", wsid, false);
         checkSearch(1, "Narrative", "species", wsid, false);
         /*indexFewVersions(new ObjectStatusEvent("-1", "WS", 10455, "1", 78, null, 
@@ -396,8 +394,8 @@ public class IndexerWorkerIntegrationTest {
                 .withNullableVersion(1)
                 .withNullableisPublic(false)
                 .build();
-        indexFewVersions(new StoredStatusEvent(ev, new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC, null, null));
+        indexFewVersions(StoredStatusEvent.getBuilder(ev, new StatusEventID("-1"),
+                StatusEventProcessingState.UNPROC).build());
         checkSearch(1, "PairedEndLibrary", "Illumina", wsid, true);
         checkSearch(1, "PairedEndLibrary", "sample1se.fastq.gz", wsid, false);
         final StatusEvent ev2 = StatusEvent.getBuilder(
@@ -409,8 +407,8 @@ public class IndexerWorkerIntegrationTest {
                 .withNullableVersion(1)
                 .withNullableisPublic(false)
                 .build();
-        indexFewVersions(new StoredStatusEvent(ev2, new StatusEventID("-1"),
-                StatusEventProcessingState.UNPROC, null, null));
+        indexFewVersions(StoredStatusEvent.getBuilder(ev2, new StatusEventID("-1"),
+                StatusEventProcessingState.UNPROC).build());
         checkSearch(1, "SingleEndLibrary", "PacBio", wsid, true);
         checkSearch(1, "SingleEndLibrary", "reads.2", wsid, false);
     }

--- a/test/src/kbasesearchengine/test/main/PerformanceTester.java
+++ b/test/src/kbasesearchengine/test/main/PerformanceTester.java
@@ -224,7 +224,7 @@ public class PerformanceTester {
                 String[] parts = ref.split("/");
                 int wsId = Integer.parseInt(parts[0]);
                 int version = Integer.parseInt(parts[2]);
-                final StoredStatusEvent ev = new StoredStatusEvent(StatusEvent.getBuilder(
+                final StoredStatusEvent ev = StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                         new StorageObjectType("WS", "KBaseGenomes.Genome"),
                         Instant.now(),
                         StatusEventType.NEW_VERSION)
@@ -234,9 +234,8 @@ public class PerformanceTester {
                         .withNullableisPublic(true)
                         .build(),
                         new StatusEventID("-1"),
-                        StatusEventProcessingState.UNPROC,
-                        null,
-                        null);
+                        StatusEventProcessingState.UNPROC)
+                        .build();
                 long t2 = System.currentTimeMillis();
                 try {
                     mop.processOneEvent(ev.getEvent());


### PR DESCRIPTION
In preparation for adding the ability to assign events to a subset of workers.

Worker codes are currently unused elsewhere.