### PR TITLE
SCT-508  Alter queue so verison level events block each other 

### DIFF
--- a/lib/src/kbasesearchengine/events/AccessGroupEventQueue.java
+++ b/lib/src/kbasesearchengine/events/AccessGroupEventQueue.java
@@ -7,11 +7,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.function.Function;
+
+import com.google.common.base.Optional;
 
 import kbasesearchengine.events.exceptions.NoSuchEventException;
 import kbasesearchengine.tools.Utils;
@@ -48,7 +49,7 @@ public class AccessGroupEventQueue {
             });
     /* if drain != null, ready and processing must = null. Object queues should be draining
      * events until the timestamp on the drain event.
-     * if ready or processing != null, drain and the non null field must be null. All object
+     * if ready or processing != null, drain and the other field must be null. All object
      * queues must be drained at this point. 
      */
     private StoredStatusEvent drain = null; // AG event waiting for object queues to drain
@@ -56,7 +57,7 @@ public class AccessGroupEventQueue {
     private StoredStatusEvent processing = null; // AG event processing
     private int size = 0; // keep a record of size rather than running through sub queues
     
-    /* should maybe initialize with an acccess group id and reject events that don't match */
+    /* should maybe initialize with an access group id and reject events that don't match */
     
     /** Create a new, empty, queue. */
     public AccessGroupEventQueue() {}
@@ -68,8 +69,7 @@ public class AccessGroupEventQueue {
      * <ul>
      * <li> Only one access group level event can be in the ready or processing state, and
      * if so no other events can be in the ready or processing state</li>
-     * <li> Only one object level event per object ID can be in the ready or processing state, and
-     * if so no version level events for that objectID can be in the ready or processing state</li>
+     * <li> Only one event per object ID can be in the ready or processing state</li>
      * </ul>
      * @param initialLoad the events to load into the queue.
      */
@@ -77,8 +77,6 @@ public class AccessGroupEventQueue {
         Utils.nonNull(initialLoad, "initialLoad");
         Utils.noNulls(initialLoad, "initialLoad has null entries");
         final Map<String, StoredStatusEvent> objects = new HashMap<>();
-        final Map<String, List<StoredStatusEvent>> objectVersionReady = new HashMap<>();
-        final Map<String, List<StoredStatusEvent>> objectVersionProcessing = new HashMap<>();
         
         for (final StoredStatusEvent e: initialLoad) {
             if (!e.getState().equals(StatusEventProcessingState.READY) &&
@@ -87,8 +85,6 @@ public class AccessGroupEventQueue {
             }
             if (ACCESS_GROUP_EVENTS.contains(e.getEvent().getEventType())) {
                 initAccessGroupEvent(e);
-            } else if (ObjectEventQueue.isVersionLevelEvent(e)) {
-                initVersionEvent(objectVersionReady, objectVersionProcessing, e);
             } else {
                 initObjectEvent(objects, e);
             }
@@ -97,25 +93,9 @@ public class AccessGroupEventQueue {
             throw new IllegalArgumentException("If an access group level event is in the " +
                     "ready or processing state, no other events may be submitted");
         }
-        final Set<String> allObjIDs = new HashSet<>();
-        allObjIDs.addAll(objects.keySet());
-        allObjIDs.addAll(objectVersionReady.keySet());
-        allObjIDs.addAll(objectVersionProcessing.keySet());
         
-        for (final String objID: allObjIDs) {
-            if ((objectVersionReady.containsKey(objID) ||
-                    objectVersionProcessing.containsKey(objID)) &&
-                    objects.containsKey(objID)) {
-                throw new IllegalArgumentException("Cannot submit both object and " +
-                        "version level events for object ID " + objID);
-            }
-            if (objects.containsKey(objID)) {
-                objectQueues.put(objID, new ObjectEventQueue(objects.get(objID)));
-            } else {
-                objectQueues.put(objID, new ObjectEventQueue(
-                        objectVersionReady.getOrDefault(objID, Collections.emptyList()),
-                        objectVersionProcessing.getOrDefault(objID, Collections.emptyList())));
-            }
+        for (final String objID: objects.keySet()) {
+            objectQueues.put(objID, new ObjectEventQueue(objects.get(objID)));
         }
         this.size = initialLoad.size();
     }
@@ -129,28 +109,6 @@ public class AccessGroupEventQueue {
                     "Already contains an event for object ID " + objID);
         }
         objectMap.put(objID, e);
-    }
-
-    private void initVersionEvent(
-            final Map<String, List<StoredStatusEvent>> objectVersionReady,
-            final Map<String, List<StoredStatusEvent>> objectVersionProcessing,
-            final StoredStatusEvent e) {
-        final String objID = e.getEvent().getAccessGroupObjectId().get();
-        if (e.getState().equals(StatusEventProcessingState.READY)) {
-            addEvent(objectVersionReady, objID, e);
-        } else {
-            addEvent(objectVersionProcessing, objID, e);
-        }
-    }
-    
-    private void addEvent(
-            final Map<String, List<StoredStatusEvent>> objectVersionProcessing,
-            final String objID,
-            final StoredStatusEvent e) {
-        if (!objectVersionProcessing.containsKey(objID)) {
-            objectVersionProcessing.put(objID, new LinkedList<>());
-        }
-        objectVersionProcessing.get(objID).add(e);
     }
 
     private void initAccessGroupEvent(final StoredStatusEvent e) {
@@ -208,7 +166,7 @@ public class AccessGroupEventQueue {
             if (drainTime != null) {
                 oq.drainAndBlockAt(drainTime);
             }
-            ret.addAll(oq.moveToReady());
+            addMoveToReady(oq, ret);
             drained = drained && !oq.isProcessingOrReady();
         }
         if (drained && drain != null) {
@@ -219,6 +177,32 @@ public class AccessGroupEventQueue {
         return Collections.unmodifiableSet(ret);
     }
     
+    private void addMoveToReady(final ObjectEventQueue oq, final Set<StoredStatusEvent> ret) {
+        add(q -> q.moveToReady(), oq, ret);
+    }
+    
+    private void addGetReady(final ObjectEventQueue oq, final Set<StoredStatusEvent> ret) {
+        add(q -> q.getReadyForProcessing(), oq, ret);
+    }
+    
+    private void addMoveToProcessing(final ObjectEventQueue oq, final Set<StoredStatusEvent> ret) {
+        add(q -> q.moveReadyToProcessing(), oq, ret);
+    }
+    
+    private void addGetProcessing(final ObjectEventQueue oq, final Set<StoredStatusEvent> ret) {
+        add(q -> q.getProcessing(), oq, ret);
+    }
+
+    private void add(
+            final Function<ObjectEventQueue, Optional<StoredStatusEvent>> func,
+            final ObjectEventQueue oq,
+            final Set<StoredStatusEvent> ret) {
+        final Optional<StoredStatusEvent> e = func.apply(oq);
+        if (e.isPresent()) {
+            ret.add(e.get());
+        }
+    }
+
     /** Move any events in the ready state to the processing state and return the modified
      * events.
      * @return the events that were moved to the processing state.
@@ -228,7 +212,7 @@ public class AccessGroupEventQueue {
         if (ready == null) {
             if (processing == null) {
                 for (final ObjectEventQueue oq: objectQueues.values()) {
-                    ret.addAll(oq.moveReadyToProcessing());
+                    addMoveToProcessing(oq, ret);
                 }
             }
             // if processing != null do nothing
@@ -296,7 +280,7 @@ public class AccessGroupEventQueue {
         if (ready != null) {
             ret.add(ready);
         } else if (processing == null) {
-            objectQueues.values().stream().forEach(q -> ret.addAll(q.getReadyForProcessing()));
+            objectQueues.values().stream().forEach(q -> addGetReady(q, ret));
         }
         return Collections.unmodifiableSet(ret);
     }
@@ -309,7 +293,7 @@ public class AccessGroupEventQueue {
         if (processing != null) {
             ret.add(processing);
         } else if (ready == null) {
-            objectQueues.values().stream().forEach(q -> ret.addAll(q.getProcessing()));
+            objectQueues.values().stream().forEach(q -> addGetProcessing(q, ret));
         }
         return Collections.unmodifiableSet(ret);
     }

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -2,12 +2,8 @@ package kbasesearchengine.events;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 
@@ -16,9 +12,7 @@ import com.google.common.base.Optional;
 import kbasesearchengine.events.exceptions.NoSuchEventException;
 import kbasesearchengine.tools.Utils;
 
-/** An event queue on the level of an object. Object level events block the queue entirely,
- * while in contrast multiple version level events (e.g. {@link StatusEventType#NEW_VERSION})
- * can run at the same time.
+/** An event queue on the level of an object.
  * 
  * The queue never changes the state of the {@link StoredStatusEvent}s submitted to it.
  * 
@@ -32,19 +26,6 @@ import kbasesearchengine.tools.Utils;
  */
 public class ObjectEventQueue {
     
-    /* Implementation notes:
-     * the queue can have an unlimited number of NEW_VERSION events ready for processing or
-     * processing at once, but only if no other type of event is ready for processing or
-     * processing.
-     * 
-     * In other words, if the ready variable is not null, processing must be null and 
-     * versionReady and versionProcessing must be empty. Same for processing except ready must
-     * be null.
-     * If versionReady or versionProcessing are not empty, both ready and processing must be null.
-     * 
-     * The intent is to ensure that no record in the search index is modified concurrently.
-     */
-    
     /* may want to initialize with an access group & object ID and ensure that all incoming
      * events match
      */
@@ -52,13 +33,8 @@ public class ObjectEventQueue {
     private static final Set<StatusEventType> OBJ_LVL_EVENTS = new HashSet<>(Arrays.asList(
             StatusEventType.DELETE_ALL_VERSIONS, StatusEventType.NEW_ALL_VERSIONS,
             StatusEventType.PUBLISH_ALL_VERSIONS, StatusEventType.RENAME_ALL_VERSIONS,
-            StatusEventType.UNDELETE_ALL_VERSIONS, StatusEventType.UNPUBLISH_ALL_VERSIONS));
-    
-    private static final Set<StatusEventType> OBJ_AND_VER_LVL_EVENTS = new HashSet<>(Arrays.asList(
+            StatusEventType.UNDELETE_ALL_VERSIONS, StatusEventType.UNPUBLISH_ALL_VERSIONS,
             StatusEventType.NEW_VERSION));
-    static {
-        OBJ_AND_VER_LVL_EVENTS.addAll(OBJ_LVL_EVENTS);
-    }
     
     private final PriorityQueue<StoredStatusEvent> queue = new PriorityQueue<StoredStatusEvent>(
             new Comparator<StoredStatusEvent>() {
@@ -70,10 +46,7 @@ public class ObjectEventQueue {
             });
     
     private StoredStatusEvent ready = null;
-    private final Set<StoredStatusEvent> versionReady = new HashSet<>();
     private StoredStatusEvent processing = null;
-    // maps id to event
-    private final Map<StatusEventID, StoredStatusEvent> versionProcessing = new HashMap<>();
     private Instant blockTime = null;
     
     // could require an access group id and object id and reject any events that don't match
@@ -81,40 +54,7 @@ public class ObjectEventQueue {
     /** Create a new, empty, queue. */
     public ObjectEventQueue() {}
     
-    /** Create a new queue with an initial state consisting of {@link StatusEventType#NEW_VERSION}
-     * events in the {@link StatusEventProcessingState#READY} and
-     * {@link StatusEventProcessingState#PROC} states.
-     * @param initialReady a list of events that are ready for processing.
-     * @param initialProcessing a list of event that are being processed.
-     */
-    public ObjectEventQueue(
-            final List<StoredStatusEvent> initialReady,
-            final List<StoredStatusEvent> initialProcessing) {
-        Utils.nonNull(initialReady, "initialReady");
-        Utils.nonNull(initialProcessing, "initialProcessing");
-        checkState(initialReady, StatusEventProcessingState.READY, StatusEventType.NEW_VERSION);
-        checkState(initialProcessing, StatusEventProcessingState.PROC,
-                StatusEventType.NEW_VERSION);
-        versionReady.addAll(initialReady);
-        initialProcessing.stream().forEach(e -> versionProcessing.put(e.getId(), e));
-    }
-    
-    private void checkState(
-            final List<StoredStatusEvent> events,
-            final StatusEventProcessingState state,
-            final StatusEventType type) {
-        for (final StoredStatusEvent e: events) {
-            if (!e.getState().equals(state)) {
-                throw new IllegalArgumentException("Illegal initial event state: " + e.getState());
-            }
-            if (!e.getEvent().getEventType().equals(type)) {
-                throw new IllegalArgumentException("Illegal initial event type: " +
-                        e.getEvent().getEventType());
-            }
-        }
-    }
-
-    /** Create a new queue with an initial state consisting of an object-level, not version-level,
+    /** Create a new queue with an initial state consisting of an object-level
      * event. The event must be in either the {@link StatusEventProcessingState#READY} or
      * {@link StatusEventProcessingState#PROC} state.
      * @param initialEvent the initial event.
@@ -135,8 +75,8 @@ public class ObjectEventQueue {
         }
     }
     
-    private boolean isObjectLevelEvent(final StoredStatusEvent initialEvent) {
-        return OBJ_LVL_EVENTS.contains(initialEvent.getEvent().getEventType());
+    private boolean isObjectLevelEvent(final StoredStatusEvent event) {
+        return OBJ_LVL_EVENTS.contains(event.getEvent().getEventType());
     }
 
     /** Add a new {@link StatusEventProcessingState#UNPROC} event to the queue.
@@ -150,62 +90,45 @@ public class ObjectEventQueue {
             throw new IllegalArgumentException("Illegal state for loading event: " +
                     event.getState());
         }
-        if (!OBJ_AND_VER_LVL_EVENTS.contains(event.getEvent().getEventType())) {
+        if (!isObjectLevelEvent(event)) {
             throw new IllegalArgumentException("Illegal type for loading event: " +
                     event.getEvent().getEventType());
         }
         queue.add(event);
     }
     
-    /** Get the set of events that the queue has determined are ready for processing.
-     * @return the events ready for processing.
+    /** Get the event that the queue has determined are ready for processing, or absent if
+     * no events are ready.
+     * @return the event ready for processing.
      */
-    public Set<StoredStatusEvent> getReadyForProcessing() {
-        final Set<StoredStatusEvent> ret;
-        if (ready == null) {
-            // if processing != null this'll return an empty list
-            ret = new HashSet<>(versionReady);
-        } else {
-            ret = new HashSet<>(Arrays.asList(ready));
-        }
-        return Collections.unmodifiableSet(ret);
+    public Optional<StoredStatusEvent> getReadyForProcessing() {
+        return Optional.fromNullable(ready);
     }
     
-    /** Get the set of events that the queue has determined are ready for processing, and set
-     * those events as in process in the queue.
-     * @return the events that were ready for processing and are now in the processing state.
+    /** Get the event that the queue has determined is ready for processing, and set
+     * that event as in process in the queue, or absent if no events are ready.
+     * @return the event that was ready for processing and is now in the processing state.
      */
-    public Set<StoredStatusEvent> moveReadyToProcessing() {
-        final Set<StoredStatusEvent> ret;
+    public Optional<StoredStatusEvent> moveReadyToProcessing() {
         if (ready == null) {
-            // if processing != null this'll return an empty list
-            ret = new HashSet<>(versionReady);
-            versionReady.stream().forEach(e -> versionProcessing.put(e.getId(), e));
-            versionReady.clear();
+            return Optional.absent();
         } else {
-            ret = new HashSet<>(Arrays.asList(ready));
             processing = ready;
             ready = null;
+            return Optional.of(processing);
         }
-        return Collections.unmodifiableSet(ret);
     }
     
-    /** Get the set of events in the processing state.
-     * @return the events that are in the processing state.
+    /** Get the event in the processing state, or absent if no events are in the processing
+     * state.
+     * @return the event that is in the processing state.
      */
-    public Set<StoredStatusEvent> getProcessing() {
-        final Set<StoredStatusEvent> ret;
-        if (processing == null) {
-            // will be empty list if ready != null;
-            ret = new HashSet<>(versionProcessing.values());
-        } else {
-            ret = new HashSet<>(Arrays.asList(processing));
-        }
-        return Collections.unmodifiableSet(ret);
+    public Optional<StoredStatusEvent> getProcessing() {
+        return Optional.fromNullable(processing);
     }
     
     /** Remove a processed event from the queue and update the queue state, potentially adding
-     * more events to the ready state.
+     * an event to the ready state.
      * This function implicitly calls {@link #moveToReady()}.
      * @param event the event to remove.
      * @throws NoSuchEventException if there is no event with the given ID in the processing
@@ -213,39 +136,30 @@ public class ObjectEventQueue {
      */
     public void setProcessingComplete(final StoredStatusEvent event) {
         Utils.nonNull(event, "event");
-        if (processing != null) {
-            if (event.getId().equals(processing.getId())) {
-                processing = null;
-                moveToReady();
-            } else {
-                throw new NoSuchEventException(event);
-            }
+        if (processing != null && event.getId().equals(processing.getId())) {
+            processing = null;
+            moveToReady();
         } else {
-            if (versionProcessing.containsKey(event.getId())) {
-                versionProcessing.remove(event.getId());
-                moveToReady();
-            } else {
-                throw new NoSuchEventException(event);
-            }
+            throw new NoSuchEventException(event);
         }
     }
     
-    /** Returns true if at least one event is in the processing state.
-     * @return true if the queue has events in the processing state.
+    /** Returns true if an event is in the processing state.
+     * @return true if the queue has an event in the processing state.
      */
     public boolean isProcessing() {
-        return !versionProcessing.isEmpty() || processing != null;
+        return processing != null;
     }
     
-    /** Returns true if at least one event is in the ready state.
-     * @return true if the queue has events in the ready state.
+    /** Returns true if an event is in the ready state.
+     * @return true if the queue has an event in the ready state.
      */
     public boolean hasReady() {
-        return !versionReady.isEmpty() || ready != null;
+        return ready != null;
     }
     
-    /** Returns true if at least one event is in the ready or processing state.
-     * @return true if the queue has events in the ready or processing state.
+    /** Returns true if an event is in the ready or processing state.
+     * @return true if the queue has an event in the ready or processing state.
      */
     public boolean isProcessingOrReady() {
         return isProcessing() || hasReady();
@@ -255,8 +169,7 @@ public class ObjectEventQueue {
      * @return the queue size.
      */
     public int size() {
-        return queue.size() + versionReady.size() + versionProcessing.size() +
-                (ready == null ? 0 : 1) + (processing == null ? 0 : 1);
+        return queue.size() + (ready == null ? 0 : 1) + (processing == null ? 0 : 1);
     }
     
     /** Check if the queue is empty.
@@ -266,53 +179,22 @@ public class ObjectEventQueue {
         return size() == 0;
     }
     
-    /** Move events into the ready state if possible. Usually called after loading
-     * ({@link #load(StoredStatusEvent)}) one or more events.
-     * @return the events that have been moved into the ready state.
+    /** Move an event into the ready state if possible, or absent if not.
+     * Usually called after loading ({@link #load(StoredStatusEvent)}) one or more events.
+     * @return the event that has been moved into the ready state.
      */
-    public Set<StoredStatusEvent> moveToReady() {
-        final Set<StoredStatusEvent> ret = new HashSet<>();
+    public Optional<StoredStatusEvent> moveToReady() {
         // if a object level event is ready for processing or processing, do nothing.
         // the queue is blocked.
         if (ready != null || processing != null) {
-            return Collections.unmodifiableSet(ret);
+            return Optional.absent();
         }
-        /* Either no events are ready/processing or only version level events are ready/processing.
-         * Pull all the version level events off the front of the queue and put them in
-         * the ready state.
-         */
-        /* should really check we're not running events for the same version at the same time,
-         * but that should never happen since you only create a new version once.
-         * might add admin tools to delete and reindex something but again, that should not
-         * cause multiple events for the same version.
-         */
-        StoredStatusEvent next = queue.peek();
-        while (next != null && isVersionLevelEvent(next) && !isBlockActive(next)) {
-            versionReady.add(next);
-            ret.add(next);
-            queue.remove();
-            next = queue.peek();
-        }
-        // if there's still an event left in the queue and no version level events are ready
-        // for processing or processing, put the object level event in the ready state.
-        // this blocks the queue for all other events.
-        if (next != null && versionProcessing.isEmpty() && versionReady.isEmpty() &&
-                !isBlockActive(next)) {
+        final StoredStatusEvent next = queue.peek();
+        if (next != null && !isBlockActive(next)) {
             ready = next;
-            ret.add(next);
             queue.remove();
         }
-        return Collections.unmodifiableSet(ret);
-    }
-
-    /** Check if an event is a version level, as opposed to an object or access group level,
-     * event.
-     * @param event the event to check.
-     * @return true if the event is a version level event.
-     */
-    public static boolean isVersionLevelEvent(final StoredStatusEvent event) {
-        Utils.nonNull(event, "event");
-        return event.getEvent().getEventType().equals(StatusEventType.NEW_VERSION);
+        return Optional.fromNullable(ready);
     }
 
     private boolean isBlockActive(final StoredStatusEvent next) {

--- a/test/src/kbasesearchengine/test/events/AccessGroupEventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/AccessGroupEventQueueTest.java
@@ -148,13 +148,12 @@ public class AccessGroupEventQueueTest {
     @Test
     public void multipleEventTypes() throws Exception {
         /* tests a queue loaded with a bunch of different events blocking each other. This tests:
-         * * blocking a version level event with an object level event
-         * * blocking both object level and version level events with an access group level event
-         * * blocking an access level event with version level and object level events with an
+         * * blocking object level events with an access group level event
+         * * blocking an access level event with object level events with an
          *   earlier timestamp
          *   
          * These are all the combinations of blocking that are possible other than same level
-         * blocks. Object /version level blocks are tested in ObjectEventQueueTest.
+         * blocks.
          */
         final AccessGroupEventQueue q = new AccessGroupEventQueue();
         
@@ -165,103 +164,85 @@ public class AccessGroupEventQueueTest {
         final StoredStatusEvent e3 = loadUnproc(q, "3", Instant.ofEpochMilli(60000), "24",
                 StatusEventType.DELETE_ALL_VERSIONS);
         final StoredStatusEvent e4 = loadUnprocVer(q, "4", Instant.ofEpochMilli(70000), "24");
-        final StoredStatusEvent e5 = loadUnprocVer(q, "5", Instant.ofEpochMilli(80000), "24");
         final StoredStatusEvent e6 = loadUnproc(q, "6", Instant.ofEpochMilli(110000), "24",
                 StatusEventType.DELETE_ALL_VERSIONS);
         final StoredStatusEvent e7 = loadUnprocVer(q, "7", Instant.ofEpochMilli(200000), "24");
         
         final StoredStatusEvent e8 = loadUnprocVer(q, "8", Instant.ofEpochMilli(50000), "25");
-        final StoredStatusEvent e9 = loadUnprocVer(q, "9", Instant.ofEpochMilli(60000), "25");
         final StoredStatusEvent e10 = loadUnprocVer(q, "10", Instant.ofEpochMilli(105000), "25");
-        final StoredStatusEvent e11 = loadUnprocVer(q, "11", Instant.ofEpochMilli(120000), "25");
         final StoredStatusEvent e12 = loadUnprocVer(q, "12", Instant.ofEpochMilli(170000), "25");
-        final StoredStatusEvent e13 = loadUnprocVer(q, "13", Instant.ofEpochMilli(200000), "25");
         
         final StoredStatusEvent e20 = loadUnproc(
                 q, "20", Instant.ofEpochMilli(150000), null, StatusEventType.PUBLISH_ACCESS_GROUP);
         
-        assertQueueState(q, set(), set(), 14);
-        assertMoveToReadyCorrect(q, set(e2, e8, e9));
-        assertQueueState(q, set(e2, e8, e9), set(), 14);
+        assertQueueState(q, set(), set(), 10);
+        assertMoveToReadyCorrect(q, set(e2, e8));
+        assertQueueState(q, set(e2, e8), set(), 10);
         assertMoveToReadyCorrect(q, set());
-        assertMoveToProcessingCorrect(q, set(e2, e8, e9));
-        assertQueueState(q, set(), set(e2, e8, e9), 14);
+        assertMoveToProcessingCorrect(q, set(e2, e8));
+        assertQueueState(q, set(), set(e2, e8), 10);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e8);
-        assertQueueState(q, set(), set(e2, e9), 13);
+        assertQueueState(q, set(), set(e2), 9);
         
         q.setProcessingComplete(e2);
-        assertQueueState(q, set(e3), set(e9), 12);
+        assertQueueState(q, set(e3), set(), 8);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set(e3));
-        assertQueueState(q, set(), set(e3, e9), 12);
-        assertMoveToReadyCorrect(q, set());
-        assertMoveToProcessingCorrect(q, set());
-        
-        q.setProcessingComplete(e9);
-        assertQueueState(q, set(), set(e3), 11);
+        assertQueueState(q, set(), set(e3), 8);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e3);
-        assertQueueState(q, set(e4, e5), set(), 10);
+        assertQueueState(q, set(e4), set(), 7);
         assertMoveToReadyCorrect(q, set());
-        assertMoveToProcessingCorrect(q, set(e4, e5));
-        assertQueueState(q, set(), set(e4, e5), 10);
+        assertMoveToProcessingCorrect(q, set(e4));
+        assertQueueState(q, set(), set(e4), 7);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e4);
-        assertQueueState(q, set(), set(e5), 9);
-        q.setProcessingComplete(e5);
-        assertQueueState(q, set(e1), set(), 8);
+        assertQueueState(q, set(e1), set(), 6);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set(e1));
-        assertQueueState(q, set(), set(e1), 8);
+        assertQueueState(q, set(), set(e1), 6);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e1);
-        assertQueueState(q, set(e6, e10, e11), set(), 7);
+        assertQueueState(q, set(e6, e10), set(), 5);
         assertMoveToReadyCorrect(q, set());
-        assertMoveToProcessingCorrect(q, set(e6, e10, e11));
-        assertQueueState(q, set(), set(e6, e10, e11), 7);
+        assertMoveToProcessingCorrect(q, set(e6, e10));
+        assertQueueState(q, set(), set(e6, e10), 5);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e10);
-        assertQueueState(q, set(), set(e6, e11), 6);
+        assertQueueState(q, set(), set(e6), 4);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
 
-        q.setProcessingComplete(e11);
-        assertQueueState(q, set(), set(e6), 5);
-        assertMoveToReadyCorrect(q, set());
-        assertMoveToProcessingCorrect(q, set());
-        
         q.setProcessingComplete(e6);
-        assertQueueState(q, set(e20), set(), 4);
+        assertQueueState(q, set(e20), set(), 3);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set(e20));
-        assertQueueState(q, set(), set(e20), 4);
+        assertQueueState(q, set(), set(e20), 3);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e20);
-        assertQueueState(q, set(e7, e12, e13), set(), 3);
+        assertQueueState(q, set(e7, e12), set(), 2);
         assertMoveToReadyCorrect(q, set());
-        assertMoveToProcessingCorrect(q, set(e7, e12, e13));
-        assertQueueState(q, set(), set(e7, e12, e13), 3);
+        assertMoveToProcessingCorrect(q, set(e7, e12));
+        assertQueueState(q, set(), set(e7, e12), 2);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set());
         
         q.setProcessingComplete(e7);
-        assertQueueState(q, set(), set(e12, e13), 2);
+        assertQueueState(q, set(), set(e12), 1);
         q.setProcessingComplete(e12);
-        assertQueueState(q, set(), set(e13), 1);
-        q.setProcessingComplete(e13);
         
         assertEmpty(q);
     }
@@ -563,7 +544,7 @@ public class AccessGroupEventQueueTest {
         
         
         // with version level event with different event id
-        final AccessGroupEventQueue q4= new AccessGroupEventQueue(Arrays.asList(
+        final AccessGroupEventQueue q4 = new AccessGroupEventQueue(Arrays.asList(
                 StoredStatusEvent.getBuilder(StatusEvent.getBuilder(
                         "bar", Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
                         .withNullableObjectID("id")
@@ -647,12 +628,11 @@ public class AccessGroupEventQueueTest {
         final StoredStatusEvent e3 = proc("3", Instant.ofEpochMilli(20000), "foo3",
                 StatusEventType.DELETE_ALL_VERSIONS);
         final StoredStatusEvent e4 = readyVer("4", Instant.ofEpochMilli(20000), "foo4");
-        final StoredStatusEvent e5 = procVer("5", Instant.ofEpochMilli(20000), "foo4");
         
         final AccessGroupEventQueue q = new AccessGroupEventQueue(
-                Arrays.asList(e1, e2, e3, e4, e5));
+                Arrays.asList(e1, e2, e3, e4));
         
-        assertQueueState(q, set(e1, e2, e4), set(e3, e5), 5);
+        assertQueueState(q, set(e1, e2, e4), set(e3), 4);
         
         // add access group, object and version events to make sure they're blocked
         final StoredStatusEvent e6 = unproc(
@@ -665,13 +645,11 @@ public class AccessGroupEventQueueTest {
         q.load(e8);
         assertMoveToReadyCorrect(q, set());
         assertMoveToProcessingCorrect(q, set(e1, e2, e4));
-        assertQueueState(q, set(), set(e1, e2, e3, e4, e5), 8);
+        assertQueueState(q, set(), set(e1, e2, e3, e4), 7);
         
         q.setProcessingComplete(e1);
-        assertQueueState(q, set(e8), set(e2, e3, e4, e5), 7);
+        assertQueueState(q, set(e8), set(e2, e3, e4), 6);
         q.setProcessingComplete(e4);
-        assertQueueState(q, set(e8), set(e2, e3, e5), 6);
-        q.setProcessingComplete(e5);
         assertQueueState(q, set(e8, e7), set(e2, e3), 5);
         
         assertMoveToProcessingCorrect(q, set(e8, e7));
@@ -689,14 +667,14 @@ public class AccessGroupEventQueueTest {
         // tests adding more than one version of the same type to an object queue,
         // but not adding the other type to ensure that null pointers don't occur for the missing
         // type
+        // note: changed this test to pass when altering the queue so multiple versions of the
+        // same object can't process at once, but I'm not quite sure what the above means
         final StoredStatusEvent e1 = readyVer("1", Instant.ofEpochMilli(20000), "foo1");
-        final StoredStatusEvent e2 = readyVer("2", Instant.ofEpochMilli(20000), "foo1");
         final StoredStatusEvent e3 = procVer("3", Instant.ofEpochMilli(20000), "foo2");
-        final StoredStatusEvent e4 = procVer("4", Instant.ofEpochMilli(20000), "foo2");
         
-        final AccessGroupEventQueue q = new AccessGroupEventQueue(Arrays.asList(e1, e2, e3, e4));
+        final AccessGroupEventQueue q = new AccessGroupEventQueue(Arrays.asList(e1, e3));
         
-        assertQueueState(q, set(e1, e2), set(e3, e4), 4);
+        assertQueueState(q, set(e1), set(e3), 2);
     }
     
     @Test
@@ -718,8 +696,6 @@ public class AccessGroupEventQueueTest {
                 "3", Instant.ofEpochMilli(10000), "foo1", StatusEventType.DELETE_ALL_VERSIONS);
         final StoredStatusEvent objproc1 = ready(
                 "4", Instant.ofEpochMilli(10000), "foo1", StatusEventType.DELETE_ALL_VERSIONS);
-        final StoredStatusEvent verready1 = readyVer("5", Instant.ofEpochMilli(20000), "foo1");
-        final StoredStatusEvent verproc1 = readyVer("6", Instant.ofEpochMilli(20000), "foo1");
         
         final IllegalArgumentException expAccess = new IllegalArgumentException(
                 "More than one access level event is not allowed");
@@ -733,19 +709,8 @@ public class AccessGroupEventQueueTest {
                 "other events may be submitted");
         failConstruct(expAccessPlus, agready, objready1);
         failConstruct(expAccessPlus, agready, objproc1);
-        failConstruct(expAccessPlus, agready, verready1);
-        failConstruct(expAccessPlus, agready, verproc1);
         failConstruct(expAccessPlus, agproc, objready1);
         failConstruct(expAccessPlus, agproc, objproc1);
-        failConstruct(expAccessPlus, agproc, verready1);
-        failConstruct(expAccessPlus, agproc, verproc1);
-        
-        final IllegalArgumentException expObjVer = new IllegalArgumentException(
-                "Cannot submit both object and version level events for object ID foo1");
-        failConstruct(expObjVer, objready1, verready1);
-        failConstruct(expObjVer, objready1, verproc1);
-        failConstruct(expObjVer, objproc1, verready1);
-        failConstruct(expObjVer, objproc1, verproc1);
         
         final IllegalArgumentException expObj2 = new IllegalArgumentException(
                 "Already contains an event for object ID foo1");

--- a/test/src/kbasesearchengine/test/events/EventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/EventQueueTest.java
@@ -108,15 +108,6 @@ public class EventQueueTest {
                 StatusEventProcessingState.READY, objectID);
     }
     
-    private StoredStatusEvent procVer(
-            final int accgrpID,
-            final String eventid,
-            final Instant time,
-            final String objectID) {
-        return createEvent(accgrpID, eventid, time, StatusEventType.NEW_VERSION,
-                StatusEventProcessingState.PROC, objectID);
-    }
-    
     private StoredStatusEvent loadUnproc(
             final EventQueue queue,
             final int accgrpID,
@@ -264,18 +255,15 @@ public class EventQueueTest {
                 1, "1", Instant.ofEpochMilli(10000), "1", StatusEventType.DELETE_ALL_VERSIONS);
         final StoredStatusEvent e2 = readyVer(
                 1, "2", Instant.ofEpochMilli(10000), "3");
-        final StoredStatusEvent e3 = procVer(
-                1, "3", Instant.ofEpochMilli(15000), "3");
         final StoredStatusEvent e4 = ready(
                 2, "4", Instant.ofEpochMilli(15000), "1", StatusEventType.COPY_ACCESS_GROUP);
 
-        final EventQueue q = new EventQueue(Arrays.asList(e1, e2, e3, e4));
+        final EventQueue q = new EventQueue(Arrays.asList(e1, e2, e4));
         
-        assertQueueState(q, set(e2, e4), set(e1, e3), 4);
+        assertQueueState(q, set(e2, e4), set(e1), 3);
         
         assertMoveToReadyCorrect(q, set());
         
-        q.setProcessingComplete(e3);
         assertQueueState(q, set(e2, e4), set(e1), 3);
         assertMoveToReadyCorrect(q, set());
         


### PR DESCRIPTION
Currently version level events don't block each other in the queue, and
unlimited version level events can run at the same time per object. It
turns out that the ElasticIndexingStorage class runs a script that
touches all versions of an object when a NEW_VERSION event is processed,
and this is causing 409 conflict errors when processing two versions of
the same object at the same time.

Alter the queue so that only one NEW_VERSION event can run per object at
once.