### PR TITLE
SCT-642 Add error type to errors

### DIFF
--- a/lib/src/kbasesearchengine/events/exceptions/ErrorType.java
+++ b/lib/src/kbasesearchengine/events/exceptions/ErrorType.java
@@ -13,7 +13,7 @@ public enum ErrorType {
      */
 
     /** Lack of location data for a location transform. */
-    LOCATION_MISSING,
+    LOCATION_ERROR,
     
     /** An object has too many subobjects to index. */
     SUBOBJECT_COUNT,

--- a/lib/src/kbasesearchengine/events/exceptions/ErrorType.java
+++ b/lib/src/kbasesearchengine/events/exceptions/ErrorType.java
@@ -1,0 +1,30 @@
+package kbasesearchengine.events.exceptions;
+
+/** An enum representing the type of a particular error.
+ * @author gaprice@lbl.gov
+ *
+ */
+public enum ErrorType {
+
+    // be very careful about changing error type ids as they may be stored in DBs
+    
+    /* add new error types as needed. These are primarily to allow selecting or excluding
+     * types of errors when doing database searches.
+     */
+
+    /** Lack of location data for a location transform. */
+    LOCATION_MISSING,
+    
+    /** An object has too many subobjects to index. */
+    SUBOBJECT_COUNT,
+    
+    /** A conflict error when attempting to index data. */
+    INDEXING_CONFLICT,
+
+    /** A catch all category for error types without a specific entry. */
+    OTHER;
+    
+    
+
+
+}

--- a/lib/src/kbasesearchengine/events/exceptions/FatalIndexingException.java
+++ b/lib/src/kbasesearchengine/events/exceptions/FatalIndexingException.java
@@ -8,12 +8,15 @@ package kbasesearchengine.events.exceptions;
 @SuppressWarnings("serial")
 public class FatalIndexingException extends IndexingException {
 
-    public FatalIndexingException(final String message) {
-        super(message);
+    public FatalIndexingException(final ErrorType errorType, final String message) {
+        super(errorType, message);
     }
     
-    public FatalIndexingException(final String message, final Throwable cause) {
-        super(message, cause);
+    public FatalIndexingException(
+            final ErrorType errorType,
+            final String message,
+            final Throwable cause) {
+        super(errorType, message, cause);
     }
     
 }

--- a/lib/src/kbasesearchengine/events/exceptions/FatalRetriableIndexingException.java
+++ b/lib/src/kbasesearchengine/events/exceptions/FatalRetriableIndexingException.java
@@ -9,12 +9,15 @@ package kbasesearchengine.events.exceptions;
 @SuppressWarnings("serial")
 public class FatalRetriableIndexingException extends RetriableIndexingException {
 
-    public FatalRetriableIndexingException(final String message) {
-        super(message);
+    public FatalRetriableIndexingException(final ErrorType errorType, final String message) {
+        super(errorType, message);
     }
     
-    public FatalRetriableIndexingException(final String message, final Throwable cause) {
-        super(message, cause);
+    public FatalRetriableIndexingException(
+            final ErrorType errorType,
+            final String message,
+            final Throwable cause) {
+        super(errorType, message, cause);
     }
     
 }

--- a/lib/src/kbasesearchengine/events/exceptions/IndexingException.java
+++ b/lib/src/kbasesearchengine/events/exceptions/IndexingException.java
@@ -1,5 +1,7 @@
 package kbasesearchengine.events.exceptions;
 
+import kbasesearchengine.tools.Utils;
+
 /** The root class for all non-retriable indexing exceptions.
  * @author gaprice@lbl.gov
  *
@@ -7,12 +9,27 @@ package kbasesearchengine.events.exceptions;
 @SuppressWarnings("serial")
 public class IndexingException extends Exception {
 
-    protected IndexingException(final String message) {
+    private final ErrorType errorType;
+    
+    protected IndexingException(final ErrorType errorType, final String message) {
         super(message);
+        Utils.nonNull(errorType, "errorType");
+        this.errorType = errorType;
     }
     
-    protected IndexingException(final String message, final Throwable cause) {
+    protected IndexingException(
+            final ErrorType errorType,
+            final String message,
+            final Throwable cause) {
         super(message, cause);
+        Utils.nonNull(errorType, "errorType");
+        this.errorType = errorType;
     }
-    
+
+    /** Get the type of this error.
+     * @return the error type.
+     */
+    public ErrorType getErrorType() {
+        return errorType;
+    }
 }

--- a/lib/src/kbasesearchengine/events/exceptions/RetriableIndexingException.java
+++ b/lib/src/kbasesearchengine/events/exceptions/RetriableIndexingException.java
@@ -1,5 +1,7 @@
 package kbasesearchengine.events.exceptions;
 
+import kbasesearchengine.tools.Utils;
+
 /** An exception thrown when a particular event could not be processed, but a retry is possible.
  * Generally speaking, a handler should try again with a delay and fail hard after
  * some number of retries. For example, a data source might not be contactable temporarily.
@@ -8,13 +10,28 @@ package kbasesearchengine.events.exceptions;
  */
 @SuppressWarnings("serial")
 public class RetriableIndexingException extends Exception {
+    
+    private final ErrorType errorType;
 
-    public RetriableIndexingException(final String message) {
+    public RetriableIndexingException(final ErrorType errorType, final String message) {
         super(message);
+        Utils.nonNull(errorType, "errorType");
+        this.errorType = errorType;
     }
     
-    public RetriableIndexingException(final String message, final Throwable cause) {
+    public RetriableIndexingException(
+            final ErrorType errorType,
+            final String message,
+            final Throwable cause) {
         super(message, cause);
+        Utils.nonNull(errorType, "errorType");
+        this.errorType = errorType;
     }
-    
+
+    /** Get the type of this error.
+     * @return the error type.
+     */
+    public ErrorType getErrorType() {
+        return errorType;
+    }
 }

--- a/lib/src/kbasesearchengine/events/exceptions/Retrier.java
+++ b/lib/src/kbasesearchengine/events/exceptions/Retrier.java
@@ -152,7 +152,7 @@ public class Retrier {
             throws InterruptedException, IndexingException {
         if (e instanceof FatalRetriableIndexingException) {
             if (fatalRetries - 1 >= fatalRetryBackoffsMS.size()) {
-                throw new FatalIndexingException(e.getMessage(), e);
+                throw new FatalIndexingException(e.getErrorType(), e.getMessage(), e);
             } else {
                 logger.log(fatalRetries, Optional.fromNullable(event), e);
                 TimeUnit.MILLISECONDS.sleep(fatalRetryBackoffsMS.get(fatalRetries - 1));
@@ -160,7 +160,7 @@ public class Retrier {
             }
         } else {
             if (retries > retryCount) {
-                throw new RetriesExceededIndexingException(e.getMessage(), e);
+                throw new RetriesExceededIndexingException(e.getErrorType(), e.getMessage(), e);
             } else {
                 logger.log(retries, Optional.fromNullable(event), e);
                 TimeUnit.MILLISECONDS.sleep(delayMS);

--- a/lib/src/kbasesearchengine/events/exceptions/RetriesExceededIndexingException.java
+++ b/lib/src/kbasesearchengine/events/exceptions/RetriesExceededIndexingException.java
@@ -8,12 +8,15 @@ package kbasesearchengine.events.exceptions;
 @SuppressWarnings("serial")
 public class RetriesExceededIndexingException extends IndexingException {
 
-    public RetriesExceededIndexingException(final String message) {
-        super(message);
+    public RetriesExceededIndexingException(final ErrorType errorType, final String message) {
+        super(errorType, message);
     }
     
-    public RetriesExceededIndexingException(final String message, final Throwable cause) {
-        super(message, cause);
+    public RetriesExceededIndexingException(
+            final ErrorType errorType,
+            final String message,
+            final Throwable cause) {
+        super(errorType, message, cause);
     }
     
 }

--- a/lib/src/kbasesearchengine/events/exceptions/UnprocessableEventIndexingException.java
+++ b/lib/src/kbasesearchengine/events/exceptions/UnprocessableEventIndexingException.java
@@ -9,12 +9,15 @@ package kbasesearchengine.events.exceptions;
 @SuppressWarnings("serial")
 public class UnprocessableEventIndexingException extends IndexingException {
 
-    public UnprocessableEventIndexingException(final String message) {
-        super(message);
+    public UnprocessableEventIndexingException(final ErrorType errorType, final String message) {
+        super(errorType, message);
     }
     
-    public UnprocessableEventIndexingException(final String message, final Throwable cause) {
-        super(message, cause);
+    public UnprocessableEventIndexingException(
+            final ErrorType errorType,
+            final String message,
+            final Throwable cause) {
+        super(errorType, message, cause);
     }
     
 }

--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -27,6 +27,7 @@ import kbasesearchengine.events.ChildStatusEvent;
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.IndexingException;
@@ -237,30 +238,30 @@ public class WorkspaceEventHandler implements EventHandler {
 
     private static IndexingException handleException(final JsonClientException e) {
         if (e instanceof UnauthorizedException) {
-            return new FatalIndexingException(e.getMessage(), e);
+            return new FatalIndexingException(ErrorType.OTHER, e.getMessage(), e);
         }
         if (e.getMessage() == null) {
             return new UnprocessableEventIndexingException(
-                    "Null error message from workspace server", e);
+                    ErrorType.OTHER, "Null error message from workspace server", e);
         } else if (e.getMessage().toLowerCase().contains("login")) {
             return new FatalIndexingException(
-                    "Workspace credentials are invalid: " + e.getMessage(), e);
+                    ErrorType.OTHER, "Workspace credentials are invalid: " + e.getMessage(), e);
         } else if (e.getMessage().toLowerCase().contains("did not start up properly")) {
-            return new FatalIndexingException("Fatal error returned from workspace: " +
-                    e.getMessage(), e);
+            return new FatalIndexingException(ErrorType.OTHER,
+                    "Fatal error returned from workspace: " + e.getMessage(), e);
         } else {
             // this may need to be expanded, some errors may require retries or total failures
             return new UnprocessableEventIndexingException(
-                    "Unrecoverable error from workspace on fetching object: " + e.getMessage(),
-                    e);
+                    ErrorType.OTHER, "Unrecoverable error from workspace on fetching object: " +
+                            e.getMessage(), e);
         }
     }
 
     private static RetriableIndexingException handleException(final IOException e) {
         if (e instanceof ConnectException) {
-            return new FatalRetriableIndexingException(e.getMessage(), e);
+            return new FatalRetriableIndexingException(ErrorType.OTHER, e.getMessage(), e);
         }
-        return new RetriableIndexingException(e.getMessage(), e);
+        return new RetriableIndexingException(ErrorType.OTHER, e.getMessage(), e);
     }
     
     @Override
@@ -582,8 +583,8 @@ public class WorkspaceEventHandler implements EventHandler {
         try {
             objid = Long.parseLong(event.getAccessGroupObjectId().get());
         } catch (NumberFormatException ne) {
-            throw new UnprocessableEventIndexingException("Illegal workspace object id: " +
-                    event.getAccessGroupObjectId());
+            throw new UnprocessableEventIndexingException(ErrorType.OTHER,
+                    "Illegal workspace object id: " + event.getAccessGroupObjectId());
         }
         final Map<String, Object> command = new HashMap<>();
         command.put("command", "getObjectHistory");

--- a/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/MongoDBStatusEventStorage.java
@@ -31,6 +31,7 @@ import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StoredStatusEvent;
 import kbasesearchengine.events.StatusEvent.Builder;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.system.StorageObjectType;
 import kbasesearchengine.tools.Utils;
@@ -220,7 +221,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
             db.getCollection(COL_EVENT).insertOne(doc);
         } catch (MongoException e) {
             throw new FatalRetriableIndexingException(
-                    "Failed event storage: " + e.getMessage(), e);
+                    ErrorType.OTHER, "Failed event storage: " + e.getMessage(), e);
         }
         final StoredStatusEvent.Builder b = StoredStatusEvent.getBuilder(
                 newEvent, new StatusEventID(doc.getObjectId("_id").toString()), state)
@@ -242,7 +243,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
                     new Document("_id", new ObjectId(id.getId()))).first();
         } catch (MongoException e) {
             throw new FatalRetriableIndexingException(
-                    "Failed getting event: " + e.getMessage(), e);
+                    ErrorType.OTHER, "Failed getting event: " + e.getMessage(), e);
         }
         if (event == null) {
             return Optional.absent();
@@ -310,7 +311,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
             }
         } catch (MongoException e) {
             throw new FatalRetriableIndexingException(
-                    "Failed getting events: " + e.getMessage(), e);
+                    ErrorType.OTHER, "Failed getting events: " + e.getMessage(), e);
         }
         return ret;
     }
@@ -334,7 +335,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
             return res.getMatchedCount() == 1;
         } catch (MongoException e) {
             throw new FatalRetriableIndexingException(
-                    "Failed setting event state: " + e.getMessage(), e);
+                    ErrorType.OTHER, "Failed setting event state: " + e.getMessage(), e);
         }
     }
 
@@ -376,7 +377,7 @@ public class MongoDBStatusEventStorage implements StatusEventStorage {
                              .returnDocument(ReturnDocument.AFTER));
         } catch (MongoException e) {
             throw new FatalRetriableIndexingException(
-                    "Failed setting event state: " + e.getMessage(), e);
+                    ErrorType.OTHER, "Failed setting event state: " + e.getMessage(), e);
         }
         if (ret == null) {
             return Optional.absent();

--- a/lib/src/kbasesearchengine/main/IndexerCoordinator.java
+++ b/lib/src/kbasesearchengine/main/IndexerCoordinator.java
@@ -168,11 +168,11 @@ public class IndexerCoordinator implements Stoppable {
             try {
                 runOneCycle();
             } catch (InterruptedException | FatalIndexingException e) {
-                logError(ErrorType.FATAL, e);
+                logError(true, e);
                 executor.shutdown();
                 signalMonitor.signal();
             } catch (Throwable e) {
-                logError(ErrorType.UNEXPECTED, e);
+                logError(false, e);
             }
         }
     }
@@ -187,18 +187,9 @@ public class IndexerCoordinator implements Stoppable {
         executor.awaitTermination(millisToWait, TimeUnit.MILLISECONDS);
     }
     
-    private enum ErrorType {
-        FATAL, UNEXPECTED;
-    }
-    
-    private void logError(final ErrorType errtype, final Throwable e) {
-        final String msg;
-        if (ErrorType.FATAL.equals(errtype)) {
-            msg = "Fatal error in indexer, shutting down";
-        } else { // has to be UNEXPECTED
-            msg = "Unexpected error in indexer";
-        }
-        logError(msg, e);
+    private void logError(final boolean fatal, final Throwable e) {
+        logError(fatal ?
+                "Fatal error in indexer, shutting down" : "Unexpected error in indexer", e);
     }
 
     private void logError(final String msg, final Throwable e) {

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -43,6 +43,7 @@ import kbasesearchengine.events.handler.EventHandler;
 import kbasesearchengine.events.handler.ResolvedReference;
 import kbasesearchengine.events.handler.SourceData;
 import kbasesearchengine.events.storage.StatusEventStorage;
+import kbasesearchengine.parse.ContigLocationException;
 import kbasesearchengine.parse.KeywordParser;
 import kbasesearchengine.parse.ObjectParseException;
 import kbasesearchengine.parse.ObjectParser;
@@ -631,8 +632,10 @@ public class IndexerWorker implements Stoppable {
              * File IO problems are generally going to mean something is very wrong
              * (like bad disk), since the file should already exist at this point.
              */
+        } catch (ContigLocationException e) {
+            throw new UnprocessableEventIndexingException(
+                    ErrorType.LOCATION_ERROR, e.getMessage(), e);
         } catch (ObjectParseException e) {
-            //TODO NNOW location exception
             throw new UnprocessableEventIndexingException(ErrorType.OTHER, e.getMessage(), e);
         } catch (IOException e) {
             throw new FatalRetriableIndexingException(ErrorType.OTHER, e.getMessage(), e);

--- a/lib/src/kbasesearchengine/parse/ContigLocationException.java
+++ b/lib/src/kbasesearchengine/parse/ContigLocationException.java
@@ -1,0 +1,11 @@
+package kbasesearchengine.parse;
+
+public class ContigLocationException extends ObjectParseException {
+
+    private static final long serialVersionUID = 1L;
+    
+    public ContigLocationException(final String message) {
+        super(message);
+    }
+
+}

--- a/lib/src/kbasesearchengine/parse/ContigLocationException.java
+++ b/lib/src/kbasesearchengine/parse/ContigLocationException.java
@@ -1,5 +1,9 @@
 package kbasesearchengine.parse;
 
+/** An error thrown when data regarding locations on a contig are missing or erroneous.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class ContigLocationException extends ObjectParseException {
 
     private static final long serialVersionUID = 1L;

--- a/lib/src/kbasesearchengine/parse/KeywordParser.java
+++ b/lib/src/kbasesearchengine/parse/KeywordParser.java
@@ -329,24 +329,24 @@ public class KeywordParser {
             final GUID subObjectGuid,
             final Object value,
             final LocationTransformType locationTransformType)
-            throws ObjectParseException {
+            throws ContigLocationException {
         final List<List<Object>> loc;
         try {
             @SuppressWarnings("unchecked")
             final List<List<Object>> locloc = (List<List<Object>>) value;
             loc = locloc;
             if (loc.size() < 1) {
-                throw new ObjectParseException(String.format(
+                throw new ContigLocationException(String.format(
                         "Expected location array for location transform for %s, got empty array",
                         subObjectGuid));
             }
             if (loc.get(0).size() < 4) {
-                throw new ObjectParseException(String.format(
+                throw new ContigLocationException(String.format(
                         "Expected location array for location transform for %s, got %s",
                         subObjectGuid, loc.get(0)));
             }
         } catch (ClassCastException e) {
-            throw new ObjectParseException(String.format(
+            throw new ContigLocationException(String.format(
                     "Expected location array for location transform for %s, got %s",
                     subObjectGuid, value));
         }

--- a/test/src/kbasesearchengine/test/common/TestCommon.java
+++ b/test/src/kbasesearchengine/test/common/TestCommon.java
@@ -24,6 +24,9 @@ import java.util.Properties;
 import java.util.Set;
 
 import kbasesearchengine.ObjectData;
+import kbasesearchengine.events.exceptions.IndexingException;
+import kbasesearchengine.events.exceptions.RetriableIndexingException;
+
 import org.apache.commons.io.IOUtils;
 import org.bson.Document;
 
@@ -181,6 +184,13 @@ public class TestCommon {
                 got.getLocalizedMessage(),
                 is(expected.getLocalizedMessage()));
         assertThat("incorrect exception type", got, instanceOf(expected.getClass()));
+        if (got instanceof IndexingException) {
+            assertThat("incorrect error code", ((IndexingException) got).getErrorType(),
+                    is(((IndexingException) expected).getErrorType()));
+        } else if (got instanceof RetriableIndexingException) {
+            assertThat("incorrect error code", ((RetriableIndexingException) got).getErrorType(),
+                    is(((RetriableIndexingException) expected).getErrorType()));
+        }
     }
     
     @SafeVarargs

--- a/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
@@ -165,7 +165,7 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(1, 100, Collections.emptyList(), collog);
         final Instant start = Instant.now();
-        ret.retryCons(new TestConsumer<>("foo", 1, ErrorType.LOCATION_MISSING), "foo", null);
+        ret.retryCons(new TestConsumer<>("foo", 1, ErrorType.LOCATION_ERROR), "foo", null);
         final Instant end = Instant.now();
         
         assertThat("incorrect retries", collog.events.size(), is(1));
@@ -173,7 +173,7 @@ public class RetrierTest {
         assertThat("incorrect retry count", le.retryCount, is(1));
         assertThat("incorrect event", le.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le.exception, new RetriableIndexingException(
-                ErrorType.LOCATION_MISSING, "bar"));
+                ErrorType.LOCATION_ERROR, "bar"));
         assertCloseMS(start, le.time, 0, 60);
         assertCloseMS(start, end, 100, 60);
     }
@@ -377,7 +377,7 @@ public class RetrierTest {
         final Retrier ret = new Retrier(1, 100, Collections.emptyList(), collog);
         final Instant start = Instant.now();
         final long result = ret.retryFunc(new TestFunction<>(
-                "foo", 24L, 1, ErrorType.LOCATION_MISSING), "foo", null);
+                "foo", 24L, 1, ErrorType.LOCATION_ERROR), "foo", null);
         final Instant end = Instant.now();
         
         assertThat("incorrect result", result, is(24L));
@@ -386,7 +386,7 @@ public class RetrierTest {
         assertThat("incorrect retry count", le.retryCount, is(1));
         assertThat("incorrect event", le.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le.exception, new RetriableIndexingException(
-                ErrorType.LOCATION_MISSING, "bar"));
+                ErrorType.LOCATION_ERROR, "bar"));
         assertCloseMS(start, le.time, 0, 60);
         assertCloseMS(start, end, 100, 60);
     }

--- a/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
+++ b/test/src/kbasesearchengine/test/events/exceptions/RetrierTest.java
@@ -21,6 +21,7 @@ import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StatusEventWithId;
 import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.IndexingException;
@@ -125,17 +126,20 @@ public class RetrierTest {
         private final int retries;
         private int count = 0;
         private final boolean fatal;
+        private final ErrorType errorType;
         
-        private TestConsumer(T input, int retries) {
+        private TestConsumer(T input, int retries, ErrorType errorType) {
             this.input = input;
             this.retries = retries;
             fatal = false;
+            this.errorType = errorType;
         }
         
-        private TestConsumer(T input, int retries, boolean fatal) {
+        private TestConsumer(T input, int retries, ErrorType errorType, boolean fatal) {
             this.input = input;
             this.retries = retries;
             this.fatal = fatal;
+            this.errorType = errorType;
         }
 
         @Override
@@ -147,9 +151,9 @@ public class RetrierTest {
             } else {
                 count++;
                 if (fatal) {
-                    throw new FatalRetriableIndexingException("game over man");
+                    throw new FatalRetriableIndexingException(errorType, "game over man");
                 } else {
-                    throw new RetriableIndexingException("bar");
+                    throw new RetriableIndexingException(errorType, "bar");
                 }
             }
         }
@@ -161,14 +165,15 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(1, 100, Collections.emptyList(), collog);
         final Instant start = Instant.now();
-        ret.retryCons(new TestConsumer<>("foo", 1), "foo", null);
+        ret.retryCons(new TestConsumer<>("foo", 1, ErrorType.LOCATION_MISSING), "foo", null);
         final Instant end = Instant.now();
         
         assertThat("incorrect retries", collog.events.size(), is(1));
         final LogEvent le = collog.events.get(0);
         assertThat("incorrect retry count", le.retryCount, is(1));
         assertThat("incorrect event", le.event, is(Optional.absent()));
-        TestCommon.assertExceptionCorrect(le.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le.exception, new RetriableIndexingException(
+                ErrorType.LOCATION_MISSING, "bar"));
         assertCloseMS(start, le.time, 0, 60);
         assertCloseMS(start, end, 100, 60);
     }
@@ -187,20 +192,22 @@ public class RetrierTest {
                 StatusEventProcessingState.UNPROC)
                 .build();
         final Instant start = Instant.now();
-        ret.retryCons(new TestConsumer<>("foo", 2), "foo", ev);
+        ret.retryCons(new TestConsumer<>("foo", 2, ErrorType.INDEXING_CONFLICT), "foo", ev);
         final Instant end = Instant.now();
         
         assertThat("incorrect retries", collog.events.size(), is(2));
         final LogEvent le1 = collog.events.get(0);
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.of(ev)));
-        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException(
+                ErrorType.INDEXING_CONFLICT, "bar"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.of(ev)));
-        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException(
+                ErrorType.INDEXING_CONFLICT, "bar"));
         assertCloseMS(start, le2.time, 100, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -211,9 +218,10 @@ public class RetrierTest {
         final Retrier ret = new Retrier(2, 100, Collections.emptyList(), collog);
         final Instant start = Instant.now();
         try {
-            ret.retryCons(new TestConsumer<>("foo", -1), "foo", null);
+            ret.retryCons(new TestConsumer<>("foo", -1, ErrorType.SUBOBJECT_COUNT), "foo", null);
         } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new RetriesExceededIndexingException("bar"));
+            TestCommon.assertExceptionCorrect(got, new RetriesExceededIndexingException(
+                    ErrorType.SUBOBJECT_COUNT, "bar"));
         }
         final Instant end = Instant.now();
         
@@ -221,13 +229,15 @@ public class RetrierTest {
         final LogEvent le1 = collog.events.get(0);
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.absent()));
-        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException(
+                ErrorType.SUBOBJECT_COUNT, "bar"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.absent()));
-        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException(
+                ErrorType.SUBOBJECT_COUNT, "bar"));
         assertCloseMS(start, le2.time, 100, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -237,7 +247,7 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(1, 100, Arrays.asList(140), collog);
         final Instant start = Instant.now();
-        ret.retryCons(new TestConsumer<>("foo", 1, true), "foo", null);
+        ret.retryCons(new TestConsumer<>("foo", 1, ErrorType.OTHER, true), "foo", null);
         final Instant end = Instant.now();
         
         assertThat("incorrect retries", collog.events.size(), is(1));
@@ -245,7 +255,7 @@ public class RetrierTest {
         assertThat("incorrect retry count", le.retryCount, is(1));
         assertThat("incorrect event", le.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le.time, 0, 60);
         assertCloseMS(start, end, 140, 60);
     }
@@ -264,7 +274,7 @@ public class RetrierTest {
                 StatusEventProcessingState.UNPROC)
                 .build();
         final Instant start = Instant.now();
-        ret.retryCons(new TestConsumer<>("foo", 2, true), "foo", ev);
+        ret.retryCons(new TestConsumer<>("foo", 2, ErrorType.OTHER, true), "foo", ev);
         final Instant end = Instant.now();
         
         assertThat("incorrect retries", collog.events.size(), is(2));
@@ -272,14 +282,14 @@ public class RetrierTest {
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.of(ev)));
         TestCommon.assertExceptionCorrect(le1.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.of(ev)));
         TestCommon.assertExceptionCorrect(le2.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le2.time, 140, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -290,9 +300,10 @@ public class RetrierTest {
         final Retrier ret = new Retrier(2, 100, Arrays.asList(60, 140), collog);
         final Instant start = Instant.now();
         try {
-            ret.retryCons(new TestConsumer<>("foo", -1, true), "foo", null);
+            ret.retryCons(new TestConsumer<>("foo", -1, ErrorType.OTHER, true), "foo", null);
         } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new FatalIndexingException("game over man"));
+            TestCommon.assertExceptionCorrect(got, new FatalIndexingException(
+                    ErrorType.OTHER, "game over man"));
         }
         final Instant end = Instant.now();
         
@@ -301,14 +312,14 @@ public class RetrierTest {
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le1.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le2.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le2.time, 60, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -320,19 +331,27 @@ public class RetrierTest {
         private final int retries;
         private int count = 0;
         private final boolean fatal;
+        private final ErrorType errorType;
         
-        private TestFunction(T input, R ret, int retries) {
+        private TestFunction(T input, R ret, int retries, ErrorType errorType) {
             this.input = input;
             this.ret = ret;
             this.retries = retries;
             fatal = false;
+            this.errorType = errorType;
         }
         
-        private TestFunction(T input, R ret, int retries, final boolean fatal) {
+        private TestFunction(
+                T input,
+                R ret,
+                int retries,
+                ErrorType errorType,
+                final boolean fatal) {
             this.input = input;
             this.ret = ret;
             this.retries = retries;
             this.fatal = fatal;
+            this.errorType = errorType;
         }
 
         @Override
@@ -344,9 +363,9 @@ public class RetrierTest {
             } else {
                 count++;
                 if (fatal) {
-                    throw new FatalRetriableIndexingException("game over man");
+                    throw new FatalRetriableIndexingException(errorType, "game over man");
                 } else {
-                    throw new RetriableIndexingException("bar");
+                    throw new RetriableIndexingException(errorType, "bar");
                 }
             }
         }
@@ -357,7 +376,8 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(1, 100, Collections.emptyList(), collog);
         final Instant start = Instant.now();
-        final long result = ret.retryFunc(new TestFunction<>("foo", 24L, 1), "foo", null);
+        final long result = ret.retryFunc(new TestFunction<>(
+                "foo", 24L, 1, ErrorType.LOCATION_MISSING), "foo", null);
         final Instant end = Instant.now();
         
         assertThat("incorrect result", result, is(24L));
@@ -365,7 +385,8 @@ public class RetrierTest {
         final LogEvent le = collog.events.get(0);
         assertThat("incorrect retry count", le.retryCount, is(1));
         assertThat("incorrect event", le.event, is(Optional.absent()));
-        TestCommon.assertExceptionCorrect(le.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le.exception, new RetriableIndexingException(
+                ErrorType.LOCATION_MISSING, "bar"));
         assertCloseMS(start, le.time, 0, 60);
         assertCloseMS(start, end, 100, 60);
     }
@@ -384,7 +405,8 @@ public class RetrierTest {
                 StatusEventProcessingState.UNPROC)
                 .build();
         final Instant start = Instant.now();
-        final long result = ret.retryFunc(new TestFunction<>("foo", 26L, 2), "foo", ev);
+        final long result = ret.retryFunc(new TestFunction<>(
+                "foo", 26L, 2, ErrorType.INDEXING_CONFLICT), "foo", ev);
         final Instant end = Instant.now();
         
         assertThat("incorrect result", result, is(26L));
@@ -392,13 +414,15 @@ public class RetrierTest {
         final LogEvent le1 = collog.events.get(0);
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.of(ev)));
-        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException(
+                ErrorType.INDEXING_CONFLICT, "bar"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.of(ev)));
-        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException(
+                ErrorType.INDEXING_CONFLICT, "bar"));
         assertCloseMS(start, le2.time, 100, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -409,9 +433,11 @@ public class RetrierTest {
         final Retrier ret = new Retrier(2, 100, Collections.emptyList(), collog);
         final Instant start = Instant.now();
         try {
-            ret.retryFunc(new TestFunction<>("foo", 3L, -1), "foo", null);
+            ret.retryFunc(new TestFunction<>(
+                    "foo", 3L, -1, ErrorType.SUBOBJECT_COUNT), "foo", null);
         } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new RetriesExceededIndexingException("bar"));
+            TestCommon.assertExceptionCorrect(got, new RetriesExceededIndexingException(
+                    ErrorType.SUBOBJECT_COUNT, "bar"));
         }
         final Instant end = Instant.now();
         
@@ -419,13 +445,15 @@ public class RetrierTest {
         final LogEvent le1 = collog.events.get(0);
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.absent()));
-        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le1.exception, new RetriableIndexingException(
+                ErrorType.SUBOBJECT_COUNT, "bar"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.absent()));
-        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException("bar"));
+        TestCommon.assertExceptionCorrect(le2.exception, new RetriableIndexingException(
+                ErrorType.SUBOBJECT_COUNT, "bar"));
         assertCloseMS(start, le2.time, 100, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -435,7 +463,8 @@ public class RetrierTest {
         final CollectingLogger collog = new CollectingLogger();
         final Retrier ret = new Retrier(1, 100, Arrays.asList(140), collog);
         final Instant start = Instant.now();
-        final long result = ret.retryFunc(new TestFunction<>("foo", 42L, 1, true), "foo", null);
+        final long result = ret.retryFunc(new TestFunction<>(
+                "foo", 42L, 1, ErrorType.OTHER, true), "foo", null);
         final Instant end = Instant.now();
         
         assertThat("incorrect result", result, is(42L));
@@ -444,7 +473,7 @@ public class RetrierTest {
         assertThat("incorrect retry count", le.retryCount, is(1));
         assertThat("incorrect event", le.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le.time, 0, 60);
         assertCloseMS(start, end, 140, 60);
     }
@@ -463,7 +492,8 @@ public class RetrierTest {
                 StatusEventProcessingState.UNPROC)
                 .build();
         final Instant start = Instant.now();
-        final long result = ret.retryFunc(new TestFunction<>("foo", 64L, 2, true), "foo", ev);
+        final long result = ret.retryFunc(new TestFunction<>(
+                "foo", 64L, 2, ErrorType.OTHER, true), "foo", ev);
         final Instant end = Instant.now();
         
         assertThat("incorrect result", result, is(64L));
@@ -472,14 +502,14 @@ public class RetrierTest {
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.of(ev)));
         TestCommon.assertExceptionCorrect(le1.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.of(ev)));
         TestCommon.assertExceptionCorrect(le2.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le2.time, 140, 60);
         assertCloseMS(start, end, 200, 60);
     }
@@ -490,9 +520,10 @@ public class RetrierTest {
         final Retrier ret = new Retrier(2, 100, Arrays.asList(60, 140), collog);
         final Instant start = Instant.now();
         try {
-            ret.retryFunc(new TestFunction<>("foo", 43L, -1, true), "foo", null);
+            ret.retryFunc(new TestFunction<>("foo", 43L, -1, ErrorType.OTHER, true), "foo", null);
         } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new FatalIndexingException("game over man"));
+            TestCommon.assertExceptionCorrect(got, new FatalIndexingException(
+                    ErrorType.OTHER, "game over man"));
         }
         final Instant end = Instant.now();
         
@@ -501,14 +532,14 @@ public class RetrierTest {
         assertThat("incorrect retry count", le1.retryCount, is(1));
         assertThat("incorrect event", le1.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le1.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le1.time, 0, 60);
         
         final LogEvent le2 = collog.events.get(1);
         assertThat("incorrect retry count", le2.retryCount, is(2));
         assertThat("incorrect event", le2.event, is(Optional.absent()));
         TestCommon.assertExceptionCorrect(le2.exception,
-                new FatalRetriableIndexingException("game over man"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "game over man"));
         assertCloseMS(start, le2.time, 60, 60);
         assertCloseMS(start, end, 200, 60);
     }

--- a/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
+++ b/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentMatcher;
 import com.google.common.collect.ImmutableMap;
 
 import kbasesearchengine.common.GUID;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.RetriableIndexingException;
@@ -583,27 +584,28 @@ public class WorkspaceEventHandlerTest {
     @Test
     public void loadFailWSGetObjExceptions() throws Exception {
         failLoadWSGetObjException(new ConnectException("hot damn"),
-                new FatalRetriableIndexingException("hot damn"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "hot damn"));
         
         failLoadWSGetObjException(new IOException("pump yer brakes, kid"),
-                new RetriableIndexingException("pump yer brakes, kid"));
+                new RetriableIndexingException(ErrorType.OTHER, "pump yer brakes, kid"));
         
         failLoadWSGetObjException(new UnauthorizedException("dvd commentary"),
-                new FatalIndexingException("dvd commentary"));
+                new FatalIndexingException(ErrorType.OTHER, "dvd commentary"));
         
         failLoadWSGetObjException(new JsonClientException(null),
                 new UnprocessableEventIndexingException(
-                        "Null error message from workspace server"));
+                        ErrorType.OTHER, "Null error message from workspace server"));
         
         failLoadWSGetObjException(new JsonClientException("Couldn't Login"),
-                new FatalIndexingException("Workspace credentials are invalid: Couldn't Login"));
+                new FatalIndexingException(ErrorType.OTHER, 
+                        "Workspace credentials are invalid: Couldn't Login"));
         
         failLoadWSGetObjException(new JsonClientException("Did not start Up Properly"),
-                new FatalIndexingException(
+                new FatalIndexingException(ErrorType.OTHER, 
                         "Fatal error returned from workspace: Did not start Up Properly"));
         
         failLoadWSGetObjException(new JsonClientException("That man's a national treasure"),
-                new UnprocessableEventIndexingException(
+                new UnprocessableEventIndexingException(ErrorType.OTHER, 
                         "Unrecoverable error from workspace on fetching object: " +
                         "That man's a national treasure"));
     }
@@ -611,27 +613,28 @@ public class WorkspaceEventHandlerTest {
     @Test
     public void loadFailWSGetWSInfoExceptions() throws Exception {
         failLoadWSGetWSInfoException(new ConnectException("hot damn"),
-                new FatalRetriableIndexingException("hot damn"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "hot damn"));
         
         failLoadWSGetWSInfoException(new IOException("pump yer brakes, kid"),
-                new RetriableIndexingException("pump yer brakes, kid"));
+                new RetriableIndexingException(ErrorType.OTHER, "pump yer brakes, kid"));
         
         failLoadWSGetWSInfoException(new UnauthorizedException("dvd commentary"),
-                new FatalIndexingException("dvd commentary"));
+                new FatalIndexingException(ErrorType.OTHER, "dvd commentary"));
         
         failLoadWSGetWSInfoException(new JsonClientException(null),
                 new UnprocessableEventIndexingException(
-                        "Null error message from workspace server"));
+                        ErrorType.OTHER, "Null error message from workspace server"));
         
         failLoadWSGetWSInfoException(new JsonClientException("Couldn't Login"),
-                new FatalIndexingException("Workspace credentials are invalid: Couldn't Login"));
+                new FatalIndexingException(
+                        ErrorType.OTHER, "Workspace credentials are invalid: Couldn't Login"));
         
         failLoadWSGetWSInfoException(new JsonClientException("Did not start Up Properly"),
-                new FatalIndexingException(
+                new FatalIndexingException(ErrorType.OTHER, 
                         "Fatal error returned from workspace: Did not start Up Properly"));
         
         failLoadWSGetWSInfoException(new JsonClientException("That man's a national treasure"),
-                new UnprocessableEventIndexingException(
+                new UnprocessableEventIndexingException(ErrorType.OTHER, 
                         "Unrecoverable error from workspace on fetching object: " +
                         "That man's a national treasure"));
     }

--- a/test/src/kbasesearchengine/test/main/IndexerCoordinatorTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerCoordinatorTest.java
@@ -33,6 +33,7 @@ import kbasesearchengine.events.StatusEventID;
 import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.IndexingException;
@@ -594,7 +595,7 @@ public class IndexerCoordinatorTest {
                 Arrays.asList(1, 1), ST, SC);
         
         when(storage.get(StatusEventProcessingState.UNPROC, 3)).thenThrow(
-                new FatalRetriableIndexingException("wheee!"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "wheee!"));
         
         final Runnable coordRunner = getIndexerRunnable(executor, coord);
         
@@ -617,9 +618,9 @@ public class IndexerCoordinatorTest {
         verify(logger, times(3)).logError(retExpCaptor.capture());
         
         final List<Exception> expected = Arrays.asList(
-                new FatalRetriableIndexingException("wheee!"),
-                new FatalRetriableIndexingException("wheee!"),
-                new FatalIndexingException("wheee!"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "wheee!"),
+                new FatalRetriableIndexingException(ErrorType.OTHER, "wheee!"),
+                new FatalIndexingException(ErrorType.OTHER, "wheee!"));
         
         for (int i = 0; i < expected.size(); i++) {
             TestCommon.assertExceptionCorrect(retExpCaptor.getAllValues().get(i), expected.get(i));
@@ -685,7 +686,8 @@ public class IndexerCoordinatorTest {
         
         when(storage.setProcessingState(new StatusEventID("foo1"),
                 StatusEventProcessingState.UNPROC, StatusEventProcessingState.READY)).thenThrow(
-                        new FatalRetriableIndexingException("oof ouch owie my bones"));
+                        new FatalRetriableIndexingException(
+                                ErrorType.OTHER, "oof ouch owie my bones"));
         
         coordRunner.run();
         assertThat("incorrect cycle count", coord.getContinuousCycles(), is(0));
@@ -707,8 +709,8 @@ public class IndexerCoordinatorTest {
         verify(logger, times(2)).logError(retExpCaptor.capture());
         
         final List<Exception> expected = Arrays.asList(
-                new FatalRetriableIndexingException("oof ouch owie my bones"),
-                new FatalIndexingException("oof ouch owie my bones"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "oof ouch owie my bones"),
+                new FatalIndexingException(ErrorType.OTHER, "oof ouch owie my bones"));
         
         for (int i = 0; i < expected.size(); i++) {
             TestCommon.assertExceptionCorrect(retExpCaptor.getAllValues().get(i), expected.get(i));
@@ -737,7 +739,7 @@ public class IndexerCoordinatorTest {
         when(storage.get(StatusEventProcessingState.UNPROC, 3)).thenReturn(Arrays.asList(event1));
         
         when(storage.get(new StatusEventID("foo1"))).thenThrow(
-                        new FatalRetriableIndexingException("yay"));
+                        new FatalRetriableIndexingException(ErrorType.OTHER, "yay"));
         
         coordRunner.run();
         assertThat("incorrect cycle count", coord.getContinuousCycles(), is(0));
@@ -769,10 +771,10 @@ public class IndexerCoordinatorTest {
         verify(logger, times(4)).logError(retExpCaptor.capture());
         
         final List<Exception> expected = Arrays.asList(
-                new FatalRetriableIndexingException("yay"),
-                new FatalRetriableIndexingException("yay"),
-                new FatalRetriableIndexingException("yay"),
-                new FatalIndexingException("yay"));
+                new FatalRetriableIndexingException(ErrorType.OTHER, "yay"),
+                new FatalRetriableIndexingException(ErrorType.OTHER, "yay"),
+                new FatalRetriableIndexingException(ErrorType.OTHER, "yay"),
+                new FatalIndexingException(ErrorType.OTHER, "yay"));
         
         for (int i = 0; i < expected.size(); i++) {
             TestCommon.assertExceptionCorrect(retExpCaptor.getAllValues().get(i), expected.get(i));

--- a/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
+++ b/test/src/kbasesearchengine/test/main/IndexerWorkerTest.java
@@ -34,6 +34,7 @@ import kbasesearchengine.common.GUID;
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventType;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.RetriableIndexingException;
 import kbasesearchengine.events.exceptions.RetriesExceededIndexingException;
 import kbasesearchengine.events.exceptions.UnprocessableEventIndexingException;
@@ -260,6 +261,7 @@ public class IndexerWorkerTest {
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, new UnprocessableEventIndexingException(
+                    ErrorType.OTHER,
                     "Could not find the subobject id for one or more of the subobjects for " +
                     "object code:1/2/3 when applying search specification foo_1"));
         }
@@ -547,6 +549,7 @@ public class IndexerWorkerTest {
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, new UnprocessableEventIndexingException(
+                    ErrorType.SUBOBJECT_COUNT,
                     "Object code:1/2/3 has 3 subobjects, exceeding the limit of 2"));
         }
         
@@ -662,7 +665,8 @@ public class IndexerWorkerTest {
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(
-                    got, new RetriesExceededIndexingException("conflict"));
+                    got, new RetriesExceededIndexingException(
+                            ErrorType.INDEXING_CONFLICT, "conflict"));
         }
         
         final String errmsg = "Retriable error in indexer, retry %s: " +
@@ -709,7 +713,8 @@ public class IndexerWorkerTest {
                     .build());
             fail("expected exception");
         } catch (Exception got) {
-            TestCommon.assertExceptionCorrect(got, new RetriableIndexingException("conflict"));
+            TestCommon.assertExceptionCorrect(got, new RetriableIndexingException(
+                    ErrorType.INDEXING_CONFLICT, "conflict"));
         }
     }
 

--- a/test/src/kbasesearchengine/test/parse/KeyWordParserTest.java
+++ b/test/src/kbasesearchengine/test/parse/KeyWordParserTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.common.ObjectJsonPath;
 import kbasesearchengine.events.exceptions.IndexingException;
+import kbasesearchengine.parse.ContigLocationException;
 import kbasesearchengine.parse.KeywordParser;
 import kbasesearchengine.parse.ObjectParseException;
 import kbasesearchengine.parse.ParsedObject;
@@ -111,17 +112,17 @@ public class KeyWordParserTest {
         // why are there multiple arrays anyway...?
         failLocationTransform(new ObjectMapper().writeValueAsString(ImmutableMap.of(
                 "location", Collections.emptyList())),
-                new ObjectParseException("Expected location array for location transform for " +
+                new ContigLocationException("Expected location array for location transform for " +
                             "CODE:1/2/3:subtype/id, got empty array"));
         
         failLocationTransform(new ObjectMapper().writeValueAsString(ImmutableMap.of(
                 "location", Arrays.asList(Arrays.asList("cid", 1, "+")))),
-                new ObjectParseException("Expected location array for location transform for " +
+                new ContigLocationException("Expected location array for location transform for " +
                             "CODE:1/2/3:subtype/id, got [cid, 1, +]"));
         
         failLocationTransform(new ObjectMapper().writeValueAsString(ImmutableMap.of(
                 "location", Arrays.asList(ImmutableMap.of("foo", "bar")))),
-                new ObjectParseException("Expected location array for location transform for " +
+                new ContigLocationException("Expected location array for location transform for " +
                             "CODE:1/2/3:subtype/id, got [{foo=bar}]"));
     }
     

--- a/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
+++ b/test/src/kbasesearchengine/test/search/ElasticIndexingStorageTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import junit.framework.Assert;
 import kbasesearchengine.common.GUID;
 import kbasesearchengine.common.ObjectJsonPath;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalIndexingException;
 import kbasesearchengine.events.exceptions.IndexingException;
 import kbasesearchengine.events.handler.SourceData;
@@ -125,7 +126,7 @@ public class ElasticIndexingStorageTest {
                 try {
                     objList = indexStorage.getObjectsByIds(guids);
                 } catch (IOException e) {
-                    throw new FatalIndexingException(e.getMessage(), e);
+                    throw new FatalIndexingException(ErrorType.OTHER, e.getMessage(), e);
                 }
                 return objList.stream().collect(
                         Collectors.toMap(od -> od.getGUID(), Function.identity()));
@@ -153,7 +154,7 @@ public class ElasticIndexingStorageTest {
                     return indexStorage.getObjectsByIds(guids, pp).stream().collect(
                             Collectors.toMap(od -> od.getGUID(), od -> od.getType().get()));
                 } catch (IOException e) {
-                    throw new FatalIndexingException(e.getMessage(), e);
+                    throw new FatalIndexingException(ErrorType.OTHER, e.getMessage(), e);
                 }
             }
         };


### PR DESCRIPTION
Adds an error type to errors that reach the portion of the worker code
where events get updated in the DB. Currently does nothing, but future
PRs will add the error type to the DB on a failed event. This will allow
for filtering on the error type when doing error analysis, rather than
having to filter on arbitrary error strings.