### PR TITLE
SCT-717 Fix error when no subobjects are found

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@ Search Service MKII release notes
 0.1.1
 -----
 
+* Fixed a bug where an empty list of subobjects in a parent object would cause a general (e.g.
+  no `key.*` fields) parent record to be stored in the subobject index in ElasticSearch. 
 * Removed `data_includes` from the API, as it was unimplemented.
 * Changed `lookupInKeys` to lookup\_in_keys to be consistent with other fields.
 

--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -639,7 +639,7 @@ public class WorkspaceEventHandler implements EventHandler {
     private static String toWSRefPath(final List<GUID> objectRefPath) {
         final List<String> refpath = new LinkedList<>();
         for (final GUID g: objectRefPath) {
-            if (!g.getStorageCode().equals("WS")) {
+            if (!g.getStorageCode().equals(STORAGE_CODE)) {
                 throw new IllegalArgumentException(String.format(
                         "GUID %s is not a workspace object", g));
             }

--- a/lib/src/kbasesearchengine/main/IndexerWorker.java
+++ b/lib/src/kbasesearchengine/main/IndexerWorker.java
@@ -528,8 +528,9 @@ public class IndexerWorker implements Stoppable {
                 final ParseObjectsRet parsedRet = parseObjects(guid, indexLookup,
                         newRefPath, obj, rule);
                 long parsingTime = System.currentTimeMillis() - t2;
-                logger.logInfo("[Indexer]   " + toVerRep(rule.getGlobalObjectType()) +
-                        ", parsing time: " + parsingTime + " ms.");
+                logger.logInfo(String.format("[Indexer]   Parsed %s %s in %s ms.",
+                        parsedRet.guidToObj.size(), toVerRep(rule.getGlobalObjectType()),
+                        parsingTime));
                 long t3 = System.currentTimeMillis();
                 indexObjectInStorage(guid, timestamp, isPublic, obj, rule,
                         parsedRet.guidToObj, parsedRet.parentJson);

--- a/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbasesearchengine/search/ElasticIndexingStorage.java
@@ -329,12 +329,16 @@ public class ElasticIndexingStorage implements IndexingStorage {
             final Map<GUID, ParsedObject> idToObj,
             final boolean isPublic)
             throws IOException, IndexingConflictException {
+        if (rule.getSubObjectType().isPresent() && idToObj.isEmpty()) {
+            return; // nothing to index. Only parent objects should get general records (see below)
+        }
         final Map<GUID, ParsedObject> idToObjCopy = new HashMap<>(idToObj);
         String indexName = checkIndex(rule, false);
         for (GUID id : idToObjCopy.keySet()) {
             GUID parentGuid = new GUID(id.getStorageCode(), id.getAccessGroupId(), 
                     id.getAccessGroupObjectId(), id.getVersion(), null, null);
             if (!parentGuid.equals(pguid)) {
+                //TODO CODE make this something that the worker error handling can work with
                 throw new IllegalStateException("Object GUID doesn't match parent GUID");
             }
         }


### PR DESCRIPTION
When a subobject array in a parent object is empty, the ES code will
insert a record with no `key.*` properties with the parent guid in the
index for the type. E.g. if a genome has no features (which really
should never happen, but there are examples in the wild), ES will insert
a record with the parent object's GUID in the genomefeature index, which
is bad, because searches for the parent object will find it and it'll
have the wrong type, which can screw up recursive indexing in some
cases.

The reason ES does this is to support specs with no indexing rules, such
that the general object properties of a type can be indexed even if
we're not interested in the contents. We want the behavior for parent
objects, but not subobjects.