### PR TITLE
Throw correct exception when location array is missing information

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -182,6 +182,7 @@ java -cp ${jar.absolute.path}:${lib.classpath} kbasesearchengine.tools.SearchToo
         <test name="kbasesearchengine.test.main.SearchMethodsTest"/>
         <test name="kbasesearchengine.test.main.SignalMonitorTest"/>
         <test name="kbasesearchengine.test.parse.IdMapperTest"/>
+        <test name="kbasesearchengine.test.parse.KeyWordParserTest"/>
         <test name="kbasesearchengine.test.parse.ObjectParserTest"/>
         <test name="kbasesearchengine.test.parse.SubObjectExtractorTest"/>
         <test name="kbasesearchengine.test.search.ElasticIndexingStorageTest"/>

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -614,7 +614,7 @@ public class IndexerWorker implements Stoppable {
             for (final GUID subGuid : guidToJson.keySet()) {
                 final String json = guidToJson.get(subGuid);
                 guidToObj.put(subGuid, KeywordParser.extractKeywords(
-                        rule.getGlobalObjectType(), json, parentJson,
+                        subGuid, rule.getGlobalObjectType(), json, parentJson,
                         rule.getIndexingRules(), indexLookup, newRefPath));
             }
             /* any errors here are due to file IO or parse exceptions.

--- a/test/src/kbasesearchengine/test/parse/KeyWordParserTest.java
+++ b/test/src/kbasesearchengine/test/parse/KeyWordParserTest.java
@@ -1,0 +1,149 @@
+package kbasesearchengine.test.parse;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import kbasesearchengine.common.GUID;
+import kbasesearchengine.common.ObjectJsonPath;
+import kbasesearchengine.events.exceptions.IndexingException;
+import kbasesearchengine.parse.KeywordParser;
+import kbasesearchengine.parse.ObjectParseException;
+import kbasesearchengine.parse.ParsedObject;
+import kbasesearchengine.system.IndexingRules;
+import kbasesearchengine.system.LocationTransformType;
+import kbasesearchengine.system.SearchObjectType;
+import kbasesearchengine.system.Transform;
+import kbasesearchengine.test.common.TestCommon;
+
+public class KeyWordParserTest {
+
+    //TODO TEST add more tests until the KWP is covered.
+    
+    //TODO TEST add tests for locations that go over the origin.
+    
+    @Test
+    public void locationTransformSimpleExtractionPosStrandTest() throws Exception {
+        locationTransformSimpleExtractionPosStrandTest(
+                LocationTransformType.contig_id, "contig_id3");
+        locationTransformSimpleExtractionPosStrandTest(LocationTransformType.length, 941);
+        locationTransformSimpleExtractionPosStrandTest(LocationTransformType.start, 24);
+        locationTransformSimpleExtractionPosStrandTest(LocationTransformType.stop, 964);
+        locationTransformSimpleExtractionPosStrandTest(LocationTransformType.strand, "+");
+    }
+    
+    @Test
+    public void locationTransformSimpleExtractionNegStrandTest() throws Exception {
+        locationTransformSimpleExtractionNegStrandTest(
+                LocationTransformType.contig_id, "contig_id3");
+        locationTransformSimpleExtractionNegStrandTest(LocationTransformType.length, 941);
+        locationTransformSimpleExtractionNegStrandTest(LocationTransformType.start, 24);
+        locationTransformSimpleExtractionNegStrandTest(LocationTransformType.stop, 964);
+        locationTransformSimpleExtractionNegStrandTest(LocationTransformType.strand, "-");
+    }
+
+    private void locationTransformSimpleExtractionPosStrandTest(
+            final LocationTransformType locationType,
+            final Object expectedKey)
+            throws JsonProcessingException, IOException, ObjectParseException,
+            IndexingException, InterruptedException {
+        final GUID parent = new GUID("CODE:1/2/3");
+        final String json = new ObjectMapper().writeValueAsString(ImmutableMap.of(
+                "location", Arrays.asList(Arrays.asList("contig_id3", 24, "+", 941))));
+        
+        final ParsedObject got = KeywordParser.extractKeywords(
+                new GUID(parent, "subtype", "id"),
+                new SearchObjectType("searchType", 1),
+                json,
+                null, // parent json
+                Arrays.asList(IndexingRules.fromPath(new ObjectJsonPath("location"))
+                    .withTransform(Transform.location(locationType))
+                    .withKeyName("newkey")
+                    .build()),
+                null, // look up provider
+                Arrays.asList(parent));
+        
+        final ParsedObject expected = new ParsedObject(json, ImmutableMap.of(
+                "newkey", Arrays.asList(expectedKey)));
+        
+        assertThat("incorrect parsed obj", got, is(expected));
+    }
+    
+    private void locationTransformSimpleExtractionNegStrandTest(
+            final LocationTransformType locationType,
+            final Object expectedKey)
+            throws JsonProcessingException, IOException, ObjectParseException,
+            IndexingException, InterruptedException {
+        final GUID parent = new GUID("CODE:1/2/3");
+        final String json = new ObjectMapper().writeValueAsString(ImmutableMap.of(
+                "location", Arrays.asList(Arrays.asList("contig_id3", 964, "-", 941))));
+        
+        final ParsedObject got = KeywordParser.extractKeywords(
+                new GUID(parent, "subtype", "id"),
+                new SearchObjectType("searchType", 1),
+                json,
+                null, // parent json
+                Arrays.asList(IndexingRules.fromPath(new ObjectJsonPath("location"))
+                    .withTransform(Transform.location(locationType))
+                    .withKeyName("newkey")
+                    .build()),
+                null, // look up provider
+                Arrays.asList(parent));
+        
+        final ParsedObject expected = new ParsedObject(json, ImmutableMap.of(
+                "newkey", Arrays.asList(expectedKey)));
+        
+        assertThat("incorrect parsed obj", got, is(expected));
+    }
+    
+    @Test
+    public void locationTransformFail() throws Exception {
+        // why are there multiple arrays anyway...?
+        failLocationTransform(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+                "location", Collections.emptyList())),
+                new ObjectParseException("Expected location array for location transform for " +
+                            "CODE:1/2/3:subtype/id, got empty array"));
+        
+        failLocationTransform(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+                "location", Arrays.asList(Arrays.asList("cid", 1, "+")))),
+                new ObjectParseException("Expected location array for location transform for " +
+                            "CODE:1/2/3:subtype/id, got [cid, 1, +]"));
+        
+        failLocationTransform(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+                "location", Arrays.asList(ImmutableMap.of("foo", "bar")))),
+                new ObjectParseException("Expected location array for location transform for " +
+                            "CODE:1/2/3:subtype/id, got [{foo=bar}]"));
+    }
+    
+    private void failLocationTransform(final String json, final Exception expected) {
+        
+        try {
+            final GUID parent = new GUID("CODE:1/2/3");
+            
+            KeywordParser.extractKeywords(
+                    new GUID(parent, "subtype", "id"),
+                    new SearchObjectType("searchType", 1),
+                    json,
+                    null, // parent json
+                    Arrays.asList(IndexingRules.fromPath(new ObjectJsonPath("location"))
+                        .withTransform(Transform.location(LocationTransformType.contig_id))
+                        .withKeyName("newkey")
+                        .build()),
+                    null, // look up provider
+                    Arrays.asList(parent));
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+}

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -186,7 +186,7 @@ public class ElasticIndexingStorageTest {
             final String parentJsonValue,
             final boolean isPublic)
             throws IOException, ObjectParseException, IndexingException, InterruptedException {
-        ParsedObject obj = KeywordParser.extractKeywords(rule.getGlobalObjectType(), json,
+        ParsedObject obj = KeywordParser.extractKeywords(id, rule.getGlobalObjectType(), json,
                 parentJsonValue, rule.getIndexingRules(), objLookup, null);
         final SourceData data = SourceData.getBuilder(new UObject(json), objectName, "creator")
                 .build();


### PR DESCRIPTION
Currently throws an IndexOutOfBounds, which is not recognized by the exception handling system.