### PR TITLE
fix incorrect workspace info field used for public permission

### DIFF
--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -819,7 +819,7 @@ public class WorkspaceEventHandler implements EventHandler, WorkspaceInfoProvide
                                    RetriableIndexingException {
         try {
             final Long wsId = Long.valueOf(ev.getAccessGroupId().get()).longValue();
-            final String isPublic = getWorkspaceInfo(wsId).getE6();
+            final String isPublic = getWorkspaceInfo(wsId).getE7();
 
             return (isPublic == "n") ? false: true;
 

--- a/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
+++ b/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
@@ -1,3 +1,4 @@
+
 package kbasesearchengine.test.events.handler;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -1471,5 +1472,124 @@ public class WorkspaceEventHandlerTest {
         Assert.assertNotSame("expected different event object", event, updatedEvent);
         Assert.assertEquals(expectedEvent, updatedEvent);
     }
+
+    /*
+    Test that a NEW_VERSION object event with the isPublic flag set to false will be updated
+    with the isPublic flag to true if the current state of the associated workspace
+    has the public permission field set to "r".
+    This triggers the isPublic logic in WorkspaceEventHandler.updateObjectEvent. 
+    */
+    @Test
+    public void newVersionPublicFlagUpdatedFromWorkspaceCase1() throws Exception {
+        final CloneableWorkspaceClient clonecli = mock(CloneableWorkspaceClient.class);
+        final WorkspaceClient cloned = mock(WorkspaceClient.class);
+        final WorkspaceClient wscli = mock(WorkspaceClient.class);
+        when(clonecli.getClientClone()).thenReturn(cloned);
+        when(clonecli.getClient()).thenReturn(wscli);
+
+        StatusEvent event = StatusEvent.getBuilder(
+                StorageObjectType.fromNullableVersion("WS", "foo", 1),
+                Instant.ofEpochMilli(20000),
+                StatusEventType.NEW_VERSION)
+                .withNullableOverwriteExistingData(true)  // overwrite existing data
+                .withNullableisPublic(Boolean.FALSE)
+                .withNullableAccessGroupID(3)
+                .withNullableObjectID("1")
+                .withNullableVersion(1)
+                .build();
+
+        List<Tuple11<Long, String, String, String,
+                Long, String, Long, String, String, Long, Map<String, String>>> objList = new ArrayList<Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>>>();
+        objList.add(objTuple(1L, null, "sometype", "date", 1L, "copier",
+                3L, "wsname", "checksum", 44, Collections.emptyMap()));
+
+        when(wscli.administer(any()))
+                // for deleted objects check
+                .thenReturn(new UObject(objList))
+                // for name check
+                .thenReturn(new UObject(new GetObjectInfo3Results().withInfos(objList)))
+                // for isPublic check
+                .thenReturn(new UObject(wsTuple(3L, "wsname", "username", "date", 7, "n", "r",
+                        "unlocked", Collections.emptyMap())));
+
+        final WorkspaceEventHandler weh = new WorkspaceEventHandler(clonecli);
+
+        StatusEvent updatedEvent = weh.updateObjectEvent(event);
+
+        StatusEvent expectedEvent = StatusEvent.getBuilder(
+                StorageObjectType.fromNullableVersion("WS", "foo", 1),
+                Instant.ofEpochMilli(20000),
+                StatusEventType.NEW_VERSION)
+                .withNullableOverwriteExistingData(true)  // overwrite existing data
+                .withNullableisPublic(Boolean.TRUE)
+                .withNullableAccessGroupID(3)
+                .withNullableObjectID("1")
+                .withNullableVersion(1)
+                .build();
+
+        Assert.assertNotSame("expected same event object after update", event, updatedEvent);
+        Assert.assertEquals("expected updated event to have been properly modified", expectedEvent, updatedEvent);
+    }
+
+    /*
+    This second case sets the event's isPublic field to true, the workspace to "n",
+    and the resulting updated event should be false.
+    */
+    @Test
+    public void newVersionPublicFlagUpdatedFromWorkspaceCase2() throws Exception {
+        final CloneableWorkspaceClient clonecli = mock(CloneableWorkspaceClient.class);
+        final WorkspaceClient cloned = mock(WorkspaceClient.class);
+        final WorkspaceClient wscli = mock(WorkspaceClient.class);
+        when(clonecli.getClientClone()).thenReturn(cloned);
+        when(clonecli.getClient()).thenReturn(wscli);
+
+        StatusEvent event = StatusEvent.getBuilder(
+                StorageObjectType.fromNullableVersion("WS", "foo", 1),
+                Instant.ofEpochMilli(20000),
+                StatusEventType.NEW_VERSION)
+                .withNullableOverwriteExistingData(true)  // overwrite existing data
+                .withNullableisPublic(Boolean.TRUE)
+                .withNullableAccessGroupID(3)
+                .withNullableObjectID("1")
+                .withNullableVersion(1)
+                .build();
+
+
+        List<Tuple11<Long, String, String, String,
+                Long, String, Long, String, String, Long, Map<String, String>>> objList = new ArrayList<Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>>>();
+        objList.add(objTuple(1L, null, "sometype", "date", 1L, "copier",
+                3L, "wsname", "checksum", 44, Collections.emptyMap()));
+
+        // This usage of mockito ensures that ANY calls to the mocked workspace client
+        // will return the three values in sequence, as noted in the comments. These calls 
+        // are buried in other code...
+        when(wscli.administer(any()))
+                // for deleted objects check
+                .thenReturn(new UObject(objList))
+                // for name check
+                .thenReturn(new UObject(new GetObjectInfo3Results().withInfos(objList)))
+                // for isPublic check
+                .thenReturn(new UObject(wsTuple(3L, "wsname", "username", "date", 7, "n", "n",
+                        "unlocked", Collections.emptyMap())));
+
+        final WorkspaceEventHandler weh = new WorkspaceEventHandler(clonecli);
+
+        StatusEvent updatedEvent = weh.updateObjectEvent(event);
+
+        StatusEvent expectedEvent = StatusEvent.getBuilder(
+                StorageObjectType.fromNullableVersion("WS", "foo", 1),
+                Instant.ofEpochMilli(20000),
+                StatusEventType.NEW_VERSION)
+                .withNullableOverwriteExistingData(true)  // overwrite existing data
+                .withNullableisPublic(Boolean.FALSE)
+                .withNullableAccessGroupID(3)
+                .withNullableObjectID("1")
+                .withNullableVersion(1)
+                .build();
+
+        Assert.assertNotSame("expected same event object after update", event, updatedEvent);
+        Assert.assertEquals("expected updated event to have been properly modified", expectedEvent, updatedEvent);
+    }
+
 
 }

--- a/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
+++ b/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
@@ -1474,10 +1474,15 @@ public class WorkspaceEventHandlerTest {
     }
 
     /*
-    Test that a NEW_VERSION object event with the isPublic flag set to false will be updated
-    with the isPublic flag to true if the current state of the associated workspace
-    has the public permission field set to "r".
-    This triggers the isPublic logic in WorkspaceEventHandler.updateObjectEvent. 
+    Test that a NEW_VERSION object event with the isPublic flag set to false 
+    will be updated setting the isPublic flag to true if the current state of 
+    the associated workspace has the public permission field set to "r".
+
+    This is accomplished by the isPublic logic in WorkspaceEventHandler.updateObjectEvent.
+
+    This test, and the following one, were created to address 
+    https://kbase-jira.atlassian.net/browse/SCT-1203 in which the isPublic flag was 
+    updated incorrectly.
     */
     @Test
     public void newVersionPublicFlagUpdatedFromWorkspaceCase1() throws Exception {
@@ -1527,13 +1532,13 @@ public class WorkspaceEventHandlerTest {
                 .withNullableVersion(1)
                 .build();
 
-        Assert.assertNotSame("expected same event object after update", event, updatedEvent);
-        Assert.assertEquals("expected updated event to have been properly modified", expectedEvent, updatedEvent);
+        Assert.assertEquals("expected updated event to be the same as original event other than isPublic field being set to TRUE", expectedEvent, updatedEvent);
     }
 
     /*
     This second case sets the event's isPublic field to true, the workspace to "n",
     and the resulting updated event should be false.
+    This is the inverse of the above test (Case1).
     */
     @Test
     public void newVersionPublicFlagUpdatedFromWorkspaceCase2() throws Exception {
@@ -1560,9 +1565,6 @@ public class WorkspaceEventHandlerTest {
         objList.add(objTuple(1L, null, "sometype", "date", 1L, "copier",
                 3L, "wsname", "checksum", 44, Collections.emptyMap()));
 
-        // This usage of mockito ensures that ANY calls to the mocked workspace client
-        // will return the three values in sequence, as noted in the comments. These calls 
-        // are buried in other code...
         when(wscli.administer(any()))
                 // for deleted objects check
                 .thenReturn(new UObject(objList))
@@ -1587,8 +1589,7 @@ public class WorkspaceEventHandlerTest {
                 .withNullableVersion(1)
                 .build();
 
-        Assert.assertNotSame("expected same event object after update", event, updatedEvent);
-        Assert.assertEquals("expected updated event to have been properly modified", expectedEvent, updatedEvent);
+        Assert.assertEquals("expected updated event to be the same as original event other than isPublic field being set to FALSE", expectedEvent, updatedEvent);
     }
 
 


### PR DESCRIPTION
fixes [SCT-1203], private data exposed in unauthenticated search.
This was due to a reference to the wrong workspace info field, getE6, rather than getE7.
The public permissions is stored in position 6 (0-based) which translates to getE7 (1-based).

I have not definitively traced down the introduction of the bug, don't know if it is important. It is not in production, just CI. It looks like this bug came in around here:
https://github.com/kbase/KBaseSearchEngine/commit/78c385a68d3feb392147d67b591bf8a410039654#diff-2ae08fe926f1612b2ee2394ef98f6b26R818

There was quite a bit of churn in this file, with the correct code disappearing, then appearing with this error, then disappearing, then the error recurs, and all the while the framing of the code changes quite a bit. I suspect dueling codebases?