### PR TITLE
Fix keys

### DIFF
--- a/resources/types/RNASeqSampleSet.yaml
+++ b/resources/types/RNASeqSampleSet.yaml
@@ -6,8 +6,8 @@ versions:
   - path: sampleset_desc
     full-text: true
   - path: num_samples
-    key-type: integer
+    keyword-type: integer
   - path: num_replicates
-    key-type: integer
+    keyword-type: integer
   - path: source
-    key-type: keyword
+    keyword-type: keyword

--- a/resources/types/SingleEndLibrary.yaml
+++ b/resources/types/SingleEndLibrary.yaml
@@ -13,7 +13,7 @@ versions:
   - path: phred_type
     keyword-type: keyword
   - path: read_count
-    keywork-type: integer
+    keyword-type: integer
     ui-name: Number of reads
   - path: read_length_mean
     keyword-type: integer


### PR DESCRIPTION
Some keys were misspelled leading to the default keyword-type of "keyword" being used. The good news is that the new validation flags this as an error. The bad news is that from what I recall, we will need to reindex the types because they are changing from "keyword" to "integer". I've duplicated this fix in the new spec repo