### PR TITLE
Select last version only when generating events

### DIFF
--- a/lib/src/kbasesearchengine/tools/SearchTools.java
+++ b/lib/src/kbasesearchengine/tools/SearchTools.java
@@ -236,6 +236,7 @@ public class SearchTools {
                 runEventGenerator(
                         out,
                         a.ref,
+                        a.lastVersionOnly,
                         getWsBlackList(a.wsBlacklist, cfg.getWorkspaceBlackList()),
                         getWsTypes(a.wsTypes, cfg.getWorkspaceTypes()),
                         cfg.getWorkerCodes());
@@ -542,6 +543,7 @@ public class SearchTools {
     private void runEventGenerator(
             final PrintStream logtarget,
             final String ref,
+            final boolean lastVersionOnly,
             final List<WorkspaceIdentifier> wsBlackList,
             final List<String> wsTypes,
             final Set<String> workerCodes)
@@ -551,6 +553,7 @@ public class SearchTools {
                 .withNullableRef(ref)
                 .withWorkspaceBlacklist(wsBlackList)
                 .withWorkerCodes(workerCodes)
+                .withLastVersionOnly(lastVersionOnly)
                 .withWorkspaceTypes(wsTypes);
         gen.build().generateEvents();
     }
@@ -672,6 +675,12 @@ public class SearchTools {
                 "The type of the object in a storage system (e.g. 'KBaseGenomes.Genome') with " +
                 "which to initialize a new search transformation spec. See --spec.")
         private String storageObjectType;
+        
+        @Parameter(names = {"--last-version-only"}, description = 
+                "When generating events, only generate events for the last version of each " +
+                "object. This parameter is ignored if a full ref including a version is " +
+                "provided in the ref argument.")
+        private boolean lastVersionOnly;
                         
         @Parameter(names = {"--version"}, description = "Print the software version and exit")
         private boolean version;

--- a/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
+++ b/lib/src/kbasesearchengine/tools/WorkspaceEventGenerator.java
@@ -89,6 +89,7 @@ public class WorkspaceEventGenerator {
     private final Set<WorkspaceIdentifier> wsBlackList;
     private final List<Pattern> wsTypes;
     private final Set<String> workerCodes;
+    private final boolean lastVersionOnly;
     
     private WorkspaceEventGenerator(
             final StatusEventStorage storage,
@@ -99,7 +100,8 @@ public class WorkspaceEventGenerator {
             final PrintStream logtarget,
             final Collection<WorkspaceIdentifier> wsBlackList,
             final Collection<String> wsTypes,
-            final Collection<String> workerCodes)
+            final Collection<String> workerCodes,
+            final boolean lastVersionOnly)
             throws EventGeneratorException {
         this.ws = ws;
         this.obj = obj;
@@ -110,6 +112,7 @@ public class WorkspaceEventGenerator {
         this.wsBlackList = Collections.unmodifiableSet(new HashSet<>(wsBlackList));
         this.wsTypes = processTypes(wsTypes);
         this.workerCodes = Collections.unmodifiableSet(new HashSet<>(workerCodes));
+        this.lastVersionOnly = lastVersionOnly;
         checkWorkspaceSchema();
     }
     
@@ -212,10 +215,10 @@ public class WorkspaceEventGenerator {
                         .append(WS_KEY_OBJ_ID, 1)
                         .append(WS_KEY_VER, -1)).iterator();
 
-        Versions vers = new Versions(vercur, 10000);
+        Versions vers = new Versions(vercur, 10000, null);
         while (!vers.isEmpty()) {
             processVers(wsid, vers, pub, tempNarr);
-            vers = new Versions(vercur, 10000);
+            vers = new Versions(vercur, 10000, vers.lastObjVer);
         }
     }
 
@@ -225,7 +228,8 @@ public class WorkspaceEventGenerator {
             final boolean pub,
             final boolean tempNarr)
             throws EventGeneratorException {
-        final Map<Integer, Document> objects = getObjects(wsid, vers.minObjId, vers.maxObjId);
+        final Map<Integer, Document> objects = getObjects(
+                wsid, vers.minObjId, vers.lastObjVer.objid);
         for (final Document ver: vers.versions) {
             final int objid = Math.toIntExact(ver.getLong(WS_KEY_OBJ_ID));
             final Document obj = objects.get(objid);
@@ -310,33 +314,53 @@ public class WorkspaceEventGenerator {
         return ret;
     }
 
+    private class ObjVer {
+        
+        public final int objid;
+        public final int ver;
+        
+        private ObjVer(final int objid, final int ver) {
+            this.objid = objid;
+            this.ver = ver;
+        }
+    }
+    
     private class Versions {
         
         public final int minObjId;
-        public final int maxObjId;
+        // the last version of the maximum object id
+        public final ObjVer lastObjVer;
         public final List<Document> versions = new LinkedList<>();
         
-        /* It is expected that the cursor is sorted by object id */
-        public Versions(final MongoCursor<Document> vercur, final int count)
+        /* It is expected that the cursor is sorted by object id asc and then by version desc */
+        public Versions(
+                final MongoCursor<Document> vercur,
+                final int count,
+                ObjVer lastObjVer)
                 throws EventGeneratorException {
             int minId = Integer.MAX_VALUE;
-            int maxId = -1;
             try {
                 int i = 0;
                 while (vercur.hasNext() && i < count) {
                     final Document ver = vercur.next();
                     final int id = Math.toIntExact(ver.getLong(WS_KEY_OBJ_ID));
-                    if (id < minId) {
-                        minId = id;
+                    final int version = Math.toIntExact(ver.getInteger(WS_KEY_VER));
+                    if (lastObjVer == null) {
+                        lastObjVer = new ObjVer(id, version);
                     }
-                    if (id > maxId) {
-                        maxId = id;
+                    if (lastObjVer.objid != id) {
+                        lastObjVer = new ObjVer(id, version);
                     }
-                    versions.add(ver);
-                    i++;
+                    if (!lastVersionOnly || version == lastObjVer.ver) {
+                        if (id < minId) {
+                            minId = id;
+                        }
+                        versions.add(ver);
+                        i++;
+                    }
                 }
                 minObjId = minId;
-                maxObjId = maxId;
+                this.lastObjVer = lastObjVer;
             } catch (MongoException e) {
                 throw convert(e, "workspace");
             }
@@ -379,6 +403,7 @@ public class WorkspaceEventGenerator {
         private Collection<WorkspaceIdentifier> wsBlackList = new LinkedList<>();
         private Collection<String> wsTypes = new LinkedList<>();
         private Collection<String> workerCodes = new HashSet<>();
+        private boolean lastVersionOnly = false;
         
         public Builder(
                 final StatusEventStorage storage,
@@ -445,11 +470,16 @@ public class WorkspaceEventGenerator {
             this.workerCodes = workerCodes;
             return this;
         }
+        
+        public Builder withLastVersionOnly(final boolean lastVersionOnly) {
+            this.lastVersionOnly = lastVersionOnly;
+            return this;
+        }
 
         public WorkspaceEventGenerator build() throws EventGeneratorException {
             return new WorkspaceEventGenerator(
                     storage, workspaceDatabase, ws, obj, ver, logtarget, wsBlackList, wsTypes,
-                    workerCodes);
+                    workerCodes, ver > 0 ? false : lastVersionOnly);
         }
 
     }


### PR DESCRIPTION
Adds the ability to select only the last version when generating events.

Tested manually in general.
Specifically tested by manually changing the batch size set in the Versions class to 10, 11, 12, and 13, which overlap an object id change.