### PR TITLE
fix public permissions test [SCT-1203]

### DIFF
--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -821,7 +821,7 @@ public class WorkspaceEventHandler implements EventHandler, WorkspaceInfoProvide
             final Long wsId = Long.valueOf(ev.getAccessGroupId().get()).longValue();
             final String isPublic = getWorkspaceInfo(wsId).getE7();
 
-            return (isPublic == "n") ? false: true;
+            return isPublic.equals("n") ? false: true;
 
         } catch (IOException ex) {
             throw handleException(ex);

--- a/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbasesearchengine/events/handler/WorkspaceEventHandler.java
@@ -821,7 +821,12 @@ public class WorkspaceEventHandler implements EventHandler, WorkspaceInfoProvide
             final Long wsId = Long.valueOf(ev.getAccessGroupId().get()).longValue();
             final String isPublic = getWorkspaceInfo(wsId).getE7();
 
-            return isPublic.equals("n") ? false: true;
+            // The workspace info array element 6 (tuple element 7) is the public permission, 
+            // and represents the access permitted to the workspace without authentication,
+            // i.e. without an identified kbase user.
+            // It is either "n" indicating not publicly accessible, or "r" indicating
+            // that it is publicly readable.
+            return isPublic.equals("r");
 
         } catch (IOException ex) {
             throw handleException(ex);

--- a/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
+++ b/test/src/kbasesearchengine/test/events/handler/WorkspaceEventHandlerTest.java
@@ -1514,7 +1514,7 @@ public class WorkspaceEventHandlerTest {
                 // for name check
                 .thenReturn(new UObject(new GetObjectInfo3Results().withInfos(objList)))
                 // for isPublic check
-                .thenReturn(new UObject(wsTuple(3L, "wsname", "username", "date", 7, "n", "r",
+                .thenReturn(new UObject(wsTuple(3L, "wsname", "username", "date", 7, "n", new String("r"),
                         "unlocked", Collections.emptyMap())));
 
         final WorkspaceEventHandler weh = new WorkspaceEventHandler(clonecli);
@@ -1571,7 +1571,7 @@ public class WorkspaceEventHandlerTest {
                 // for name check
                 .thenReturn(new UObject(new GetObjectInfo3Results().withInfos(objList)))
                 // for isPublic check
-                .thenReturn(new UObject(wsTuple(3L, "wsname", "username", "date", 7, "n", "n",
+                .thenReturn(new UObject(wsTuple(3L, "wsname", "username", "date", 7, "n", new String("n"),
                         "unlocked", Collections.emptyMap())));
 
         final WorkspaceEventHandler weh = new WorkspaceEventHandler(clonecli);


### PR DESCRIPTION
- the string equalty check unwisely used ==
- it passed the tests because the mock workspace api uses static strings
- it was also more complex than necessary
- it also used a double-negative

In the affected code, the "isPublic" flag was determined by comparing the current public permission for a workspace to the string "n", using the == operator. 

Now it compares isPublic to the read-only permission "r" using the equals method.

The previous "fix" failed to work in real life but passed the associated test because the test uses a mock workspace client which is populated with literal values. In real usage, the workspace client fetches the values from the database, and the values are objects not literals. In the associated test the public permission value is now provided as a string object, which indeed caused the test to fail if the code was not fixed to use equals over ==.

I also searched the codebase for other usages of string comparisons using == and could find none.