### PR TITLE
SCT-624 Allow easy testing of more of the event processing code

### DIFF
--- a/test/src/kbasesearchengine/test/common/TestCommon.java
+++ b/test/src/kbasesearchengine/test/common/TestCommon.java
@@ -175,8 +175,8 @@ public class TestCommon {
     }
     
     public static void assertExceptionCorrect(
-            final Exception got,
-            final Exception expected) {
+            final Throwable got,
+            final Throwable expected) {
         final StringWriter sw = new StringWriter();
         got.printStackTrace(new PrintWriter(sw));
         assertThat("incorrect exception. trace:\n" +

--- a/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
+++ b/test/src/kbasesearchengine/test/integration/IndexerWorkerIntegrationTest.java
@@ -292,7 +292,7 @@ public class IndexerWorkerIntegrationTest {
                 new StatusEventID("-1"),
                 StatusEventProcessingState.UNPROC)
                 .build();
-        worker.processOneEvent(ev.getEvent());
+        worker.processEvent(ev);
         PostProcessing pp = new PostProcessing();
         pp.objectInfo = true;
         pp.objectData = true;
@@ -337,7 +337,7 @@ public class IndexerWorkerIntegrationTest {
                     evid.getId(),
                     StatusEventProcessingState.UNPROC)
                     .build();
-            worker.processOneEvent(ev2.getEvent());
+            worker.processEvent(ev2);
         }
     }
     

--- a/test/src/kbasesearchengine/test/main/PerformanceTester.java
+++ b/test/src/kbasesearchengine/test/main/PerformanceTester.java
@@ -244,7 +244,7 @@ public class PerformanceTester {
                         .build();
                 long t2 = System.currentTimeMillis();
                 try {
-                    mop.processOneEvent(ev.getEvent());
+                    mop.processEvent(ev);
                     processTime += System.currentTimeMillis() - t2;
                 } catch (Exception ex) {
                     ex.printStackTrace();


### PR DESCRIPTION
Makes the parent method of the method formerly known as processOneEvent
the method exposed for testing rather than pOE.

1) Allows for testing event skipping.
2) Will respond correctly when asked to process an event for which no
search specs exist rather than doing some undefined weird thing.

Next PR: test event skipping.