### PR TITLE
Change media compound subobject key

### DIFF
--- a/resources/types/MediaCompound.yaml
+++ b/resources/types/MediaCompound.yaml
@@ -5,8 +5,10 @@ storage-object-type: KBaseBiochem.Media
 versions:
 - inner-sub-type: MediaCompound
   path-to-sub-objects: "/mediacompounds/[*]/"
-  primary-key-path: id
+  primary-key-path: compound_ref
   indexing-rules:
+  - path: compound_ref
+    keyword-type: string
   - path: id
     keyword-type: string
     ui-name: ID

--- a/test/src/kbasesearchengine/test/parse/ObjectParserTest.java
+++ b/test/src/kbasesearchengine/test/parse/ObjectParserTest.java
@@ -287,7 +287,9 @@ public class ObjectParserTest {
         final List<String> expectedKeys = Arrays.asList("inchikey", "concentration",
                 "minFlux", "maxFlux", "id", "name", "compound_ref");
         final List<Double> expectedFlux = Arrays.asList( 100.0, 10.0, 50.0);
+        final List<String> names = Arrays.asList( "cpd00027", "cpd00013", "cpd00009");
         final Double expectedConcentration = 0.001;
+        final String inchikey = "WQZGKKKJIJFFOK-VFUOTHLCSA-N";
         int value_index = 0;
         for (String jsonString : guidToJson.values()) {
             @SuppressWarnings("unchecked")
@@ -295,9 +297,13 @@ public class ObjectParserTest {
                     HashMap.class);
             assertThat(result.keySet().size(), is(expectedKeys.size()));
             assertThat(expectedKeys.containsAll(result.keySet()), is(true));
+            assertThat(result.get("compound_ref"), is(expectedIds.get(value_index)));
+            assertThat(result.get("id"), is(names.get(value_index)));
+            assertThat(result.get("name"), is(names.get(value_index)));
             assertThat(result.get("maxFlux"), is(expectedFlux.get(value_index)));
             assertThat(result.get("minFlux"), is(-expectedFlux.get(value_index)));
             assertThat(result.get("concentration"), is(expectedConcentration));
+            assertThat(result.get("inchikey"), is(inchikey));
             value_index++;
         }
     }

--- a/test/src/kbasesearchengine/test/parse/ObjectParserTest.java
+++ b/test/src/kbasesearchengine/test/parse/ObjectParserTest.java
@@ -293,6 +293,7 @@ public class ObjectParserTest {
             @SuppressWarnings("unchecked")
             HashMap<String, Object> result = new ObjectMapper().readValue(jsonString,
                     HashMap.class);
+            assertThat(result.keySet().size(), is(expectedKeys.size()));
             assertThat(expectedKeys.containsAll(result.keySet()), is(true));
             assertThat(result.get("maxFlux"), is(expectedFlux.get(value_index)));
             assertThat(result.get("minFlux"), is(-expectedFlux.get(value_index)));

--- a/test/src/kbasesearchengine/test/parse/ObjectParserTest.java
+++ b/test/src/kbasesearchengine/test/parse/ObjectParserTest.java
@@ -269,8 +269,10 @@ public class ObjectParserTest {
 
         assertThat(guidToJson.size(), is(3));
 
-        final List<String> expectedIds = Arrays.asList("cpd00027", "cpd00013",
-                "cpd00009");
+        final List<String> expectedIds = Arrays.asList(
+                "48/1/1/compounds/id/cpd00027",
+                "48/1/1/compounds/id/cpd00013",
+                "48/1/1/compounds/id/cpd00009");
         int key_index = 0;
         for (GUID guidKey : guidToJson.keySet()) {
             assertThat(guidKey.getSubObjectId(), is(expectedIds.get(key_index)));
@@ -283,7 +285,7 @@ public class ObjectParserTest {
         }
 
         final List<String> expectedKeys = Arrays.asList("inchikey", "concentration",
-                "minFlux", "maxFlux", "id", "name");
+                "minFlux", "maxFlux", "id", "name", "compound_ref");
         final List<Double> expectedFlux = Arrays.asList( 100.0, 10.0, 50.0);
         final Double expectedConcentration = 0.001;
         int value_index = 0;
@@ -292,7 +294,6 @@ public class ObjectParserTest {
             HashMap<String, Object> result = new ObjectMapper().readValue(jsonString,
                     HashMap.class);
             assertThat(expectedKeys.containsAll(result.keySet()), is(true));
-            assertThat(result.get("id"), is(expectedIds.get(value_index)));
             assertThat(result.get("maxFlux"), is(expectedFlux.get(value_index)));
             assertThat(result.get("minFlux"), is(-expectedFlux.get(value_index)));
             assertThat(result.get("concentration"), is(expectedConcentration));

--- a/test/src/kbasesearchengine/test/parse/media01.json.properties
+++ b/test/src/kbasesearchengine/test/parse/media01.json.properties
@@ -19,7 +19,7 @@
       "maxFlux": 10.0,
       "minFlux": -10.0,
       "name": "cpd00013",
-      "inchikey": "JHLHJLKNLDSJKL-VFUOTHLCSA-N"
+      "inchikey": "WQZGKKKJIJFFOK-VFUOTHLCSA-N"
     },
     {
       "compound_ref": "48/1/1/compounds/id/cpd00009",
@@ -28,7 +28,7 @@
       "maxFlux": 50.0,
       "minFlux": -50.0,
       "name": "cpd00009",
-      "inchikey": "WQZGKKKJIJFFOK-JKLMGKOHKJ-N"
+      "inchikey": "WQZGKKKJIJFFOK-VFUOTHLCSA-N"
     }
   ],
   "name": "tsv_media.tsv_media",

--- a/test/src/kbasesearchengine/test/parse/media01.json.properties
+++ b/test/src/kbasesearchengine/test/parse/media01.json.properties
@@ -9,7 +9,8 @@
       "id": "cpd00027",
       "maxFlux": 100.0,
       "minFlux": -100.0,
-      "name": "cpd00027"
+      "name": "cpd00027",
+      "inchikey": "WQZGKKKJIJFFOK-VFUOTHLCSA-N"
     },
     {
       "compound_ref": "48/1/1/compounds/id/cpd00013",
@@ -17,7 +18,8 @@
       "id": "cpd00013",
       "maxFlux": 10.0,
       "minFlux": -10.0,
-      "name": "cpd00013"
+      "name": "cpd00013",
+      "inchikey": "JHLHJLKNLDSJKL-VFUOTHLCSA-N"
     },
     {
       "compound_ref": "48/1/1/compounds/id/cpd00009",
@@ -25,7 +27,8 @@
       "id": "cpd00009",
       "maxFlux": 50.0,
       "minFlux": -50.0,
-      "name": "cpd00009"
+      "name": "cpd00009",
+      "inchikey": "WQZGKKKJIJFFOK-JKLMGKOHKJ-N"
     }
   ],
   "name": "tsv_media.tsv_media",

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -303,6 +303,22 @@ public class ElasticIndexingStorageTest {
         System.out.println("*** end testGenome***");
     }
 
+    @Test
+    public void testMediaCompound() throws Exception {
+        System.out.println("*** start testMediaCompound***");
+        indexObject("MediaCompound", "media01", new GUID("WS:1/1/1"), "Media.1");
+        Set<GUID> guids = indexStorage.searchIds(ImmutableList.of("MediaCompound"),
+                MatchFilter.getBuilder().withLookupInKey("name", "cpd00009").build(),
+                null, AccessFilter.create().withAdmin(true));
+        Assert.assertEquals(1, guids.size());
+        ObjectData index = indexStorage.getObjectsByIds(guids).get(0);
+        System.out.println("Indexed: " + index.getKeyProperties());
+        Assert.assertEquals("-50.0", "" + index.getKeyProperties().get("minFlux"));
+        Assert.assertEquals("50.0", "" + index.getKeyProperties().get("maxFlux"));
+        Assert.assertEquals("0.001", "" + index.getKeyProperties().get("concentration"));
+        System.out.println("*** end testMediaCompound***");
+    }
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -999,7 +1015,7 @@ public class ElasticIndexingStorageTest {
                         "{\"whee\": \"imaprettypony\"}",
                         ImmutableMap.of("whee", Arrays.asList("imaprettypony")))),
                 false);
-        
+
         indexStorage.indexObjects(
                 ObjectTypeParsingRules.getBuilder(
                         new SearchObjectType("Sort", 1),
@@ -1017,7 +1033,7 @@ public class ElasticIndexingStorageTest {
                         "{\"whee\": \"imaprettypony\"}",
                         ImmutableMap.of("whee", Arrays.asList("imaprettypony")))),
                 false);
-        
+
         indexStorage.indexObjects(
                 ObjectTypeParsingRules.getBuilder(
                         new SearchObjectType("Sort", 1),
@@ -1035,7 +1051,7 @@ public class ElasticIndexingStorageTest {
                         "{\"whee\": \"in bruges\"}",
                         ImmutableMap.of("whee", Arrays.asList("in bruges")))),
                 false);
-        
+
 
         indexStorage.indexObjects(
                 ObjectTypeParsingRules.getBuilder(
@@ -1054,10 +1070,10 @@ public class ElasticIndexingStorageTest {
                         "{\"whee\": \"in bruges\"}",
                         ImmutableMap.of("whee", Arrays.asList("in bruges")))),
                 false);
-        
+
         final PostProcessing pp = new PostProcessing();
         pp.objectData = true;
-        
+
         final List<ObjectData> ret = indexStorage.searchObjects(
                 Collections.emptyList(),
                 MatchFilter.getBuilder().build(),
@@ -1067,12 +1083,12 @@ public class ElasticIndexingStorageTest {
                 null,
                 pp)
                 .objects;
-        
+
         final List<GUID> guids = ret.stream().map(od -> od.getGUID()).collect(Collectors.toList());
-        
+
         assertThat("incorrect sort order", guids, is(Arrays.asList(new GUID("WS:1/2/1"),
                 new GUID("WS:1/1/1"), new GUID("WS:1/4/1"), new GUID("WS:1/3/1"))));
-        
+
         final List<ObjectData> ret1 = indexStorage.searchObjects(
                 Collections.emptyList(),
                 MatchFilter.getBuilder().build(),
@@ -1083,14 +1099,14 @@ public class ElasticIndexingStorageTest {
                 null,
                 pp)
                 .objects;
-        
+
         final List<GUID> guids1 = ret1.stream().map(od -> od.getGUID())
                 .collect(Collectors.toList());
-        
+
         assertThat("incorrect sort order", guids1, is(Arrays.asList(new GUID("WS:1/4/1"),
                 new GUID("WS:1/3/1"), new GUID("WS:1/2/1"), new GUID("WS:1/1/1"))));
     }
-    
+
     @Test
     public void sortFail() {
         try {
@@ -1111,7 +1127,7 @@ public class ElasticIndexingStorageTest {
                     "Unknown object property bad key"));
         }
     }
-    
+
     private void prepareTestMultiwordSearch(GUID guid1, GUID guid2, GUID guid3) throws Exception {
         final SearchObjectType objectType = new SearchObjectType("Simple", 1);
         final IndexingRules ir = IndexingRules.fromPath(new ObjectJsonPath("prop1"))


### PR DESCRIPTION
This addresses the log issues like this one:
1518923196918 2018-02-18T03:06:36.918Z Error processing event for event NEW_VERSION with parent ID 5a875ac0e4b00d0e6e4d29d3: kbasesearchengine.events.exceptions.UnprocessableEventIndexingException: Could not find the subobject id for one or more of the subobjects for object WS:28269/16/8 when applying search specification MediaCompound_1