### PR TITLE
SCT-427 add worker codes

### DIFF
--- a/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
@@ -189,7 +189,12 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
         if (workerCodes == null || workerCodes.isEmpty()) {
             workerCodes = DEFAULT_WORKER_CODES_SET;
         }
-        Utils.noNulls(workerCodes, "null item in workerCodes");
+        for (final String code: workerCodes) {
+            if (Utils.isNullOrEmpty(code)) {
+                throw new IllegalArgumentException("null or whitespace only item in workerCodes");
+            }
+        }
+        
         final Optional<StorageObjectType> sot = newEvent.getStorageObjectType();
         final Document doc = new Document()
                 .append(FLD_ACCESS_GROUP_ID, newEvent.getAccessGroupId().orNull())

--- a/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
@@ -51,8 +51,6 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     
     //TODO DB add schema ver code
     
-    //TODO NNOW test changes
-    
     private static final List<String> DEFAULT_WORKER_CODES_LIST = Collections.unmodifiableList(
             Arrays.asList(StatusEventStorage.DEFAULT_WORKER_CODE));
     private static final Set<String> DEFAULT_WORKER_CODES_SET = Collections.unmodifiableSet(

--- a/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
@@ -2,11 +2,15 @@ package kbasesearchengine.events.storage;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
@@ -39,7 +43,20 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     
     /* Note that general mongoexceptions are more or less impossible to test. */
     
+    /* No need for a worker code index at the moment I think. The query for
+     * setAndGetProcessingState should run down all the events in the target state in order of
+     * timestamp until it finds one with an appropriate code.
+     * Look into adding one if we start seeing long queries.
+     */
+    
     //TODO DB add schema ver code
+    
+    //TODO NNOW test changes
+    
+    private static final List<String> DEFAULT_WORKER_CODES_LIST = Collections.unmodifiableList(
+            Arrays.asList(StatusEventStorage.DEFAULT_WORKER_CODE));
+    private static final Set<String> DEFAULT_WORKER_CODES_SET = Collections.unmodifiableSet(
+            new HashSet<>(DEFAULT_WORKER_CODES_LIST));
     
     private static final int MAX_RETURNED_EVENTS = 10000;
     
@@ -54,6 +71,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     private static final String FLD_OBJECT_TYPE_VER = "objtypever";
     private static final String FLD_PUBLIC = "public";
     private static final String FLD_NEW_NAME = "newname";
+    private static final String FLD_WORKER_CODES = "wrkcde";
     private static final String FLD_UPDATE_TIME = "updte";
     // the ID, if any, of the operator that last changed the event status. Arbitrary string.
     private static final String FLD_UPDATER = "updtr";
@@ -163,10 +181,15 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     @Override
     public StoredStatusEvent store(
             final StatusEvent newEvent,
-            final StatusEventProcessingState state)
+            final StatusEventProcessingState state,
+            Set<String> workerCodes)
             throws FatalRetriableIndexingException {
         Utils.nonNull(newEvent, "newEvent");
         Utils.nonNull(state, "state");
+        if (workerCodes == null || workerCodes.isEmpty()) {
+            workerCodes = DEFAULT_WORKER_CODES_SET;
+        }
+        Utils.noNulls(workerCodes, "null item in workerCodes");
         final Optional<StorageObjectType> sot = newEvent.getStorageObjectType();
         final Document doc = new Document()
                 .append(FLD_ACCESS_GROUP_ID, newEvent.getAccessGroupId().orNull())
@@ -181,6 +204,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
                 .append(FLD_EVENT_TYPE, newEvent.getEventType().toString())
                 .append(FLD_NEW_NAME, newEvent.getNewName().orNull())
                 .append(FLD_PUBLIC, newEvent.isPublic().orNull())
+                .append(FLD_WORKER_CODES, workerCodes)
                 .append(FLD_TIMESTAMP, Date.from(newEvent.getTimestamp()));
         try {
             db.getCollection(COL_EVENT).insertOne(doc);
@@ -188,8 +212,12 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
             throw new FatalRetriableIndexingException(
                     "Failed event storage: " + e.getMessage(), e);
         }
-        return StoredStatusEvent.getBuilder(
-                newEvent, new StatusEventID(doc.getObjectId("_id").toString()), state).build();
+        final StoredStatusEvent.Builder b = StoredStatusEvent.getBuilder(
+                newEvent, new StatusEventID(doc.getObjectId("_id").toString()), state);
+        for (final String code: workerCodes) {
+            b.withWorkerCode(code);
+        }
+        return b.build();
     }
     
     @Override
@@ -219,13 +247,18 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
         final Instant time = event.getDate(FLD_TIMESTAMP).toInstant();
         final StatusEventType eventType = StatusEventType.valueOf(event.getString(FLD_EVENT_TYPE));
         final Date updateTime = event.getDate(FLD_UPDATE_TIME);
+        @SuppressWarnings("unchecked")
+        List<String> workerCodes = (List<String>) event.get(FLD_WORKER_CODES);
+        if (workerCodes == null || workerCodes.isEmpty()) {
+            workerCodes = DEFAULT_WORKER_CODES_LIST;
+        }
         final Builder b;
         if (sot == null) {
             b = StatusEvent.getBuilder(storageCode, time, eventType);
         } else {
             b = StatusEvent.getBuilder(sot, time, eventType);
         }
-        return StoredStatusEvent.getBuilder(
+        final StoredStatusEvent.Builder b2 = StoredStatusEvent.getBuilder(
                 b.withNullableAccessGroupID(event.getInteger(FLD_ACCESS_GROUP_ID))
                         .withNullableObjectID(event.getString(FLD_OBJECT_ID))
                         .withNullableVersion(event.getInteger(FLD_VERSION))
@@ -235,8 +268,11 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
                 new StatusEventID(event.getObjectId("_id").toString()),
                 StatusEventProcessingState.valueOf(event.getString(FLD_STATUS)))
                 .withNullableUpdate(updateTime == null ? null : updateTime.toInstant(),
-                        event.getString(FLD_UPDATER))
-                .build();
+                        event.getString(FLD_UPDATER));
+        for (final String code: workerCodes) {
+            b2.withWorkerCode(code);
+        }
+        return b2.build();
     }
     
     // note returns in order of time stamp, oldest first (e.g FIFO)
@@ -290,19 +326,35 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
     @Override
     public Optional<StoredStatusEvent> setAndGetProcessingState(
             final StatusEventProcessingState oldState,
+            final Set<String> workerCodes,
             final StatusEventProcessingState newState,
             final String updater)
             throws FatalRetriableIndexingException {
         Utils.nonNull(oldState, "oldState");
         Utils.nonNull(newState, "newState");
         Utils.notNullOrEmpty(updater, "updater cannot be null or whitespace");
+        final List<Document> codeQuery = new LinkedList<>();
+        final Set<String> codeSet = new HashSet<>();
+        if (workerCodes == null || workerCodes.isEmpty() ||
+                workerCodes.contains(StatusEventStorage.DEFAULT_WORKER_CODE)) {
+            // next line matches missing field & null fields
+            codeQuery.add(new Document(FLD_WORKER_CODES, null));
+            codeQuery.add(new Document(FLD_WORKER_CODES, Collections.emptyList()));
+            codeSet.add(StatusEventStorage.DEFAULT_WORKER_CODE);
+        }
+        if (workerCodes != null) {
+            Utils.noNulls(workerCodes, "null item in workerCodes");
+            codeSet.addAll(workerCodes);
+        }
+        codeQuery.add(new Document(FLD_WORKER_CODES, new Document("$in", codeSet)));
+        
         final Document innerUpdate = new Document(FLD_STATUS, newState.toString())
                 .append(FLD_UPDATE_TIME, Date.from(clock.instant()))
                 .append(FLD_UPDATER, updater);
         final Document ret;
         try {
-             ret = db.getCollection(COL_EVENT).findOneAndUpdate(
-                     new Document(FLD_STATUS, oldState.toString()),
+            ret = db.getCollection(COL_EVENT).findOneAndUpdate(
+                     new Document(FLD_STATUS, oldState.toString()).append("$or", codeQuery),
                      new Document("$set", innerUpdate),
                      new FindOneAndUpdateOptions()
                              .sort(new Document(FLD_TIMESTAMP, 1))

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -516,9 +516,9 @@ public class IndexerWorker implements Stoppable {
             long loadTime = System.currentTimeMillis() - t1;
             logger.logInfo("[Indexer]   " + guid + ", loading time: " + loadTime + " ms.");
             logger.timeStat(guid, loadTime, 0, 0);
-            Set<ObjectTypeParsingRules> parsingRules = 
+            final Set<ObjectTypeParsingRules> parsingRules = 
                     typeStorage.listObjectTypeParsingRules(storageObjectType);
-            for (ObjectTypeParsingRules rule : parsingRules) {
+            for (final ObjectTypeParsingRules rule : parsingRules) {
                 final long t2 = System.currentTimeMillis();
                 final ParseObjectsRet parsedRet = parseObjects(guid, indexLookup,
                         newRefPath, obj, rule);

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -218,7 +218,8 @@ public class IndexerWorker implements Stoppable {
     
     private boolean performOneTick() throws InterruptedException, IndexingException {
         final Optional<StoredStatusEvent> optEvent = retrier.retryFunc(
-                s -> s.setAndGetProcessingState(StatusEventProcessingState.READY,
+                // TODO NNOW worker codes
+                s -> s.setAndGetProcessingState(StatusEventProcessingState.READY, new HashSet<>(),
                         StatusEventProcessingState.PROC, id),
                 storage, null);
         boolean processedEvent = false;

--- a/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
+++ b/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
@@ -274,7 +274,9 @@ public class WorkspaceEventGenerator {
                     .withNullableVersion(vernum)
                     .withNullableisPublic(pub)
                     .build(),
-                    StatusEventProcessingState.UNPROC);
+                    StatusEventProcessingState.UNPROC,
+                    //TODO NNOW worker codes,
+                    new HashSet<>());
         } catch (RetriableIndexingException e) {
             throw new EventGeneratorException(e.getMessage(), e); //TODO CODE retries
         }

--- a/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
+++ b/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
@@ -571,7 +571,9 @@ public class MongoDBStatusEventStorageTest {
                 "Ws", Instant.ofEpochMilli(10000), StatusEventType.NEW_ALL_VERSIONS).build();
         failStore(event, null, null, new NullPointerException("state"));
         failStore(event, StatusEventProcessingState.UNINDX, set("foo", null),
-                new NullPointerException("null item in workerCodes"));
+                new IllegalArgumentException("null or whitespace only item in workerCodes"));
+        failStore(event, StatusEventProcessingState.UNINDX, set("foo", "   \t   \n  "),
+                new IllegalArgumentException("null or whitespace only item in workerCodes"));
     }
     
     private void failStore(

--- a/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
+++ b/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
@@ -325,22 +325,49 @@ public class MongoDBStatusEventStorageTest {
     private static final Consumer<StatusEventID> NOOP = id -> {};
     
     @Test
-    public void getAndSetProcessingWithUpdaterAndSortNullCodes() throws Exception {
+    public void getAndSetProcessingWithSortAndNullCodes() throws Exception {
         getAndSetProcessingWithUpdaterAndSort(null, NOOP);
     }
     
     @Test
-    public void getAndSetProcessingWithUpdaterAndSortEmptyCodes() throws Exception {
+    public void getAndSetProcessingWithSortNoDBWorkerCodeField() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(set(),
+                id -> db.getCollection("searchEvents").findOneAndUpdate(
+                        new Document("_id", new ObjectId(id.getId())),
+                        new Document("$unset", new Document("wrkcde", 1)),
+                        new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)));
+    }
+    
+    @Test
+    public void getAndSetProcessingWithSortNullDBWorkerCodeField() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(null,
+                id -> db.getCollection("searchEvents").findOneAndUpdate(
+                        new Document("_id", new ObjectId(id.getId())),
+                        new Document("$set", new Document("wrkcde", null)),
+                        new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)));
+    }
+    
+    @Test
+    public void getAndSetProcessingWithSortEmptyDBWorkerCodeField() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(set("default", "bar"),
+                id -> db.getCollection("searchEvents").findOneAndUpdate(
+                        new Document("_id", new ObjectId(id.getId())),
+                        new Document("$set", new Document("wrkcde", Arrays.asList())),
+                        new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)));
+    }
+    
+    @Test
+    public void getAndSetProcessingWithSortAndEmptyCodes() throws Exception {
         getAndSetProcessingWithUpdaterAndSort(set(), NOOP);
     }
     
     @Test
-    public void getAndSetProcessingWithUpdaterAndSortDefaultCode() throws Exception {
+    public void getAndSetProcessingWithSortAndDefaultCode() throws Exception {
         getAndSetProcessingWithUpdaterAndSort(set("default"), NOOP);
     }
     
     @Test
-    public void getAndSetProcessingWithUpdaterAndSortDefaultPlusCodes() throws Exception {
+    public void getAndSetProcessingWithSortAndDefaultPlusCodes() throws Exception {
         getAndSetProcessingWithUpdaterAndSort(set("default", "foo"), NOOP);
     }
 

--- a/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
+++ b/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
@@ -30,12 +30,15 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Range;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.ReturnDocument;
 
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventID;
 import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.RetriableIndexingException;
 import kbasesearchengine.events.storage.MongoDBStatusEventStorage;
 import kbasesearchengine.events.storage.StatusEventStorage;
@@ -80,7 +83,7 @@ public class MongoDBStatusEventStorageTest {
     }
 
     @Test
-    public void storeAndGetNoTypeAllFields() throws Exception {
+    public void storeAndGetNoTypeEmptyCodesAllFields() throws Exception {
         // tests with all possible fields in status event
         final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
                 "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
@@ -90,7 +93,8 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableObjectID("bar")
                 .withNullableVersion(7)
                 .build(),
-                StatusEventProcessingState.UNPROC);
+                StatusEventProcessingState.UNPROC,
+                set());
         
         assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.UNPROC));
         assertThat("incorrect updater", sse.getUpdater(), is(Optional.absent()));
@@ -103,6 +107,7 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableObjectID("bar")
                 .withNullableVersion(7)
                 .build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
         assertNotNull("id is null", sse.getId());
         
         final StoredStatusEvent got = storage.get(sse.getId()).get();
@@ -119,6 +124,36 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableObjectID("bar")
                 .withNullableVersion(7)
                 .build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
+    }
+    
+    @Test
+    public void storeAndGetNoTypeWithCodes() throws Exception {
+        // tests with all possible fields in status event
+        final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
+                "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP).build(),
+                StatusEventProcessingState.UNPROC,
+                set("business", "numbers"));
+        
+        assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", sse.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", sse.getUpdateTime(), is(Optional.absent()));
+        assertThat("incorrect event", sse.getEvent(), is(StatusEvent.getBuilder(
+                "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
+                .build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("business", "numbers")));
+        assertNotNull("id is null", sse.getId());
+        
+        final StoredStatusEvent got = storage.get(sse.getId()).get();
+        
+        assertThat("ids don't match", got.getId(), is(sse.getId()));
+        assertThat("incorrect state", got.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", sse.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", sse.getUpdateTime(), is(Optional.absent()));
+        assertThat("incorrect event", got.getEvent(), is(StatusEvent.getBuilder(
+                "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
+                .build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("business", "numbers")));
     }
     
     @Test
@@ -128,7 +163,7 @@ public class MongoDBStatusEventStorageTest {
         final StorageObjectType sot = new StorageObjectType("foo", "bar", 9);
         final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
                 sot, Instant.ofEpochMilli(20000), StatusEventType.DELETE_ALL_VERSIONS).build(),
-                StatusEventProcessingState.FAIL);
+                StatusEventProcessingState.FAIL, null);
         
         assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.FAIL));
         assertThat("incorrect updater", sse.getUpdater(), is(Optional.absent()));
@@ -138,6 +173,7 @@ public class MongoDBStatusEventStorageTest {
                     StatusEventType.DELETE_ALL_VERSIONS)
                 .build()));
         assertNotNull("id is null", sse.getId());
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
         
         final StoredStatusEvent got = storage.get(sse.getId()).get();
         
@@ -148,6 +184,7 @@ public class MongoDBStatusEventStorageTest {
         assertThat("incorrect event", got.getEvent(), is(StatusEvent.getBuilder(
                 new StorageObjectType("foo", "bar", 9), Instant.ofEpochMilli(20000),
                 StatusEventType.DELETE_ALL_VERSIONS).build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
     }
     
     @Test
@@ -156,7 +193,7 @@ public class MongoDBStatusEventStorageTest {
         final StorageObjectType sot = new StorageObjectType("foo", "bar", 9);
         final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
                 sot, Instant.ofEpochMilli(20000), StatusEventType.DELETE_ALL_VERSIONS).build(),
-                StatusEventProcessingState.FAIL);
+                StatusEventProcessingState.FAIL, null);
         
         assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.FAIL));
         assertThat("incorrect updater", sse.getUpdater(), is(Optional.absent()));
@@ -166,6 +203,7 @@ public class MongoDBStatusEventStorageTest {
                     StatusEventType.DELETE_ALL_VERSIONS)
                 .build()));
         assertNotNull("id is null", sse.getId());
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
         
         final Optional<StoredStatusEvent> got = storage.get(
                 new StatusEventID(new ObjectId().toString()));
@@ -173,10 +211,47 @@ public class MongoDBStatusEventStorageTest {
     }
     
     @Test
+    public void getWithMissingCodesField() throws Exception {
+        getWithAlteredCodesField(new Document("$unset", new Document("wrkcde", 1)));
+    }
+    
+    @Test
+    public void getWithNullCodesField() throws Exception {
+        getWithAlteredCodesField(new Document("$set", new Document("wrkcde", null)));
+    }
+    
+    @Test
+    public void getWithEmptyCodesField() throws Exception {
+        getWithAlteredCodesField(new Document("$set", new Document("wrkcde", Arrays.asList())));
+    }
+
+    private void getWithAlteredCodesField(final Document operation)
+            throws FatalRetriableIndexingException {
+        final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
+                "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP).build(),
+                StatusEventProcessingState.UNPROC,
+                set("business", "numbers"));
+        
+        db.getCollection("searchEvents").findOneAndUpdate(
+                new Document("_id", new ObjectId(sse.getId().getId())),
+                operation,
+                new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER));
+        
+        final StoredStatusEvent got = storage.get(sse.getId()).get();
+        assertThat("ids don't match", got.getId(), is(sse.getId()));
+        assertThat("incorrect state", got.getState(), is(StatusEventProcessingState.UNPROC));
+        assertThat("incorrect updater", got.getUpdater(), is(Optional.absent()));
+        assertThat("incorrect update time", got.getUpdateTime(), is(Optional.absent()));
+        assertThat("incorrect event", got.getEvent(), is(StatusEvent.getBuilder(
+                "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP).build()));
+        assertThat("incorrect worker codes", got.getWorkerCodes(), is(set("default")));
+    }
+    
+    @Test
     public void setProcessingStateWithoutOldState() throws Exception {
         final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
                 "KE", Instant.ofEpochMilli(30000), StatusEventType.COPY_ACCESS_GROUP).build(),
-                StatusEventProcessingState.UNPROC);
+                StatusEventProcessingState.UNPROC, null);
         
         when(clock.instant()).thenReturn(Instant.ofEpochMilli(30000));
         
@@ -192,13 +267,14 @@ public class MongoDBStatusEventStorageTest {
                 is(Optional.of(Instant.ofEpochMilli(30000))));
         assertThat("incorrect event", got.getEvent(), is(StatusEvent.getBuilder(
                 "KE", Instant.ofEpochMilli(30000), StatusEventType.COPY_ACCESS_GROUP).build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
     }
     
     @Test
     public void setProcessingStateWithOldState() throws Exception {
         final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
                 "KE", Instant.ofEpochMilli(30000), StatusEventType.COPY_ACCESS_GROUP).build(),
-                StatusEventProcessingState.UNPROC);
+                StatusEventProcessingState.UNPROC, null);
         
         when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
         
@@ -214,13 +290,14 @@ public class MongoDBStatusEventStorageTest {
                 is(Optional.of(Instant.ofEpochMilli(10000))));
         assertThat("incorrect event", got.getEvent(), is(StatusEvent.getBuilder(
                 "KE", Instant.ofEpochMilli(30000), StatusEventType.COPY_ACCESS_GROUP).build()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
     }
     
     @Test
     public void setProcessingStateFailNonExistant() throws Exception {
         storage.store(StatusEvent.getBuilder(
                 "FE", Instant.ofEpochMilli(30000), StatusEventType.COPY_ACCESS_GROUP).build(),
-                StatusEventProcessingState.UNPROC);
+                StatusEventProcessingState.UNPROC, null);
         
         when(clock.instant()).thenReturn(Instant.now());
         
@@ -235,7 +312,7 @@ public class MongoDBStatusEventStorageTest {
     public void setProcessingStateFailNoSuchState() throws Exception {
         final StoredStatusEvent sse = storage.store(StatusEvent.getBuilder(
                 "FE", Instant.ofEpochMilli(30000), StatusEventType.COPY_ACCESS_GROUP).build(),
-                StatusEventProcessingState.UNPROC);
+                StatusEventProcessingState.UNPROC, null);
         
         when(clock.instant()).thenReturn(Instant.now());
         
@@ -245,8 +322,32 @@ public class MongoDBStatusEventStorageTest {
         assertThat("expected fail", success, is(false));
     }
 
+    private static final Consumer<StatusEventID> NOOP = id -> {};
+    
     @Test
-    public void getAndSetProcessingWithUpdaterAndSort() throws Exception {
+    public void getAndSetProcessingWithUpdaterAndSortNullCodes() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(null, NOOP);
+    }
+    
+    @Test
+    public void getAndSetProcessingWithUpdaterAndSortEmptyCodes() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(set(), NOOP);
+    }
+    
+    @Test
+    public void getAndSetProcessingWithUpdaterAndSortDefaultCode() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(set("default"), NOOP);
+    }
+    
+    @Test
+    public void getAndSetProcessingWithUpdaterAndSortDefaultPlusCodes() throws Exception {
+        getAndSetProcessingWithUpdaterAndSort(set("default", "foo"), NOOP);
+    }
+
+    private void getAndSetProcessingWithUpdaterAndSort(
+            final Set<String> workerCodes,
+            final Consumer<StatusEventID> operation)
+            throws RetriableIndexingException, FatalRetriableIndexingException {
         // test that the event that is updated is the oldest event
         store(2, 200, StatusEventProcessingState.READY);
         final StorageObjectType sot = new StorageObjectType("foo", "bar", 9);
@@ -258,13 +359,18 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableObjectID("bar")
                 .withNullableVersion(7)
                 .build(),
-                StatusEventProcessingState.READY);
+                StatusEventProcessingState.READY,
+                null);
         store(201, 400, StatusEventProcessingState.READY);
+        
+        operation.accept(sse.getId());
         
         when(clock.instant()).thenReturn(Instant.ofEpochMilli(100000));
         
         final StoredStatusEvent ret = storage.setAndGetProcessingState(
-                StatusEventProcessingState.READY, StatusEventProcessingState.PROC, "whee").get();
+                StatusEventProcessingState.READY, workerCodes,
+                StatusEventProcessingState.PROC, "whee")
+                .get();
         assertThat("incorrect state", ret.getState(), is(StatusEventProcessingState.PROC));
         assertThat("incorrect updater", ret.getUpdater(), is(Optional.of("whee")));
         assertThat("incorrect update time", ret.getUpdateTime(),
@@ -278,6 +384,7 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableVersion(7)
                 .build()));
         assertThat("ids don't match", ret.getId(), is(sse.getId()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
         
         final StoredStatusEvent got = storage.get(sse.getId()).get();
         assertThat("incorrect state", got.getState(), is(StatusEventProcessingState.PROC));
@@ -293,6 +400,7 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableVersion(7)
                 .build()));
         assertThat("ids don't match", got.getId(), is(sse.getId()));
+        assertThat("incorrect worker codes", sse.getWorkerCodes(), is(set("default")));
     }
     
     @Test
@@ -306,36 +414,41 @@ public class MongoDBStatusEventStorageTest {
                 .withNullableObjectID("bar")
                 .withNullableVersion(7)
                 .build(),
-                StatusEventProcessingState.UNPROC);
+                StatusEventProcessingState.UNPROC,
+                null);
         
         when(clock.instant()).thenReturn(Instant.now());
         
         final Optional<StoredStatusEvent> ret = storage.setAndGetProcessingState(
-                StatusEventProcessingState.READY, StatusEventProcessingState.PROC, "whee");
+                StatusEventProcessingState.READY, null, StatusEventProcessingState.PROC, "whee");
         assertThat("expected absent", ret, is(Optional.absent()));
     }
     
     @Test
     public void setAndGetProcessingFail() {
-        failSetAndGetProcessing(null, StatusEventProcessingState.FAIL, "foo",
+        failSetAndGetProcessing(null, null, StatusEventProcessingState.FAIL, "foo",
                 new NullPointerException("oldState"));
-        failSetAndGetProcessing(StatusEventProcessingState.FAIL, null, "foo",
+        failSetAndGetProcessing(StatusEventProcessingState.FAIL, null, null, "foo",
                 new NullPointerException("newState"));
-        failSetAndGetProcessing(StatusEventProcessingState.UNPROC,
+        failSetAndGetProcessing(StatusEventProcessingState.UNPROC, null,
                 StatusEventProcessingState.READY, null,
                 new IllegalArgumentException("updater cannot be null or whitespace"));
-        failSetAndGetProcessing(StatusEventProcessingState.UNPROC,
+        failSetAndGetProcessing(StatusEventProcessingState.UNPROC, null,
                 StatusEventProcessingState.READY, "   \t \n  ",
                 new IllegalArgumentException("updater cannot be null or whitespace"));
+        failSetAndGetProcessing(StatusEventProcessingState.UNPROC, set("foo", null),
+                StatusEventProcessingState.FAIL, "foo",
+                new NullPointerException("null item in workerCodes"));
     }
     
     private void failSetAndGetProcessing(
             final StatusEventProcessingState oldState,
+            final Set<String> workerCodes,
             final StatusEventProcessingState newState,
             final String updater,
             final Exception expected) {
         try {
-            storage.setAndGetProcessingState(oldState, newState, updater);
+            storage.setAndGetProcessingState(oldState, workerCodes, newState, updater);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);
@@ -436,7 +549,7 @@ public class MongoDBStatusEventStorageTest {
         for (final int time: times) {
             storage.store(StatusEvent.getBuilder(
                     "foo", Instant.ofEpochMilli(time * 1000), StatusEventType.NEW_VERSION).build(),
-                    state);
+                    state, null);
         }
     }
     
@@ -452,18 +565,22 @@ public class MongoDBStatusEventStorageTest {
     
     @Test
     public void storeFail() {
-        failStore(null, StatusEventProcessingState.UNINDX, new NullPointerException("newEvent"));
+        failStore(null, StatusEventProcessingState.UNINDX, null,
+                new NullPointerException("newEvent"));
         final StatusEvent event = StatusEvent.getBuilder(
                 "Ws", Instant.ofEpochMilli(10000), StatusEventType.NEW_ALL_VERSIONS).build();
-        failStore(event, null, new NullPointerException("state"));
+        failStore(event, null, null, new NullPointerException("state"));
+        failStore(event, StatusEventProcessingState.UNINDX, set("foo", null),
+                new NullPointerException("null item in workerCodes"));
     }
     
     private void failStore(
             final StatusEvent event,
             final StatusEventProcessingState state,
+            final Set<String> workerCodes,
             final Exception expected) {
         try {
-            storage.store(event, state);
+            storage.store(event, state, workerCodes);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);


### PR DESCRIPTION
Adds codes to mongoDB class such that events can be assigned to workers.

TODO: Add to UI (next PR)