### PR TITLE
[SCT-593] NullPointerException running search_objects query

### DIFF
--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1163,9 +1163,15 @@ public class ElasticIndexingStorage implements IndexingStorage {
 
     private ObjectData buildObjectData(
             final Map<String, Object> obj,
-            final Map<String, List<String>> highlight,
+            Map<String, List<String>> highlight,
             final PostProcessing pp) {
         // TODO: support sub-data selection based on objectDataIncludes (acts on parent json or sub object json)
+
+        //because elastic sometimes returns highlight as null instead of empty.
+        if(highlight == null){
+            highlight = Collections.EMPTY_MAP;
+        }
+
         GUID guid = new GUID((String) obj.get("guid"));
         final ObjectData.Builder b = ObjectData.getBuilder(guid);
         if (pp.objectInfo) {
@@ -1222,7 +1228,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         if (pp.objectHighlight) {
             for(final String key : highlight.keySet()) {
                 b.withHighlight(getReadableKeyNames(key, guid), highlight.get(key));
-            }
+            }    
         }
 
         return b.build();

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1163,14 +1163,9 @@ public class ElasticIndexingStorage implements IndexingStorage {
 
     private ObjectData buildObjectData(
             final Map<String, Object> obj,
-            Map<String, List<String>> highlight,
+            final Map<String, List<String>> highlight,
             final PostProcessing pp) {
         // TODO: support sub-data selection based on objectDataIncludes (acts on parent json or sub object json)
-
-        //because elastic sometimes returns highlight as null instead of empty.
-        if(highlight == null){
-            highlight = Collections.EMPTY_MAP;
-        }
 
         GUID guid = new GUID((String) obj.get("guid"));
         final ObjectData.Builder b = ObjectData.getBuilder(guid);
@@ -1225,7 +1220,9 @@ public class ElasticIndexingStorage implements IndexingStorage {
                 }
             }
         }
-        if (pp.objectHighlight) {
+
+        //because elastic sometimes returns highlight as null instead of empty map.
+        if (pp.objectHighlight && highlight != null) {
             for(final String key : highlight.keySet()) {
                 b.withHighlight(getReadableKeyNames(key, guid), highlight.get(key));
             }    

--- a/test/src/kbasesearchengine/test/integration/SearchAPIIntegrationTest.java
+++ b/test/src/kbasesearchengine/test/integration/SearchAPIIntegrationTest.java
@@ -446,6 +446,20 @@ public class SearchAPIIntegrationTest {
         //highlight in objects
         assertThat("incorrect highlight", actual.getHighlight(), is(expected.getHighlight()));
 
+        //test b/c highlight is unable to find number/dates and may return null
+        final MatchFilter filter2 = new MatchFilter().withFullTextInAll("WS:1/1/1");
+        SearchObjectsInput params2 = new SearchObjectsInput()
+                .withPostProcessing(pp)
+                .withAccessFilter(new AccessFilter())
+                .withMatchFilter(filter2);
+
+        SearchObjectsOutput res2 = searchCli.searchObjects(params2);
+
+        final ObjectData actual2 = res2.getObjects().get(0);
+        compare(actual2, expected);
+        assertThat("highlight should return empty map", actual2.getHighlight(), is(Collections.emptyMap()));
+
+
     }
     private SearchObjectsOutput searchObjects(final MatchFilter mf) throws Exception {
         try {


### PR DESCRIPTION
- account for elasticsearch returning null for highlight instead of empty map
- appears to occur somewhat consistently for GUIDs and sporadically for other search queries. 