### PR TITLE
SCT-624 Store errors with child events

### DIFF
--- a/lib/src/kbasesearchengine/events/storage/StatusEventStorage.java
+++ b/lib/src/kbasesearchengine/events/storage/StatusEventStorage.java
@@ -42,13 +42,19 @@ public interface StatusEventStorage {
             String storedBy)
             throws FatalRetriableIndexingException;
     
-    /** Store a status event that is a child of another status event. Child status events are
-     * immutable once stored. Note that no checking is done on the validity of the parent event's
-     * ID.
+    /** Store a status event that resulted in an error and that is a child of another status event.
+     * Child status events are immutable once stored. Note that no checking is done on the
+     * validity of the parent event's ID.
      * @param newEvent the child event to store.
+     * @param errorCode a 20 character or less string identifying the error type.
+     * @param error the error.
      * @return the stored child event.
      */
-    StoredChildStatusEvent store(ChildStatusEvent newEvent) throws FatalRetriableIndexingException;
+    StoredChildStatusEvent store(
+            ChildStatusEvent newEvent,
+            final String errorCode,
+            final Throwable error)
+            throws FatalRetriableIndexingException;
 
     /** Get an event by its ID.
      * @param id the id.

--- a/test/src/kbasesearchengine/test/events/StoredChildStatusEventTest.java
+++ b/test/src/kbasesearchengine/test/events/StoredChildStatusEventTest.java
@@ -8,6 +8,8 @@ import java.time.Instant;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+
 import kbasesearchengine.events.ChildStatusEvent;
 import kbasesearchengine.events.StatusEvent;
 import kbasesearchengine.events.StatusEventID;
@@ -18,6 +20,11 @@ import kbasesearchengine.test.common.TestCommon;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class StoredChildStatusEventTest {
+
+    private static final ChildStatusEvent CHILD_STATUS_EVENT = new ChildStatusEvent(
+            StatusEvent.getBuilder("Code", Instant.ofEpochMilli(20000L),
+                    StatusEventType.DELETE_ACCESS_GROUP).build(),
+            new StatusEventID("parent id"));
 
     @Test
     public void equals() {
@@ -41,6 +48,33 @@ public class StoredChildStatusEventTest {
         assertThat("incorrect state", scse.getState(), is(StatusEventProcessingState.FAIL));
         assertThat("incorrect id", scse.getID(), is(new StatusEventID("my id")));
         assertThat("incorrect time", scse.getStoreTime(), is(Instant.ofEpochMilli(10000)));
+        assertThat("incorrect err code", scse.getErrorCode(), is(Optional.absent()));
+        assertThat("incorrect err msg", scse.getErrorMessage(), is(Optional.absent()));
+        assertThat("incorrect err trace", scse.getErrorStackTrace(), is(Optional.absent()));
+    }
+    
+    @Test
+    public void constructNulls() {
+        final StoredChildStatusEvent scse = StoredChildStatusEvent.getBuilder(
+                new ChildStatusEvent(
+                        StatusEvent.getBuilder("Code", Instant.ofEpochMilli(20000L),
+                                StatusEventType.DELETE_ACCESS_GROUP).build(),
+                        new StatusEventID("parent id")),
+                new StatusEventID("my id"),
+                Instant.ofEpochMilli(10000))
+                .withNullableError(null, "foo", "bar")
+                .build();
+        
+        assertThat("incorrect event", scse.getChildEvent(), is(new ChildStatusEvent(
+                        StatusEvent.getBuilder("Code", Instant.ofEpochMilli(20000L),
+                                StatusEventType.DELETE_ACCESS_GROUP).build(),
+                        new StatusEventID("parent id"))));
+        assertThat("incorrect state", scse.getState(), is(StatusEventProcessingState.FAIL));
+        assertThat("incorrect id", scse.getID(), is(new StatusEventID("my id")));
+        assertThat("incorrect time", scse.getStoreTime(), is(Instant.ofEpochMilli(10000)));
+        assertThat("incorrect err code", scse.getErrorCode(), is(Optional.absent()));
+        assertThat("incorrect err msg", scse.getErrorMessage(), is(Optional.absent()));
+        assertThat("incorrect err trace", scse.getErrorStackTrace(), is(Optional.absent()));
     }
     
     @Test
@@ -53,6 +87,7 @@ public class StoredChildStatusEventTest {
                 new StatusEventID("my id"),
                 Instant.ofEpochMilli(10000))
                 .withState(StatusEventProcessingState.INDX)
+                .withNullableError("code", "msg", "trace")
                 .build();
         
         assertThat("incorrect event", scse.getChildEvent(), is(new ChildStatusEvent(
@@ -62,6 +97,9 @@ public class StoredChildStatusEventTest {
         assertThat("incorrect state", scse.getState(), is(StatusEventProcessingState.INDX));
         assertThat("incorrect id", scse.getID(), is(new StatusEventID("my id")));
         assertThat("incorrect time", scse.getStoreTime(), is(Instant.ofEpochMilli(10000)));
+        assertThat("incorrect err code", scse.getErrorCode(), is(Optional.of("code")));
+        assertThat("incorrect err msg", scse.getErrorMessage(), is(Optional.of("msg")));
+        assertThat("incorrect err trace", scse.getErrorStackTrace(), is(Optional.of("trace")));
     }
 
     @Test
@@ -123,13 +161,9 @@ public class StoredChildStatusEventTest {
     }
     
     private void failWithState(final StatusEventProcessingState state, final Exception expected) {
-        final ChildStatusEvent c = new ChildStatusEvent(
-                StatusEvent.getBuilder("Code", Instant.ofEpochMilli(20000L),
-                        StatusEventType.DELETE_ACCESS_GROUP).build(),
-                new StatusEventID("parent id"));
         try {
             StoredChildStatusEvent.getBuilder(
-                    c, new StatusEventID("foo"), Instant.ofEpochMilli(10000))
+                    CHILD_STATUS_EVENT, new StatusEventID("foo"), Instant.ofEpochMilli(10000))
                     .withState(state);
             fail("expected exception");
         } catch (Exception got) {
@@ -137,4 +171,34 @@ public class StoredChildStatusEventTest {
         }
     }
     
+    @Test
+    public void withErrorFail() {
+        failWithError("  \t  \n ", "m", "t", new IllegalArgumentException(
+                "errorCode cannot be null or whitespace only"));
+        
+        failWithError("c", null, "t", new IllegalArgumentException(
+                "errorMessage cannot be null or whitespace only"));
+        failWithError("c", "   \n  \t ", "t", new IllegalArgumentException(
+                "errorMessage cannot be null or whitespace only"));
+        
+        failWithError("c", "m", null, new IllegalArgumentException(
+                "errorStackTrace cannot be null or whitespace only"));
+        failWithError("c", "m", "   \n  \t ", new IllegalArgumentException(
+                "errorStackTrace cannot be null or whitespace only"));
+    }
+    
+    private void failWithError(
+            final String code,
+            final String msg,
+            final String trace,
+            final Exception expected) {
+        try {
+            StoredChildStatusEvent.getBuilder(
+                    CHILD_STATUS_EVENT, new StatusEventID("foo"), Instant.ofEpochMilli(10000))
+                    .withNullableError(code, msg, trace);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
 }

--- a/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
+++ b/test/src/kbasesearchengine/test/events/storage/MongoDBStatusEventStorageTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static kbasesearchengine.test.common.TestCommon.set;
 
+import java.io.PrintWriter;
 import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Instant;
@@ -40,8 +41,10 @@ import kbasesearchengine.events.StatusEventProcessingState;
 import kbasesearchengine.events.StatusEventType;
 import kbasesearchengine.events.StoredChildStatusEvent;
 import kbasesearchengine.events.StoredStatusEvent;
+import kbasesearchengine.events.exceptions.ErrorType;
 import kbasesearchengine.events.exceptions.FatalRetriableIndexingException;
 import kbasesearchengine.events.exceptions.RetriableIndexingException;
+import kbasesearchengine.events.exceptions.UnprocessableEventIndexingException;
 import kbasesearchengine.events.storage.MongoDBStatusEventStorage;
 import kbasesearchengine.events.storage.StatusEventStorage;
 import kbasesearchengine.system.StorageObjectType;
@@ -49,6 +52,16 @@ import kbasesearchengine.test.common.TestCommon;
 import us.kbase.common.test.controllers.mongo.MongoController;
 
 public class MongoDBStatusEventStorageTest {
+    
+    final private static String LONG1001;
+    static {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            sb.append("01234567890");
+        }
+        sb.append("a");
+        LONG1001 = sb.toString();
+    }
 
     private StatusEventStorage storage;
     private static MongoController mongo;
@@ -316,7 +329,9 @@ public class MongoDBStatusEventStorageTest {
                     .withNullableObjectID("bar")
                     .withNullableVersion(7)
                     .build(),
-                    new StatusEventID("parent id")));
+                    new StatusEventID("parent id")),
+                "DELETED",
+                new UnprocessableEventIndexingException(ErrorType.DELETED, "deleted"));
         
         assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.FAIL));
         assertThat("incorrect event", sse.getChildEvent(), is(new ChildStatusEvent(
@@ -329,8 +344,11 @@ public class MongoDBStatusEventStorageTest {
                         .withNullableVersion(7)
                         .build(),
                 new StatusEventID("parent id"))));
-        
         assertThat("incorrect store time", sse.getStoreTime(), is(Instant.ofEpochMilli(30000L)));
+        assertThat("incorrect error code", sse.getErrorCode(), is(Optional.of("DELETED")));
+        assertThat("incorrect error msg", sse.getErrorMessage(), is(Optional.of("deleted")));
+        assertThat("incorrect error trace",
+                sse.getErrorStackTrace().get().contains("IndexingException: deleted"), is(true));
         assertNotNull("id is null", sse.getID());
         
         final StoredChildStatusEvent got = storage.getChild(sse.getID()).get();
@@ -348,6 +366,10 @@ public class MongoDBStatusEventStorageTest {
                         .build(),
                 new StatusEventID("parent id"))));
         assertThat("incorrect store time", got.getStoreTime(), is(Instant.ofEpochMilli(30000L)));
+        assertThat("incorrect error code", got.getErrorCode(), is(Optional.of("DELETED")));
+        assertThat("incorrect error msg", got.getErrorMessage(), is(Optional.of("deleted")));
+        assertThat("incorrect error trace",
+                got.getErrorStackTrace().get().contains("IndexingException: deleted"), is(true));
     }
     
     @Test
@@ -358,7 +380,9 @@ public class MongoDBStatusEventStorageTest {
                 StatusEvent.getBuilder(
                         sot, Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
                                 .build(),
-                        new StatusEventID("parent id")));
+                        new StatusEventID("parent id")),
+                "DELETED",
+                new UnprocessableEventIndexingException(ErrorType.DELETED, "deleted"));
         
         assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.FAIL));
         assertThat("incorrect event", sse.getChildEvent(), is(new ChildStatusEvent(
@@ -366,8 +390,11 @@ public class MongoDBStatusEventStorageTest {
                         sot, Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
                                 .build(),
                         new StatusEventID("parent id"))));
-        
         assertThat("incorrect store time", sse.getStoreTime(), is(Instant.ofEpochMilli(30000L)));
+        assertThat("incorrect error code", sse.getErrorCode(), is(Optional.of("DELETED")));
+        assertThat("incorrect error msg", sse.getErrorMessage(), is(Optional.of("deleted")));
+        assertThat("incorrect error trace",
+                sse.getErrorStackTrace().get().contains("IndexingException: deleted"), is(true));
         assertNotNull("id is null", sse.getID());
         
         final StoredChildStatusEvent got = storage.getChild(sse.getID()).get();
@@ -380,6 +407,67 @@ public class MongoDBStatusEventStorageTest {
                                 .build(),
                         new StatusEventID("parent id"))));
         assertThat("incorrect store time", got.getStoreTime(), is(Instant.ofEpochMilli(30000L)));
+        assertThat("incorrect error code", got.getErrorCode(), is(Optional.of("DELETED")));
+        assertThat("incorrect error msg", got.getErrorMessage(), is(Optional.of("deleted")));
+        assertThat("incorrect error trace",
+                got.getErrorStackTrace().get().contains("IndexingException: deleted"), is(true));
+    }
+    
+    @Test
+    public void storeAndGetChildWithErrMsgTruncation() throws Exception {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(30000L));
+        final StoredChildStatusEvent sse = storage.store(new ChildStatusEvent(
+                StatusEvent.getBuilder(
+                    "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
+                    .build(),
+                    new StatusEventID("parent id")),
+                "DELETED",
+                new UnprocessableEventIndexingException(ErrorType.DELETED, LONG1001));
+
+        final String msgExpected = LONG1001.substring(0, 997) + "...";
+        
+        assertThat("incorrect error msg", sse.getErrorMessage(), is(Optional.of(msgExpected)));
+        
+        final StoredChildStatusEvent got = storage.getChild(sse.getID()).get();
+        
+        assertThat("incorrect error msg", got.getErrorMessage(), is(Optional.of(msgExpected)));
+    }
+    
+    @Test
+    public void storeAndGetChildWithTraceTruncation() throws Exception {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 10_000; i++) {
+            sb.append("012345678\n");
+        }
+        sb.append("a");
+        
+        final String long100_001 = sb.toString();
+        @SuppressWarnings("serial")
+        final Exception e = new Exception("foo") {
+            
+            @Override
+            public void printStackTrace(final PrintWriter pw) {
+                pw.print(sb);
+            }
+        };
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(30000L));
+        final StoredChildStatusEvent sse = storage.store(new ChildStatusEvent(
+                StatusEvent.getBuilder(
+                    "WS", Instant.ofEpochMilli(10000), StatusEventType.COPY_ACCESS_GROUP)
+                    .build(),
+                    new StatusEventID("parent id")),
+                "DELETED",
+                e);
+
+        final String traceExpected = long100_001.substring(0, 99997) + "...";
+        
+        assertThat("incorrect error msg", sse.getErrorStackTrace(),
+                is(Optional.of(traceExpected)));
+        
+        final StoredChildStatusEvent got = storage.getChild(sse.getID()).get();
+        
+        assertThat("incorrect error msg", got.getErrorStackTrace(),
+                is(Optional.of(traceExpected)));
     }
     
     @Test
@@ -389,7 +477,9 @@ public class MongoDBStatusEventStorageTest {
                 StatusEvent.getBuilder(
                         "WS", Instant.ofEpochMilli(20000), StatusEventType.DELETE_ALL_VERSIONS)
                                 .build(),
-                new StatusEventID("parent id")));
+                new StatusEventID("parent id")),
+                "DELETED",
+                new UnprocessableEventIndexingException(ErrorType.DELETED, "deleted"));
         
         assertThat("incorrect state", sse.getState(), is(StatusEventProcessingState.FAIL));
         assertThat("incorrect event", sse.getChildEvent(), is(new ChildStatusEvent(
@@ -399,6 +489,10 @@ public class MongoDBStatusEventStorageTest {
                 new StatusEventID("parent id"))));
         assertNotNull("id is null", sse.getID());
         assertThat("incorrect store time", sse.getStoreTime(), is(Instant.ofEpochMilli(100000L)));
+        assertThat("incorrect error code", sse.getErrorCode(), is(Optional.of("DELETED")));
+        assertThat("incorrect error msg", sse.getErrorMessage(), is(Optional.of("deleted")));
+        assertThat("incorrect error trace",
+                sse.getErrorStackTrace().get().contains("IndexingException: deleted"), is(true));
         
         final Optional<StoredChildStatusEvent> got = storage.getChild(
                 new StatusEventID(new ObjectId().toString()));
@@ -908,14 +1002,32 @@ public class MongoDBStatusEventStorageTest {
     
     @Test
     public void storeChildFail() {
-        failStoreChild(null, new NullPointerException("newEvent"));
+        final ChildStatusEvent c = new ChildStatusEvent(StatusEvent.getBuilder(
+                "WS", Instant.ofEpochMilli(20000), StatusEventType.DELETE_ALL_VERSIONS).build(),
+                new StatusEventID("parent id"));
+        final Throwable e = new RuntimeException("foo");
+        
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L));
+        
+        failStoreChild(null, "c", e, new NullPointerException("newEvent"));
+        
+        failStoreChild(c, null, e, new IllegalArgumentException(
+                "errorCode cannot be null or whitespace only"));
+        failStoreChild(c, "   \t   \n   ", e, new IllegalArgumentException(
+                "errorCode cannot be null or whitespace only"));
+        failStoreChild(c, "01234567890123456789a", e, new IllegalArgumentException(
+                "errorCode exceeds max length of 20"));
+        
+        failStoreChild(c, "c", null, new NullPointerException("error"));
     }
     
     private void failStoreChild(
             final ChildStatusEvent event,
+            final String errorCode,
+            final Throwable error,
             final Exception expected) {
         try {
-            storage.store(event);
+            storage.store(event, errorCode, error);
             fail("expected exception");
         } catch (Exception got) {
             TestCommon.assertExceptionCorrect(got, expected);


### PR DESCRIPTION
Changes the child event storage interface to require an error to be stored along with the event.