### PR TITLE
SCT-626 Treat elastic conflict exceptions as non-fatal

### DIFF
--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1700,7 +1700,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         try {
             return makeRequest(reqType, urlPath, doc);
         } catch (IndexingConflictException e) {
-            // this is impossible to test, and so is not tested
+            // this is very difficult to test, and so is not tested
             throw new IOException(
                     "This operation is not expected to result in a conflict, yet it occurred: " +
                     e.getMessage(), e);

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1700,7 +1700,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         try {
             return makeRequest(reqType, urlPath, doc);
         } catch (IndexingConflictException e) {
-            // this is impossible to test, and so is not
+            // this is impossible to test, and so is not tested
             throw new IOException(
                     "This operation is not expected to result in a conflict, yet it occurred: " +
                     e.getMessage(), e);

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1746,7 +1746,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             return getRestClient().performRequest(reqType, urlPath, attributes, body);
         } catch (ResponseException re) {
             if (re.getResponse().getStatusLine().getStatusCode() == 409) {
-                // this is really difficult to test, and so is not
+                // this is really difficult to test, and so is not tested
                 throw new IndexingConflictException(re.getMessage(), re);
             }
             throw new IOException(re.getMessage(), re);

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -1700,7 +1700,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         try {
             return makeRequest(reqType, urlPath, doc);
         } catch (IndexingConflictException e) {
-            // this is really difficult to test, and so is not
+            // this is impossible to test, and so is not
             throw new IOException(
                     "This operation is not expected to result in a conflict, yet it occurred: " +
                     e.getMessage(), e);

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -310,7 +310,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final GUID id,
             final ParsedObject obj,
             final boolean isPublic)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         final GUID parentID = new GUID(id, null, null);
         indexObjects(rule, data, timestamp, parentJsonValue, parentID,
                 ImmutableMap.of(id, obj), isPublic);
@@ -328,7 +328,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final GUID pguid,
             final Map<GUID, ParsedObject> idToObj,
             final boolean isPublic)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         final Map<GUID, ParsedObject> idToObjCopy = new HashMap<>(idToObj);
         String indexName = checkIndex(rule, false);
         for (GUID id : idToObjCopy.keySet()) {
@@ -438,7 +438,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
                                                         .collect(Collectors.toList())))))));
 
         String urlPath = "/" + indexName + "/" + getDataTableName() + "/_search";
-        Response resp = makeRequest("GET", urlPath, doc);
+        Response resp = makeRequestNoConflict("GET", urlPath, doc);
         @SuppressWarnings("unchecked")
         Map<String, Object> data = UObject.getMapper().readValue(
                 resp.getEntity().getContent(), Map.class);
@@ -468,7 +468,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
                         guids.stream().map(u -> u.toString()).collect(Collectors.toList())))))));
 
         String urlPath = "/" + indexName + "/" + getAccessTableName() + "/_search";
-        Response resp = makeRequest("GET", urlPath, doc);
+        Response resp = makeRequestNoConflict("GET", urlPath, doc);
         @SuppressWarnings("unchecked")
         Map<String, Object> data = UObject.getMapper().readValue(
                 resp.getEntity().getContent(), Map.class);
@@ -505,7 +505,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
                                             "_source", Arrays.asList("pguid"));
 
         String urlPath = "/" + indexNamePrefix + "*/" + getAccessTableName() + "/_search";
-        Response resp = makeRequest("GET", urlPath, doc);
+        Response resp = makeRequestNoConflict("GET", urlPath, doc);
         @SuppressWarnings("unchecked")
         Map<String, Object> data = UObject.getMapper().readValue(
                 resp.getEntity().getContent(), Map.class);
@@ -590,7 +590,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
                                                   ImmutableMap.of("prefix", prefix))))));
 
         String urlPath = "/" + reqIndexName + "/" + getAccessTableName() + "/_search";
-        Response resp = makeRequest("GET", urlPath, doc);
+        Response resp = makeRequestNoConflict("GET", urlPath, doc);
         @SuppressWarnings("unchecked")
         Map<String, Object> data = UObject.getMapper().readValue(
                 resp.getEntity().getContent(), Map.class);
@@ -614,7 +614,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
     
     private int updateLastVersionsInData(String indexName, GUID parentGUID,
-            int lastVersion) throws IOException {
+            int lastVersion) throws IOException, IndexingConflictException {
         if (indexName == null) {
             indexName = getAnyIndexPattern();
         }
@@ -650,7 +650,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     private Map<GUID, String> checkParentDoc(String indexName, Set<GUID> parentGUIDs, 
-            boolean isPublic, int lastVersion) throws IOException {
+            boolean isPublic, int lastVersion) throws IOException, IndexingConflictException {
         boolean changed = false;
         Map<GUID, String> ret = new LinkedHashMap<>(lookupParentDocIds(indexName, parentGUIDs));
         for (GUID parentGUID : parentGUIDs) {
@@ -675,7 +675,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             doc.put("lastin", lastinGroupIds);
             doc.put("groups", accessGroupIds);
             doc.put("extpub", new ArrayList<Integer>());
-            Response resp = makeRequest("POST", "/" + indexName + "/" + getAccessTableName() + "/", 
+            Response resp = makeRequest("POST", "/" + indexName + "/" + getAccessTableName() + "/",
                     doc);
             @SuppressWarnings("unchecked")
             Map<String, Object> data = UObject.getMapper().readValue(
@@ -717,7 +717,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final Integer accessGroupId,
             final boolean includePublicAccessID,
             final boolean includeAdminAccessID)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         /* this method will cause at most 6 script compilations, which seems like a lot...
          * Could make the script always the same and put in ifs but this should be ok for now.
          */
@@ -766,7 +766,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     private boolean removeAccessGroupForVersion(String indexName, GUID guid, 
-            int accessGroupId) throws IOException {
+            int accessGroupId) throws IOException, IndexingConflictException {
         if (indexName == null) {
             indexName = getAnyIndexPattern();
         }
@@ -808,7 +808,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     private boolean updateBooleanFieldInData(String indexName, GUID parentGUID,
-            String field, boolean value) throws IOException {
+            String field, boolean value) throws IOException, IndexingConflictException {
         if (indexName == null) {
             indexName = getAnyIndexPattern();
         }
@@ -842,7 +842,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
     public int setNameOnAllObjectVersions(final GUID object, final String newName)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         return setFieldOnObject(object, OBJ_NAME, newName, true);
     }
     
@@ -853,7 +853,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final String field,
             final Object value,
             final boolean allVersions)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         final String index = getAnyIndexPattern();
         final Map<String, Object> query;
         if (allVersions) {
@@ -878,7 +878,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
     public void shareObjects(Set<GUID> guids, int accessGroupId, 
-            boolean isExternalPublicGroup) throws IOException {
+            boolean isExternalPublicGroup) throws IOException, IndexingConflictException {
         Map<String, Set<GUID>> indexToGuids = groupParentIdsByIndex(guids);
         for (String indexName : indexToGuids.keySet()) {
             Set<GUID> toAddExtPub = new LinkedHashSet<GUID>();
@@ -920,7 +920,8 @@ public class ElasticIndexingStorage implements IndexingStorage {
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void unshareObjects(Set<GUID> guids, int accessGroupId) throws IOException {
+    public void unshareObjects(Set<GUID> guids, int accessGroupId)
+            throws IOException, IndexingConflictException {
         Map<String, Set<GUID>> indexToGuids = groupParentIdsByIndex(guids);
         for (String indexName : indexToGuids.keySet()) {
             boolean needRefresh = false;
@@ -943,7 +944,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void deleteAllVersions(final GUID guid) throws IOException {
+    public void deleteAllVersions(final GUID guid) throws IOException, IndexingConflictException {
         // could optimize later by making LLV return the index name
         final Integer ver = loadLastVersion(null, guid, null);
         if (ver == null) {
@@ -965,7 +966,8 @@ public class ElasticIndexingStorage implements IndexingStorage {
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void undeleteAllVersions(final GUID guid) throws IOException {
+    public void undeleteAllVersions(final GUID guid)
+            throws IOException, IndexingConflictException {
         // could optimize later by making LLV return the index name
         final Integer ver = loadLastVersion(null, guid, null);
         if (ver == null) {
@@ -985,30 +987,31 @@ public class ElasticIndexingStorage implements IndexingStorage {
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void publishObjects(Set<GUID> guids) throws IOException {
+    public void publishObjects(Set<GUID> guids) throws IOException, IndexingConflictException {
         shareObjects(guids, PUBLIC_ACCESS_GROUP, false);
     }
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void unpublishObjects(Set<GUID> guids) throws IOException {
+    public void unpublishObjects(Set<GUID> guids) throws IOException, IndexingConflictException {
         unshareObjects(guids, PUBLIC_ACCESS_GROUP);
     }
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void publishAllVersions(final GUID guid) throws IOException {
+    public void publishAllVersions(final GUID guid) throws IOException, IndexingConflictException {
         setFieldOnObject(guid, "public", true, true);
     }
     
     //IO exception thrown for deserialization & elasticsearch contact errors
     @Override
-    public void unpublishAllVersions(final GUID guid) throws IOException {
+    public void unpublishAllVersions(final GUID guid)
+            throws IOException, IndexingConflictException {
         setFieldOnObject(guid, "public", false, true);
     }
 
     private boolean addExtPubForVersion(String indexName, GUID guid, 
-            int accessGroupId) throws IOException {
+            int accessGroupId) throws IOException, IndexingConflictException {
         // Check that we work with other than physical access group this object exists in.
         if (accessGroupId == guid.getAccessGroupId()) {
             throw new IllegalStateException("Access group should be external");
@@ -1043,7 +1046,8 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     @Override
-    public void publishObjectsExternally(Set<GUID> guids, int accessGroupId) throws IOException {
+    public void publishObjectsExternally(Set<GUID> guids, int accessGroupId)
+            throws IOException, IndexingConflictException {
         Map<String, Set<GUID>> indexToGuids = groupParentIdsByIndex(guids);
         for (String indexName : indexToGuids.keySet()) {
             boolean needRefresh = false;
@@ -1059,7 +1063,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     private boolean removeExtPubForVersion(String indexName, GUID guid, 
-            int accessGroupId) throws IOException {
+            int accessGroupId) throws IOException, IndexingConflictException {
         // Check that we work with other than physical access group this object exists in.
         if (accessGroupId == guid.getAccessGroupId()) {
             throw new IllegalStateException("Access group should be external");
@@ -1093,7 +1097,8 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     @Override
-    public void unpublishObjectsExternally(Set<GUID> guids, int accessGroupId) throws IOException {
+    public void unpublishObjectsExternally(Set<GUID> guids, int accessGroupId)
+            throws IOException, IndexingConflictException {
         Map<String, Set<GUID>> indexToGuids = groupParentIdsByIndex(guids);
         for (String indexName : indexToGuids.keySet()) {
             boolean needRefresh = false;
@@ -1140,7 +1145,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         }
 
         final String urlPath = "/" + indexNamePrefix + "*/" + getDataTableName() + "/_search";
-        final Response resp = makeRequest("GET", urlPath, doc);
+        final Response resp = makeRequestNoConflict("GET", urlPath, doc);
         @SuppressWarnings("unchecked")
         final Map<String, Object> data = UObject.getMapper().readValue(
                 resp.getEntity().getContent(), Map.class);
@@ -1310,7 +1315,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         String urlPath = "/" + indexNamePrefix + "*" +
                 (matchFilter.isExcludeSubObjects() ? EXCLUDE_SUB_OJBS_URL_SUFFIX : "") +
                 "/" + getDataTableName() + "/_search";
-        Response resp = makeRequest("GET", urlPath, doc);
+        Response resp = makeRequestNoConflict("GET", urlPath, doc);
         @SuppressWarnings("unchecked")
         Map<String, Object> data = UObject.getMapper().readValue(
                 resp.getEntity().getContent(), Map.class);
@@ -1576,7 +1581,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         }
 
         final String urlPath = "/" + indexName + "/" + getDataTableName() + "/_search";
-        final Response resp = makeRequest("GET", urlPath, ImmutableMap.copyOf(doc));
+        final Response resp = makeRequestNoConflict("GET", urlPath, ImmutableMap.copyOf(doc));
 
         @SuppressWarnings("unchecked")
         final Map<String, Object> data = UObject.getMapper().readValue(
@@ -1634,17 +1639,17 @@ public class ElasticIndexingStorage implements IndexingStorage {
         Set<String> ret = new TreeSet<>();
         @SuppressWarnings("unchecked")
         Map<String, Object> data = UObject.getMapper().readValue(
-                makeRequest("GET", "/_aliases", null).getEntity().getContent(), Map.class);
+                makeRequestNoConflict("GET", "/_aliases", null).getEntity().getContent(), Map.class);
         ret.addAll(data.keySet());
         return ret;
     }
     
     public Response deleteIndex(String indexName) throws IOException {
-        return makeRequest("DELETE", "/" + indexName, null);
+        return makeRequestNoConflict("DELETE", "/" + indexName, null);
     }
     
     public Response refreshIndex(String indexName) throws IOException {
-        return makeRequest("POST", "/" + indexName + "/_refresh", null);
+        return makeRequestNoConflict("POST", "/" + indexName + "/_refresh", null);
     }
     
     /** Refresh the elasticsearch index, where the index prefix is set by
@@ -1687,11 +1692,26 @@ public class ElasticIndexingStorage implements IndexingStorage {
         return restClient;
     }
 
-    public Response makeRequest(
+    public Response makeRequestNoConflict(
             final String reqType,
             final String urlPath,
             final Map<String, ?> doc) 
             throws IOException {
+        try {
+            return makeRequest(reqType, urlPath, doc);
+        } catch (IndexingConflictException e) {
+            // this is really difficult to test, and so is not
+            throw new IOException(
+                    "This operation is not expected to result in a conflict, yet it occurred: " +
+                    e.getMessage(), e);
+        }
+    }
+    
+    public Response makeRequest(
+            final String reqType,
+            final String urlPath,
+            final Map<String, ?> doc) 
+            throws IOException, IndexingConflictException {
         return makeRequest(reqType, urlPath, doc, Collections.emptyMap());
     }
     
@@ -1699,7 +1719,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final String reqType,
             final String indexName,
             final File jsonData) 
-            throws IOException {
+            throws IOException, IndexingConflictException {
         try (InputStream is = new FileInputStream(jsonData)) {
             return makeRequest(reqType, "/" + indexName + "/_bulk", Collections.emptyMap(),
                     new InputStreamEntity(is));
@@ -1711,7 +1731,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final String urlPath,
             final Map<String, ?> doc, 
             final Map<String, String> attributes)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         return makeRequest(reqType, urlPath, attributes, doc == null ? null : stringEntity(
                 UObject.transformObjectToString(doc)));
     }
@@ -1721,11 +1741,15 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final String urlPath,
             final Map<String, String> attributes,
             final HttpEntity body)
-            throws IOException {
+            throws IOException, IndexingConflictException {
         try {
             return getRestClient().performRequest(reqType, urlPath, attributes, body);
-        } catch (ResponseException ex) {
-            throw new IOException(ex.getMessage(), ex);
+        } catch (ResponseException re) {
+            if (re.getResponse().getStatusLine().getStatusCode() == 409) {
+                // this is really difficult to test, and so is not
+                throw new IndexingConflictException(re.getMessage(), re);
+            }
+            throw new IOException(re.getMessage(), re);
         }
     }
     
@@ -1880,7 +1904,7 @@ public class ElasticIndexingStorage implements IndexingStorage {
         Map<String, Object> doc = new LinkedHashMap<>();
         doc.put("mappings", mappings);
 
-        makeRequest("PUT", "/" + indexName, doc);
+        makeRequestNoConflict("PUT", "/" + indexName, doc);
     }
     
     public void close() throws IOException {

--- a/lib/src/kbasesearchengine/search/IndexingConflictException.java
+++ b/lib/src/kbasesearchengine/search/IndexingConflictException.java
@@ -1,0 +1,15 @@
+package kbasesearchengine.search;
+
+/** Thrown when an attempt to index and object in an indexing storage system results in a
+ * conflict error. Storage systems that implement optimistic concurrency may throw these types
+ * of errors.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class IndexingConflictException extends Exception {
+    
+    public IndexingConflictException(final String message, final Throwable exception) {
+        super(message, exception);
+    }
+}

--- a/lib/src/kbasesearchengine/search/IndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/IndexingStorage.java
@@ -20,11 +20,14 @@ public interface IndexingStorage {
     
     /**
      * Adds object to searchable indexing storage.
-     * @param id  global object ID including: storage type, parent object reference, inner sub-type and inner sub-object unique key (last two are optional)
+     * @param id  global object ID including: storage type, parent object reference,
+     * inner sub-type and inner sub-object unique key (last two are optional)
      * @param objectType  global type of object
-     * @param jsonValue  object value (consisting of maps, lists and primitive types like number, string, boolean or null)
+     * @param jsonValue  object value (consisting of maps, lists and primitive types like
+     * number, string, boolean or null)
      * @param indexingRules  indexing rules
      * @throws IOException
+     * @throws IndexingConflictException if a conflict occurs while modifying the index. 
      */
     public void indexObject(
             ObjectTypeParsingRules rule,
@@ -34,7 +37,7 @@ public interface IndexingStorage {
             GUID guid,
             ParsedObject obj,
             boolean isPublic)
-            throws IOException;
+            throws IOException, IndexingConflictException;
 
     public void indexObjects(
             ObjectTypeParsingRules rule,
@@ -44,7 +47,7 @@ public interface IndexingStorage {
             GUID pguid,
             Map<GUID, ParsedObject> idToObj,
             boolean isPublic) 
-            throws IOException;
+            throws IOException, IndexingConflictException;
     
     /** Check that the parent objects (e.g. the access information) exists for a set of GUIDS.
      * Equivalent to {@link #checkParentGuidsExist(String, Set)} with a null String.
@@ -57,17 +60,21 @@ public interface IndexingStorage {
 
     public void flushIndexing(ObjectTypeParsingRules objectType) throws IOException;
     
-    public void shareObjects(Set<GUID> guids, int accessGroupId, boolean isPublicGroup) throws IOException;
+    public void shareObjects(Set<GUID> guids, int accessGroupId, boolean isPublicGroup)
+            throws IOException, IndexingConflictException;
 
-    public void unshareObjects(Set<GUID> guids, int accessGroupId) throws IOException;
+    public void unshareObjects(Set<GUID> guids, int accessGroupId)
+            throws IOException, IndexingConflictException;
 
-    public void publishObjects(Set<GUID> guids) throws IOException;
+    public void publishObjects(Set<GUID> guids) throws IOException, IndexingConflictException;
 
-    public void unpublishObjects(Set<GUID> guids) throws IOException;
+    public void unpublishObjects(Set<GUID> guids) throws IOException, IndexingConflictException;
 
-    public void publishObjectsExternally(Set<GUID> guids, int accessGroupId) throws IOException;
+    public void publishObjectsExternally(Set<GUID> guids, int accessGroupId)
+            throws IOException, IndexingConflictException;
 
-    public void unpublishObjectsExternally(Set<GUID> guids, int accessGroupId) throws IOException;
+    public void unpublishObjectsExternally(Set<GUID> guids, int accessGroupId)
+            throws IOException, IndexingConflictException;
 
     public List<ObjectData> getObjectsByIds(Set<GUID> guids) throws IOException;
     
@@ -122,31 +129,37 @@ public interface IndexingStorage {
      * @param newName the new name of the object.
      * @return the number of documents modified, including sub objects.
      * @throws IOException if an IO error occurs when contacting the indexing storage.
+     * @throws IndexingConflictException if a conflict occurs while modifying the index. 
      */
-    int setNameOnAllObjectVersions(GUID object, String newName) throws IOException;
+    int setNameOnAllObjectVersions(GUID object, String newName)
+            throws IOException, IndexingConflictException;
 
     /** Delete all versions of an object from its access group. The object may still be
      * accessible via other access groups.
      * @param guid the object to delete.
      * @throws IOException if an IO error occurs when contacting the indexing storage.
+     * @throws IndexingConflictException if a conflict occurs while modifying the index.
      */
-    void deleteAllVersions(GUID guid) throws IOException;
+    void deleteAllVersions(GUID guid) throws IOException, IndexingConflictException;
 
     /** Delete all versions of an object from its access group.
      * @param guid the object to delete.
      * @throws IOException if an IO error occurs when contacting the indexing storage.
+     * @throws IndexingConflictException if a conflict occurs while modifying the index. 
      */
-    void undeleteAllVersions(GUID guid) throws IOException;
+    void undeleteAllVersions(GUID guid) throws IOException, IndexingConflictException;
 
     /** Set all versions of an object to public.
      * @param guid the object to publish.
      * @throws IOException if an IO error occurs when contacting the indexing storage.
+     * @throws IndexingConflictException if a conflict occurs while modifying the index. 
      */
-    void publishAllVersions(GUID guid) throws IOException;
+    void publishAllVersions(GUID guid) throws IOException, IndexingConflictException;
 
     /** Make all versions of an object private.
      * @param guid the object to make private.
      * @throws IOException if an IO error occurs when contacting the indexing storage.
+     * @throws IndexingConflictException if a conflict occurs while modifying the index. 
      */
-    void unpublishAllVersions(GUID guid) throws IOException;
+    void unpublishAllVersions(GUID guid) throws IOException, IndexingConflictException;
 }

--- a/test/src/kbasesearchengine/test/ElasticPayloadAnanlyzerTester.java
+++ b/test/src/kbasesearchengine/test/ElasticPayloadAnanlyzerTester.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import kbasesearchengine.search.ElasticIndexingStorage;
+import kbasesearchengine.search.IndexingConflictException;
 import us.kbase.common.service.UObject;
 
 public class ElasticPayloadAnanlyzerTester {
@@ -41,7 +42,8 @@ public class ElasticPayloadAnanlyzerTester {
     }
     
     @SuppressWarnings("serial")
-    private static void createTables(String indexName) throws IOException {
+    private static void createTables(String indexName)
+            throws IOException, IndexingConflictException {
         // Index settings
         Map<String, Object> payloadAnalyzer = new LinkedHashMap<String, Object>() {{
             put("type", "custom");

--- a/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +34,8 @@ import kbasesearchengine.common.GUID;
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.exceptions.RetriableIndexingException;
+import kbasesearchengine.events.exceptions.RetriesExceededIndexingException;
 import kbasesearchengine.events.exceptions.UnprocessableEventIndexingException;
 import kbasesearchengine.events.handler.EventHandler;
 import kbasesearchengine.events.handler.SourceData;
@@ -39,6 +43,7 @@ import kbasesearchengine.events.storage.StatusEventStorage;
 import kbasesearchengine.main.IndexerWorker;
 import kbasesearchengine.main.LineLogger;
 import kbasesearchengine.parse.ParsedObject;
+import kbasesearchengine.search.IndexingConflictException;
 import kbasesearchengine.search.IndexingStorage;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
@@ -556,6 +561,155 @@ public class IndexerWorkerTest {
                     .sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
                     .forEach(File::delete);
+        }
+    }
+    
+    @Test
+    public void conflictOnIndex() throws Exception {
+        /* tests the handling of conflict errors when indexing an object. */
+        
+        //TODO TEST allow configuring the retry time to speed this test up
+        
+        final Map<String, Object> data = ImmutableMap.of(
+                "thingy", 1,
+                "thingy2", "foo",
+                "subobjs", Arrays.asList(
+                        ImmutableMap.of("id", "an id", "somedata", "data"),
+                        ImmutableMap.of("id", "an id2", "somedata", "data2")
+                        )
+                );
+        
+        final EventHandler ws = mock(EventHandler.class);
+        final StatusEventStorage storage = mock(StatusEventStorage.class);
+        final IndexingStorage idxStore = mock(IndexingStorage.class);
+        final TypeStorage typeStore = mock(TypeStorage.class);
+        final LineLogger logger = mock(LineLogger.class);
+        
+        final Path tempDir = Paths.get(TestCommon.getTempDir()).toAbsolutePath()
+                .resolve("IndexerWorkerTest");
+        deleteRecursively(tempDir);
+        
+        when(ws.getStorageCode()).thenReturn("code");
+        
+        final IndexerWorker worker = new IndexerWorker(
+                "myid", Arrays.asList(ws), storage, idxStore, typeStore, tempDir.toFile(), logger,
+                null, 1000);
+        
+        final GUID guid = new GUID("code:1/2/3");
+        when(idxStore.checkParentGuidsExist(set(guid))).thenReturn(ImmutableMap.of(guid, false));
+        
+        when(ws.load(eq(Arrays.asList(guid)), any(Path.class)))
+                .thenAnswer(new Answer<SourceData>() {
+
+                        @Override
+                        public SourceData answer(final InvocationOnMock inv) throws Throwable {
+                            final Path path = inv.getArgument(1);
+                            new ObjectMapper().writeValue(path.toFile(), data);
+                            return SourceData.getBuilder(
+                                    new UObject(path.toFile()), "myobj", "somedude")
+                                    .withNullableMD5("md5")
+                                    .build();
+                        }
+        });
+
+        final StorageObjectType storageObjectType = StorageObjectType
+                .fromNullableVersion("code", "sometype", 3);
+        
+        final ObjectTypeParsingRules rule = ObjectTypeParsingRules.getBuilder(
+                new SearchObjectType("foo", 1), storageObjectType)
+                .toSubObjectRule("subfoo", new ObjectJsonPath("/subobjs/[*]/"),
+                        new ObjectJsonPath("id"))
+                .withIndexingRule(IndexingRules.fromPath(
+                        new ObjectJsonPath("somedata"))
+                        .build())
+                .withIndexingRule(IndexingRules.fromPath(new ObjectJsonPath("id"))
+                        .build())
+                .build();
+        when(typeStore.listObjectTypeParsingRules(storageObjectType)).thenReturn(set(rule));
+        
+        final ParsedObject po1 = new ParsedObject(
+                new ObjectMapper().writeValueAsString(
+                        ImmutableMap.of( "id", "an id", "somedata", "data")),
+                ImmutableMap.of("somedata", Arrays.asList("data"),
+                        "id", Arrays.asList("an id")));
+        final ParsedObject po2 = new ParsedObject(
+                new ObjectMapper().writeValueAsString(
+                        ImmutableMap.of("id", "an id2", "somedata", "data2")),
+                ImmutableMap.of("somedata", Arrays.asList("data2"),
+                        "id", Arrays.asList("an id2")));
+        
+        doThrow(new IndexingConflictException("conflict", new IOException("placeholder")))
+            .when(idxStore).indexObjects(
+                    eq(rule),
+                    any(SourceData.class),
+                    eq(Instant.ofEpochMilli(10000)),
+                    eq(null),
+                    eq(guid),
+                    eq(ImmutableMap.of(
+                            new GUID(guid, "subfoo", "an id2"), po2,
+                            new GUID(guid, "subfoo", "an id"), po1)),
+                    eq(false));
+        
+        try {
+            worker.processOneEvent(StatusEvent.getBuilder(
+                    storageObjectType,
+                    Instant.ofEpochMilli(10000), StatusEventType.NEW_VERSION)
+                    .withNullableAccessGroupID(1)
+                    .withNullableObjectID("2")
+                    .withNullableVersion(3)
+                    .withNullableisPublic(false)
+                    .build());
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(
+                    got, new RetriesExceededIndexingException("conflict"));
+        }
+        
+        final String errmsg = "Retriable error in indexer, retry %s: " +
+                "kbasesearchengine.events.exceptions.RetriableIndexingException: conflict";
+        
+        verify(logger).logError(String.format(errmsg, 1));
+        verify(logger).logError(String.format(errmsg, 2));
+        verify(logger).logError(String.format(errmsg, 3));
+        verify(logger).logError(String.format(errmsg, 4));
+        verify(logger).logError(String.format(errmsg, 5));
+    }
+    
+    @Test
+    public void conflictOnModify() throws Exception {
+        /* tests the handling of conflict errors when modifying an object already in the index.
+         * We just test one case rather than having tests that are identical other than which
+         * IndexingStorage method throws the error.
+         */
+
+        final EventHandler ws = mock(EventHandler.class);
+        final StatusEventStorage storage = mock(StatusEventStorage.class);
+        final IndexingStorage idxStore = mock(IndexingStorage.class);
+        final TypeStorage typeStore = mock(TypeStorage.class);
+        final LineLogger logger = mock(LineLogger.class);
+        
+        final Path tempDir = Paths.get(TestCommon.getTempDir()).toAbsolutePath()
+                .resolve("IndexerWorkerTest");
+        deleteRecursively(tempDir);
+        
+        when(ws.getStorageCode()).thenReturn("code");
+        
+        final IndexerWorker worker = new IndexerWorker(
+                "myid", Arrays.asList(ws), storage, idxStore, typeStore, tempDir.toFile(), logger,
+                null, 1000);
+        
+        doThrow(new IndexingConflictException("conflict", new IOException("placeholder")))
+                .when(idxStore).deleteAllVersions(new GUID("WS:3/6"));
+        
+        try {
+            worker.processOneEvent(StatusEvent.getBuilder(
+                    "WS", Instant.ofEpochMilli(10000), StatusEventType.DELETE_ALL_VERSIONS)
+                    .withNullableAccessGroupID(3)
+                    .withNullableObjectID("6")
+                    .build());
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, new RetriableIndexingException("conflict"));
         }
     }
 

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -60,6 +60,7 @@ import kbasesearchengine.search.ObjectData;
 import kbasesearchengine.search.PostProcessing;
 import kbasesearchengine.search.SortingRule;
 import kbasesearchengine.search.FoundHits;
+import kbasesearchengine.search.IndexingConflictException;
 import kbasesearchengine.system.IndexingRules;
 import kbasesearchengine.system.ObjectTypeParsingRules;
 import kbasesearchengine.system.ObjectTypeParsingRulesFileParser;
@@ -185,7 +186,8 @@ public class ElasticIndexingStorageTest {
             final Instant timestamp,
             final String parentJsonValue,
             final boolean isPublic)
-            throws IOException, ObjectParseException, IndexingException, InterruptedException {
+            throws IOException, ObjectParseException, IndexingException, InterruptedException,
+                IndexingConflictException {
         ParsedObject obj = KeywordParser.extractKeywords(id, rule.getGlobalObjectType(), json,
                 parentJsonValue, rule.getIndexingRules(), objLookup, null);
         final SourceData data = SourceData.getBuilder(new UObject(json), objectName, "creator")


### PR DESCRIPTION
They're not great in that they mean the code isn't handling indexing
correctly in some cases, but shutting the worker down and leaving events
in a stuck state is worse.

This doesn't fix the root cause of the problem but means there's no
known errors that cause a worker shutdown where the worker continuing
does no further harm.

Unfortunately reliably testing elastic conflicts is going to be very difficult (at least I can't think of a simple way to do it) so we'll have to test in CI.