### PR TITLE
Fix coordinator load bug

### DIFF
--- a/lib/src/kbasesearchengine/events/EventQueue.java
+++ b/lib/src/kbasesearchengine/events/EventQueue.java
@@ -83,9 +83,10 @@ public class EventQueue {
         return event.getEvent().getAccessGroupId().get();
     }
     
-    /** Add an new {@link StatusEventProcessingState#UNPROC} event to the queue. Before any
-     * loaded events are added to the ready or processing states, {@link #moveToReady()} must
-     * be called.
+    /** Add a new {@link StatusEventProcessingState#UNPROC} event to the queue.
+     * Events that already exist in the queue as determined by the event id are ignored.
+     * Before any loaded events are added to the ready or processing states,
+     * {@link #moveToReady()} must be called.
      * @param event the event to add.
      */
     public void load(final StoredStatusEvent event) {
@@ -93,8 +94,8 @@ public class EventQueue {
         if (!queues.containsKey(accgrpID)) {
             queues.put(accgrpID, new AccessGroupEventQueue());
         }
-        queues.get(accgrpID).load(event);
-        size++;
+        final boolean loaded = queues.get(accgrpID).load(event);
+        size += loaded ? 1: 0;
     }
     
     /** Remove a processed event from the queue and update the queue state, potentially moving

--- a/lib/src/kbasesearchengine/events/ObjectEventQueue.java
+++ b/lib/src/kbasesearchengine/events/ObjectEventQueue.java
@@ -82,12 +82,14 @@ public class ObjectEventQueue {
     }
 
     /** Add a new {@link StatusEventProcessingState#UNPROC} event to the queue.
-     * Events that already exist in the queue as determined by the event id are silently ignored.
+     * Events that already exist in the queue as determined by the event id are ignored.
      * Before any loaded events are added to the ready or processing states,
      * {@link #moveToReady()} must be called.
      * @param event the event to add.
+     * @return true if the object was added to the queue, false if the event already existed in
+     * the queue
      */
-    public void load(final StoredStatusEvent event) {
+    public boolean load(final StoredStatusEvent event) {
         Utils.nonNull(event, "event");
         if (!event.getState().equals(StatusEventProcessingState.UNPROC)) {
             throw new IllegalArgumentException("Illegal state for loading event: " +
@@ -100,7 +102,9 @@ public class ObjectEventQueue {
         if (!containedEvents.contains(event.getId())) {
             queue.add(event);
             containedEvents.add(event.getId());
+            return true;
         }
+        return false;
     }
     
     /** Get the event that the queue has determined are ready for processing, or absent if

--- a/test/src/kbasesearchengine/test/events/EventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/EventQueueTest.java
@@ -311,4 +311,34 @@ public class EventQueueTest {
             TestCommon.assertExceptionCorrect(got, expected);
         }
     }
+    
+    @Test
+    public void ignoreLoad() {
+        final EventQueue q = new EventQueue();
+        
+        final StoredStatusEvent sse = unproc(
+                1, "foo", Instant.ofEpochMilli(10000), "1", StatusEventType.NEW_VERSION);
+        q.load(sse);
+        
+        assertQueueState(q, set(), set(), 1);
+        
+        final StoredStatusEvent sse2 = unproc(
+                1, "foo", Instant.ofEpochMilli(10000), "1", StatusEventType.DELETE_ALL_VERSIONS);
+        
+        q.load(sse2);
+        assertQueueState(q, set(), set(), 1);
+        
+        q.moveToReady();
+        assertQueueState(q, set(sse), set(), 1);
+        q.moveReadyToProcessing();
+        q.setProcessingComplete(sse);
+        
+        assertEmpty(q);
+        
+        q.load(sse2);
+        assertQueueState(q, set(), set(), 1);
+        
+        q.moveToReady();
+        assertQueueState(q, set(sse2), set(), 1);
+    }
 }

--- a/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
+++ b/test/src/kbasesearchengine/test/events/ObjectEventQueueTest.java
@@ -462,7 +462,8 @@ public class ObjectEventQueueTest {
                 .build(),
                 new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
-        q.load(sse2);
+        final boolean loaded = q.load(sse2);
+        assertThat("incorrect loaded", loaded, is(false));
         
         assertQueueState(q, Optional.of(sse), Optional.absent(), 1);
         
@@ -471,7 +472,8 @@ public class ObjectEventQueueTest {
         
         assertQueueState(q, Optional.absent(), Optional.absent(), 0);
         
-        q.load(sse2);
+        final boolean loaded2 = q.load(sse2);
+        assertThat("incorrect loaded", loaded2, is(true));
         
         assertQueueState(q, Optional.absent(), Optional.absent(), 1);
         q.moveToReady();
@@ -487,7 +489,8 @@ public class ObjectEventQueueTest {
                 .build(),
                 new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
-        q.load(sse);
+        final boolean loaded = q.load(sse);
+        assertThat("incorrect loaded", loaded, is(true));
         
         assertQueueState(q, Optional.absent(), Optional.absent(), 1);
         
@@ -496,7 +499,8 @@ public class ObjectEventQueueTest {
                 .build(),
                 new StatusEventID("foo"), StatusEventProcessingState.UNPROC).build();
         
-        q.load(sse2);
+        final boolean loaded2 = q.load(sse2);
+        assertThat("incorrect loaded", loaded2, is(false));
         
         assertQueueState(q, Optional.absent(), Optional.absent(), 1);
         
@@ -507,7 +511,8 @@ public class ObjectEventQueueTest {
         
         assertQueueState(q, Optional.absent(), Optional.absent(), 0);
         
-        q.load(sse2);
+        final boolean loaded3 = q.load(sse2);
+        assertThat("incorrect loaded", loaded3, is(true));
         
         assertQueueState(q, Optional.absent(), Optional.absent(), 1);
         q.moveToReady();

--- a/test/src/kbasesearchengine/test/main/IndexerCoordinatorTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerCoordinatorTest.java
@@ -331,7 +331,7 @@ public class IndexerCoordinatorTest {
                 "WS", Instant.ofEpochMilli(30000), StatusEventType.PUBLISH_ACCESS_GROUP)
                 .withNullableAccessGroupID(2)
                 .build(),
-                new StatusEventID("foo2"), StatusEventProcessingState.UNPROC).build();
+                new StatusEventID("foo3"), StatusEventProcessingState.UNPROC).build();
         
         final StoredStatusEvent ready1 = to(event1, StatusEventProcessingState.READY);
         


### PR DESCRIPTION
The coordinator currently has no way to know which events in the DB are in memory without passing all the event IDs into the DB query, and so continually loads the same UNPROC events over and over, duplicating queued events and eventually filling the queue. 

This change makes the queue ignore events that already exist in the queue based on the event id. The same UNPROC events will get pulled from the DB over and over, but will not be added to the queue. As before, events that have been set to READY will no longer get pulled.

This does mean that the effective load size will be less than requested, since some of the events will be ignored. Since the oldest events will still get loaded before newer events, things should work ok.

A pathological example might be if 5000 events are in the queue, and therefore the coordinator requests a load of 5000 events. The same 5000 events may be loaded and all ignored if no changes have occurred in the DB (e.g. the creation of events with older timestamps than the 5000). Eventually the coordinator will work through the 5000 events, setting them to READY, and the load will no longer include those events. If a new event is added to the DB with an older time stamp, it will take the place of one of the 5000 events in the next load.

Longer term, and if performance becomes an issue (which seems unlikely), the coordinator could mark events as loaded in the db and not include them in the db query results. Those marks would need to be cleared on coordinator startup.